### PR TITLE
docs(sandbox): 调整自定义模板文档格式

### DIFF
--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/03.构建自定义镜像模板.md
@@ -1,366 +1,260 @@
-# 构建自定义镜像模板
+# 自定义模板
 
-自定义模板允许您使用自己的容器镜像创建沙箱环境，预装业务所需的依赖、工具和证书，构建标准化的专属沙箱。自定义模板通过 `container_configuration` 指定容器镜像地址和启动命令，不局限于官方的 base、code-interpreter-v1、browser、all in one 四种模板。
+系统预置的沙箱模板提供了基础运行环境。当您需要预装业务依赖、配置特定工具链或固化运行环境时，可以创建自定义模板。模板将环境配置固化后，后续创建沙箱时直接调用，无需每次重复安装依赖。
 
-## 功能特性
+## 快速开始
 
-| **特性** | **说明** |
-| --- | --- |
-| 自定义镜像 | 使用任意容器镜像（ACR 个人版/企业版、其他公有镜像仓库等）作为沙箱运行环境 |
-| 自定义启动命令 | 指定容器启动命令，灵活控制沙箱的初始化行为 |
-| 预装依赖 | 在镜像中预装业务所需的 Python 库、系统工具、证书等，避免每次创建沙箱时重复安装 |
-| 环境一致性 | 通过镜像版本管理确保沙箱环境的一致性，支持灰度发布和回滚 |
-| 完整沙箱能力 | 自定义镜像沙箱同样享有会话亲和、会话隔离、休眠唤醒、动态挂载等平台能力 |
+### ACREE 准备
 
-## 适用场景
+1. 在与云沙箱相同 UID、相同地域下，[创建 ACR EE 实例](https://www.aliyun.com/product/acr)（经济版暂不支持）。
+2. 为 ACR EE 实例添加专有网络，确保云沙箱可以通过 VPC 拉取镜像。
 
-| **场景** | **说明** |
-| --- | --- |
-| 预装业务依赖 | 在镜像中预装特定的 Python 库（如 TensorFlow、PyTorch）、系统工具或业务 SDK |
-| 证书与安全 | 预装企业 CA 证书、SSH 密钥等安全凭证，满足企业级安全合规要求 |
-| 自定义运行时 | 使用非默认的运行时环境（如特定版本的 Python、Java、Go 等） |
-| 标准化环境 | 构建标准化的业务模板，确保团队成员使用的沙箱环境完全一致 |
-| 性能优化 | 将耗时的依赖安装步骤固化到镜像中，减少沙箱冷启动后的初始化时间 |
+### 镜像推送
 
-## 推荐使用路径
+将镜像推送到该 ACR EE 仓库，得到支持 VPC 访问的内网镜像地址，例如 `test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12`。
 
-自定义模板支持多种构建路径，根据您的镜像来源和需求选择最合适的方式：
+### 构建 template
 
-| **构建路径** | **说明** | **适用场景** |
-| --- | --- | --- |
-| ACR 企业版直接构建 | 直接使用 ACR EE 中的镜像，无需中间转换 | 已有自定义镜像，追求最简流程（推荐） |
-| E2B 兼容镜像构建 | 使用 E2B SDK 的 `from_image` 方法，基于已注入 envd 的镜像创建模板 | 需要快速验证或基线对比 |
-| layer-build 转换构建 | 使用 `layer-build` CLI 工具将标准镜像转换为 FC E2B 兼容镜像 | 标准镜像无法直接构建时的备选方案 |
-
-### 路径选择建议
-
-| **如果您当前已有** | **建议路径** | **原因** |
-| --- | --- | --- |
-| 已在 ACR 中维护的业务镜像，容器启动后可直接提供沙箱服务 | ACR 企业版直接构建 | 链路最短，便于复用现有镜像发布、扫描和权限体系 |
-| 标准 Docker 镜像，但需要通过 E2B SDK 管理模板和沙箱实例 | E2B SDK `from_image` | 与 E2B 兼容调用方式保持一致，适合迁移或双栈验证 |
-| 标准镜像无法被直接用作 E2B 兼容模板 | `layer-build` 转换构建 | 通过转换注入兼容组件，生成可用于模板构建的新镜像 |
-
-如果您只是需要 Python、Node.js、文件管理或浏览器自动化等通用能力，建议先使用官方模板。只有当官方模板无法满足依赖、证书、系统库、运行时版本或企业标准化要求时，再创建自定义模板。
-
-## 使用方式
-
-### 通过函数计算控制台创建
-
-1. 登录[函数计算控制台](https://fcnext.console.aliyun.com/)。
-2. 创建沙箱函数时，在**代码配置**面板中选择镜像来源（ACR 个人版镜像、ACR 企业版镜像、其他公有镜像、自定义镜像仓库）。
-3. 填入镜像地址和启动命令（如需）。
-4. 配置实例规格、会话参数等其他选项，完成创建。
-
-控制台方式适合直接使用已经构建好的业务镜像。创建时请确认镜像地域、仓库权限、VPC 访问配置与沙箱函数所在地域一致；如果使用 ACR 企业版私有镜像，还需要确保 ACR 企业版实例与函数计算可通过 VPC 网络互通。
-
-### 通过 E2B SDK 创建（快速开始）
-
-使用 E2B SDK 基于自定义镜像创建模板并启动沙箱：
-
-```python
-from e2b import Sandbox, Template
-
-# 基于自定义镜像创建模板
-template = Template().from_image(
-    image="registry.cn-hangzhou.aliyuncs.com/your-namespace/your-image:v1.0"
-)
-
-build_info = Template.build(
-    template,
-    "my-custom-sandbox",
-    cpu_count=2,
-    memory_mb=4096,
-    api_key="your-api-key",
-)
-
-# 使用模板创建沙箱实例
-sbx = Sandbox.create(template=build_info.template_id, api_key="your-api-key")
-result = sbx.commands.run("echo 'Hello from custom sandbox!'")
-print(result.stdout)
-sbx.kill()
-```
-
-更完整的生产级构建脚本（含环境变量管理和错误处理），请参见下方[通过 E2B SDK 构建自定义模板](#通过-e2b-sdk-构建自定义模板)章节。
-
-### 通过 E2B SDK 构建自定义模板
-
-如果您使用 E2B 兼容模式，可以通过 E2B SDK 的 `from_image` 方法基于自定义镜像构建模板。
-
-#### 环境配置
-
-安装 Python 依赖：
+安装依赖：
 
 ```bash
-pip install e2b==2.20.0 python-dotenv==1.2.2
+python3 -m venv .venv
+source .venv/bin/activate
+pip install e2b==2.26.0 e2b-code-interpreter python-dotenv
 ```
 
-创建 `.env` 文件，配置关键参数：
+创建 `.env` 文件：
 
-| **参数** | **说明** |
-| --- | --- |
-| `E2B_API_KEY` | 认证密钥 |
-| `E2B_API_URL` | 控制面 API 端点 |
-| `E2B_DOMAIN` | 沙箱连接域名 |
-| `E2B_TEMPLATE_IMAGE` | 源容器镜像地址（需已注入 envd） |
-| `E2B_TEMPLATE_NAME` | 模板名称标识 |
+```bash
+# 使用前请替换为自己的 API_KEY 和镜像地址
+E2B_API_KEY=e2b_xxx
+FROM_IMAGE="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12"
 
-#### 构建脚本示例
+# 北京生产环境地址示例值
+E2B_API_URL=https://api.cn-beijing.e2b.fc.aliyuncs.com
+E2B_DOMAIN=cn-beijing.e2b.fc.aliyuncs.com
+```
+
+运行脚本，将 image 构建为 template，并创建 sandbox 验证：
 
 ```python
+#!/usr/bin/env python3
+
 import os
-import sys
-import uuid
+import time
 
 from dotenv import load_dotenv
-from e2b import Sandbox, Template
-
-TEMPLATE_CPU_COUNT = 2
-TEMPLATE_MEMORY_MB = 4 * 1024
+from e2b import Template, default_build_logger
+from e2b_code_interpreter import Sandbox
 
 
-def _require_env(name: str) -> str:
-    value = os.environ.get(name, "").strip()
-    if not value:
-        print(f"ERROR: 缺少环境变量 {name}")
-        sys.exit(1)
-    return value
+load_dotenv()
 
+API_KEY = os.getenv("E2B_API_KEY", "").strip()
+FROM_IMAGE = os.getenv("FROM_IMAGE", "").strip()
+API_URL = os.getenv("E2B_API_URL", "https://api.cn-beijing.e2b.fc.aliyuncs.com").strip()
+DOMAIN = os.getenv("E2B_DOMAIN", "cn-beijing.e2b.fc.aliyuncs.com").strip()
+RUN_CODE = "print('hello')"
+OPTS = {"api_key": API_KEY, "api_url": API_URL, "domain": DOMAIN}
 
-def _optional_env(name: str) -> str | None:
-    value = os.environ.get(name, "").strip()
-    return value or None
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name=f"template-{int(time.time())}",
+    cpu_count=2,
+    memory_mb=2048,
+    skip_cache=False,
+    on_build_logs=default_build_logger(),
+    **OPTS,
+)
+sandbox = Sandbox.create(template=build.template_id, timeout=900, **OPTS)
 
+try:
+    print(f"template_id: {build.template_id}")
+    print(f"build_id: {build.build_id}")
+    print(f"sandbox_id: {sandbox.sandbox_id}")
+    print(f"sandbox_domain: {sandbox.sandbox_domain}")
+    print(f"envd_api_url: {sandbox.envd_api_url}")
 
-def main() -> None:
-    load_dotenv()
+    execution = sandbox.run_code(RUN_CODE, timeout=60, request_timeout=120)
+    stdout = "".join(execution.logs.stdout or [])
+    stderr = "".join(execution.logs.stderr or [])
 
-    api_key = _require_env("E2B_API_KEY")
-    image = _require_env("E2B_TEMPLATE_IMAGE")
-    name = _optional_env("E2B_TEMPLATE_NAME") or f"e2b-sdk-smoke-{uuid.uuid4().hex[:8]}"
+    print(f"run_code code: {RUN_CODE}")
+    print(f"run_code stdout: {stdout.strip()}")
+    print(f"run_code stderr: {stderr.strip()}")
+    print(f"run_code error: {execution.error}")
 
-    conn_opts = {}
-    if api_url := _optional_env("E2B_API_URL"):
-        conn_opts["api_url"] = api_url
-    if domain := _optional_env("E2B_DOMAIN"):
-        conn_opts["domain"] = domain
-
-    # 基于自定义镜像创建模板对象
-    template = Template().from_image(image=image)
-
-    print(f"开始构建模板: {name}")
-    print(f"镜像: {image}")
-    print(f"CPU: {TEMPLATE_CPU_COUNT}")
-    print(f"内存: {TEMPLATE_MEMORY_MB} MB")
-
-    # 触发构建
-    build_info = Template.build(
-        template,
-        name,
-        cpu_count=TEMPLATE_CPU_COUNT,
-        memory_mb=TEMPLATE_MEMORY_MB,
-        api_key=api_key,
-        **conn_opts,
-    )
-
-    print("构建完成")
-    print(f"template_id: {build_info.template_id}")
-    print(f"build_id: {build_info.build_id}")
-    print(f"name: {build_info.name}")
-
-    # 验证：创建沙箱并执行测试命令
-    sandbox = Sandbox.create(
-        template=build_info.template_id,
-        api_key=api_key,
-        **conn_opts,
-    )
-    try:
-        result = sandbox.commands.run("echo 'Hello from custom template!'")
-        print(f"验证结果: {result.stdout}")
-    finally:
-        sandbox.kill()
-        print("sandbox 已销毁")
-
-
-if __name__ == "__main__":
-    main()
+    if execution.error is not None:
+        raise RuntimeError(f"run_code 执行失败: {execution.error}")
+    if stdout.strip() != "hello":
+        raise RuntimeError(f"run_code stdout 不符合预期: {stdout!r}")
+finally:
+    print(f"killing sandbox: {sandbox.sandbox_id}")
+    sandbox.kill()
+    print("sandbox killed")
 ```
 
-构建完成后，可通过 CLI 检查模板状态：
+## 注意事项
+
+### 使用 FC E2B 官方镜像
+
+FC E2B 提供了官方镜像，不需要您提供 ACREE，即可直接构建模板并创建沙箱验证：
+
+复用快速开始的 Python 脚本，直接使用以下镜像地址：
+
+```javascript
+FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.31"
+```
+
+目前北京地域的 FC E2B 官方镜像地址列表为
 
 ```bash
-export E2B_API_KEY=your-api-key
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.31
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.31
+```
+
+### 使用 CLI 查看模板并创建沙箱
+
+如果已经安装 E2B CLI，可以通过模板列表确认构建状态：
+
+```bash
+export E2B_API_KEY=e2b_xxx
+export E2B_ACCESS_TOKEN=$E2B_API_KEY
+export E2B_API_URL=https://api.cn-beijing.e2b.fc.aliyuncs.com
+export E2B_DOMAIN=cn-beijing.e2b.fc.aliyuncs.com
+
 e2b template list
 ```
 
-确认模板状态为 `"ready"` 后，即可使用该模板创建沙箱。
-
-### 使用 layer-build 转换镜像
-
-当您的标准镜像无法直接用于构建时，可以使用 `layer-build` 工具将标准镜像转换为 FC E2B 兼容镜像（注入 envd 组件）。
-
-#### 安装 layer-build
-
-macOS / Linux 一键安装：
+当模板状态为 `ready` 后，可以使用模板名称或 `template_id` 创建沙箱：
 
 ```bash
-curl -o- -L https://images.devsapp.cn/e2b/layer-build/latest/install.sh | bash
+e2b sandbox create my-code-interpreter-v1
 ```
 
-也支持手动下载：
-
-| **平台** | **下载地址** |
-| --- | --- |
-| Linux/x86 | [layer-build-linux-amd64](https://serverless-tool-images.oss-cn-hangzhou.aliyuncs.com/e2b/layer-build/latest/layer-build-linux-amd64) |
-| Linux/arm64 | [layer-build-linux-arm64](https://serverless-tool-images.oss-cn-hangzhou.aliyuncs.com/e2b/layer-build/latest/layer-build-linux-arm64) |
-| macOS/x86 | [layer-build-darwin-amd64](https://serverless-tool-images.oss-cn-hangzhou.aliyuncs.com/e2b/layer-build/latest/layer-build-darwin-amd64) |
-| macOS/arm64 | [layer-build-darwin-arm64](https://serverless-tool-images.oss-cn-hangzhou.aliyuncs.com/e2b/layer-build/latest/layer-build-darwin-arm64) |
-| Windows/x86 | [layer-build-windows-amd64.exe](https://serverless-tool-images.oss-cn-hangzhou.aliyuncs.com/e2b/layer-build/latest/layer-build-windows-amd64.exe) |
-| Windows/arm64 | [layer-build-windows-arm64.exe](https://serverless-tool-images.oss-cn-hangzhou.aliyuncs.com/e2b/layer-build/latest/layer-build-windows-arm64.exe) |
-
-#### 执行镜像转换
-
-在北京阿里云 ACR 镜像仓库中准备 x86 Docker 镜像后，运行转换命令。转换会将原始镜像注入 envd 组件，生成 FC E2B 兼容的新镜像：
+进入沙箱后建议先验证关键依赖：
 
 ```bash
-# 将源镜像转换为 FC E2B 兼容镜像
-# 请将 u1 和 p1 替换为 ACR 的实际用户名和密码
-layer-build \
-  --source registry.cn-beijing.aliyuncs.com/your-namespace/your-image:stable \
-  --target registry.cn-beijing.aliyuncs.com/your-namespace/your-image:stable-envd \
-  --source_username "u1" \
-  --source_password "p1" \
-  --target_username "u1" \
-  --target_password "p1"
+env | sort | head
+python3 --version
+which python3
 ```
 
-转换完成后，使用生成的 `-envd` 标签镜像作为 `E2B_TEMPLATE_IMAGE` 的值，通过上述 E2B SDK 脚本构建模板。
+### ACR EE 网络要求
 
-`layer-build` 适合作为兼容性补充路径，不建议替代正常的镜像构建流程。生产环境中建议仍然保留原始 Dockerfile、基础镜像版本、依赖锁文件和镜像安全扫描记录，确保可以复现和回滚。
+使用自己的 ACR EE 镜像前，请先确认以下条件：
 
-### 通过 OpenAPI 创建
+- ACR EE 实例已至少绑定一个专有网络 VPC。
+- 该 VPC 下至少有一个 vSwitch 位于函数计算支持的可用区。
+- ACR EE 镜像仓库、VPC、vSwitch 与云沙箱需位于同一地域，例如本文默认使用北京地域。
+- ACR EE 访问控制与 VPC 配置已允许对应网络访问。
+- VPC 网段需使用 RFC 1918 规定的私有地址段，即 `10.0.0.0/8`、`172.16.0.0/12` 或 `192.168.0.0/16`。不支持公网私用，详情请参见[VPC 常见问题](https://help.aliyun.com/zh/vpc/frequently-asked-questions#c814109cb0l1h)。
+- VPC 下需至少配置一个非云服务托管的安全组，且该安全组规则需允许访问对应的 ACR EE 实例。
 
-通过控制面 OpenAPI 创建模板时，在请求体中指定 `containerConfiguration`：
+函数计算支持的可用区会随地域和产品能力调整，最新列表请参考[函数计算支持的可用区](t1881025.md#section-40g-39j-s9a)。
 
-```json
-{
-  "templateName": "my-custom-sandbox",
-  "cpu": 2.0,
-  "memory": 4096,
-  "diskSize": 10240,
-  "containerConfiguration": {
-    "image": "registry.cn-hangzhou.aliyuncs.com/your-namespace/your-image:v1.0",
-    "command": ["/bin/bash", "-c", "python server.py"]
-  },
-  "environmentVariables": {
-    "MY_APP_CONFIG": "production"
-  }
+### 模板名称最佳实践
+
+建议在模板名称中包含业务名、基础镜像、关键依赖版本或日期，例如 `agent-python313-20260531`。生产环境避免覆盖正在使用的模板，先创建新模板并灰度验证。
+
+### 高级配置：通过 Header 调整模板构建
+
+`sandbox-gateway` 支持通过 `Template.build(..., headers={...})` 传入 `X-E2B-Template-*` 扩展 Header。只有需要显式指定构建模式、目标镜像、私有仓库凭证或 ACR EE 网络时，才需要配置这些 Header。
+
+其中 `builder` 用于把普通业务镜像处理成可用于云沙箱模板的镜像。构建时，平台会临时启动一个 FC 函数，由这个 `builder` 函数拉取源镜像、加入云沙箱运行所需的依赖，并推送为目标镜像；模板最终使用这个目标镜像创建沙箱运行环境。
+
+示例：
+
+```python
+headers = {
+    "X-E2B-Template-Build-Mode": "builder",
+    "X-E2B-Template-Source-Registry-Type": "acree",
+    "X-E2B-Template-Dest-Image-Ref": "example-registry.cn-beijing.cr.aliyuncs.com/example/app:e2b",
+    "X-E2B-Template-Source-Username": "source-user",
+    "X-E2B-Template-Source-Password": "source-password",
+    "X-E2B-Template-Dest-Username": "dest-user",
+    "X-E2B-Template-Dest-Password": "dest-password",
+    "X-E2B-Template-Source-ACREE-Instance-ID": "cri-example",
+    "X-E2B-Template-Source-VPC-ID": "vpc-example",
+    "X-E2B-Template-Source-VSwitch-IDs": "vsw-example-a,vsw-example-b",
+    "X-E2B-Template-Source-Security-Group-ID": "sg-example",
 }
+
+build = Template.build(
+    Template().from_image(image),
+    name=name,
+    cpu_count=2,
+    memory_mb=2048,
+    skip_cache=False,
+    on_build_logs=default_build_logger(),
+    headers=headers,
+    **conn_opts,
+)
 ```
 
-#### 高级 Header 配置
+支持的 Header：
 
-在构建模板时，可以通过传递 `X-E2B-Template-*` 系列 Header 来精细控制构建过程：
-
-| **Header** | **说明** |
-| --- | --- |
-| Build Mode | 设置为 `"builder"` 时由临时函数注入依赖；设置为 `"direct"` 时直接使用源镜像不做转换 |
-| Credentials | 提供源镜像仓库和目标镜像仓库的用户名和 Token |
-| Network Routing | 指定 VPC、vSwitch 和安全组 ID，使构建器能够安全访问私有镜像仓库 |
-
-通过 OpenAPI 创建自定义模板时，应避免在请求体、代码仓库或脚本中硬编码镜像仓库密码、Token、AccessKey 等敏感信息。建议通过环境变量、凭据管理服务或临时凭证注入。
-
-## 镜像要求
-
-自定义镜像需要满足以下要求才能作为沙箱模板使用：
-
-| **要求** | **说明** |
-| --- | --- |
-| 架构要求 | 镜像需要 **x86_64** 架构 |
-| 容器格式 | 标准 OCI/Docker 容器镜像 |
-| 网络监听 | 容器启动后需在指定端口提供 HTTP 服务（用于接收数据面 API 请求） |
-| 基础环境 | 建议包含基本的 Linux 工具（如 bash、coreutils） |
-| 权限配置 | 容器内的进程应以非 root 用户运行（推荐） |
-| 镜像大小 | 建议控制镜像大小以优化冷启动时间，3 GB 以内镜像可实现 P100 < 1 秒冷启动 |
-| 可选依赖 | SDK 的 Git 相关功能需要镜像中包含 `git` 命令；Python 代码执行需要 `python`；Node.js 代码执行需要 `node` |
-
-如果自定义模板需要提供与官方 Code Interpreter 类似的数据面能力，镜像内需要启动相应 HTTP 服务并暴露约定端口；如果需要浏览器自动化能力，镜像内还需要包含浏览器、CDP 服务、图形/虚拟显示相关依赖以及对应的健康检查逻辑。只预装依赖但不提供沙箱数据面服务的镜像，通常无法直接替代官方模板。
-
-## 镜像仓库配置
-
-使用自定义镜像时，需要确保函数计算服务有权访问您的镜像仓库：
-
-| **镜像来源** | **前置条件** |
-| --- | --- |
-| ACR 个人版 | 确保 ACR 仓库与函数计算在同一地域，或已配置跨地域同步 |
-| ACR 企业版 | 确保已配置实例访问凭证，且网络互通（见下方网络前提条件） |
-| 其他公有镜像 | 确保镜像仓库允许匿名拉取，或已配置访问凭证 |
-| 自定义镜像仓库 | 需配置仓库访问凭证（用户名/密码或 Token） |
-
-### ACR 企业版网络前提条件
-
-使用 ACR 企业版私有镜像时，需要确保以下网络条件：
-
-1. ACR EE 实例必须已绑定 VPC。
-2. VPC 中需包含一个位于函数计算支持可用区的 vSwitch。
-3. 所有网络资源必须与沙箱所在的地域一致。
-4. ACR EE 访问控制与 VPC 配置允许对应网络访问。
-5. VPC 网段使用 RFC 1918 规定的私有地址段。
-6. VPC 下至少配置一个非云服务托管的安全组，且安全组规则允许访问对应的 ACR EE 实例。
-
-如果遇到 `"vSwitch is in unsupported zone"` 错误，请在同一 VPC 中创建一个函数计算支持可用区的 vSwitch。
-
-## 已知限制条件
-
-| **限制** | **说明** |
-| --- | --- |
-| 镜像架构 | 仅支持 x86_64 架构镜像 |
-| Git 功能 | SDK 的 Git 相关功能需要镜像中预装 `git` 命令 |
-| Python 执行 | SDK 的 Python 代码执行功能需要镜像中预装 `python` 命令 |
-| Node.js 执行 | SDK 的 Node.js 代码执行功能需要镜像中预装 `node` 命令 |
-| apt_install | Template 暂不支持通过 `apt_install` 等方式在构建时安装软件包，请通过 Dockerfile 预装所需依赖后使用 `from_image` 传入构建后的镜像 |
-| start_command | 暂不支持自定义 `start_command` |
-| Jupyter 集成 | 深休眠功能上线后，将支持使用 Jupyter 替代内置执行器以获得更高兼容性（需要镜像中包含 `jupyter` 命令） |
-
-## 与官方模板的对比
-
-| **对比项** | **官方模板** | **自定义模板** |
+| Header | 取值或格式 | 说明 |
 | --- | --- | --- |
-| 镜像来源 | 平台提供的官方镜像 | 用户自己的容器镜像 |
-| 开箱即用 | 开箱即用，无需额外配置 | 需要自行构建和维护镜像 |
-| 灵活性 | 使用平台预装的环境和工具 | 完全自定义运行环境和依赖 |
-| 维护成本 | 平台负责镜像更新和维护 | 用户负责镜像的构建、更新和安全补丁 |
-| 适用场景 | 通用场景、快速验证 | 有特定依赖需求的生产环境 |
+| `X-E2B-Template-Build-Mode` | `builder`、`direct` | 构建模式。`builder` 会使用临时 FC 函数生成适配云沙箱的目标镜像；`direct` 会直接使用源镜像。 |
 
-**建议**：如果官方模板能满足需求，优先使用官方模板以降低维护成本。当官方模板无法满足特定依赖或环境需求时，再使用自定义模板。
+`builder` 模式还可以配置以下 Header：
 
-## 最佳实践
-
-**镜像分层构建**：将基础环境（操作系统、运行时）和业务依赖（库、工具、证书）分层构建，利用容器缓存加速镜像构建和拉取。
-
-**版本管理**：为自定义镜像使用语义化版本号（如 `v1.0.0`）或在模板名称中追加日期后缀，便于追踪和回滚，防止意外覆盖。
-
-**最小化镜像**：仅安装必要的依赖，减小镜像体积以优化冷启动时间。
-
-**安全扫描**：定期对镜像进行安全漏洞扫描，及时更新基础镜像和依赖版本。
-
-**环境变量管理**：通过环境变量传递配置信息，避免将敏感信息硬编码到镜像中。
-
-**启动健康检查**：确保容器启动后监听的端口、启动命令和健康检查一致。自定义镜像常见问题不是镜像拉取失败，而是容器已启动但沙箱数据面服务没有按预期监听端口。
-
-**先小规格验证**：先用最小依赖镜像验证模板创建、沙箱启动、命令执行、文件读写和销毁流程，再逐步加入大型依赖或模型文件，便于定位冷启动和兼容性问题。
-
-## 常见问题排查
-
-| **问题** | **可能原因** | **解决方案** |
+| Header | 取值或格式 | 说明 |
 | --- | --- | --- |
-| 构建速度慢 | 镜像体积过大、网络链路不佳 | 优化镜像大小，检查网络路由和缓存配置 |
-| 镜像拉取失败 | 仓库访问权限不足或 VPC 未打通 | 检查仓库访问控制策略和 VPC 绑定配置 |
-| 沙箱执行报错 | 镜像中缺少必要命令（如 python、node） | 确认镜像中已预装所需运行时和工具 |
-| 模板名称冲突 | 使用了已存在的模板名称 | 在模板名称中追加版本号或日期后缀 |
-| vSwitch 不支持 | vSwitch 所在可用区不被函数计算支持 | 在同一 VPC 中创建函数计算支持可用区的 vSwitch |
+| `X-E2B-Template-Source-Registry-Type` | `acr`、`acree` | 源镜像仓库类型。 |
+| `X-E2B-Template-Dest-Image-Ref` | 完整镜像地址 | 目标镜像地址。 |
+| `X-E2B-Template-Source-Username` | 字符串 | 源镜像拉取用户名。 |
+| `X-E2B-Template-Source-Password` | 字符串 | 源镜像拉取密码或 token。 |
+| `X-E2B-Template-Dest-Username` | 字符串 | 目标镜像推送用户名。 |
+| `X-E2B-Template-Dest-Password` | 字符串 | 目标镜像推送密码或 token。 |
+| `X-E2B-Template-Source-ACREE-Instance-ID` | ACR EE 实例 ID | 源 ACR EE 实例 ID。 |
+| `X-E2B-Template-Source-VPC-ID` | VPC ID | 访问源镜像仓库使用的 VPC。 |
+| `X-E2B-Template-Source-VSwitch-IDs` | vSwitch ID 列表，逗号分隔 | 访问源镜像仓库使用的交换机。 |
+| `X-E2B-Template-Source-Security-Group-ID` | 安全组 ID | 访问源镜像仓库使用的安全组。 |
 
-## 相关文档
+构建模式说明：
 
-- [Templates 概览](01.概览.md)
-- [定义模板](04.定义模板.md)
-- [生命周期](../01.Sandbox/01.生命周期.md)
+- `builder`：使用临时 FC 函数处理源镜像，加入云沙箱运行依赖，并生成适配云沙箱的目标镜像，适合普通业务镜像。
+- `direct`：不执行镜像转换，直接把源镜像作为 `custom-container` 模板函数镜像。源镜像需要已经具备 E2B 运行依赖。
+
+注意事项：
+
+- 密码、token 等敏感信息建议只从 `.env` 或环境变量读取，不要写入代码仓库，也不要打印到日志。
+- VPC、vSwitch、安全组 Header 只用于 builder 访问源镜像仓库，不影响最终模板和沙箱的网络配置。
+
+## 问题排查
+
+### 1. 模板构建慢
+
+优先检查自己的 ACR EE 镜像体积、网络链路、镜像层缓存和 ACR EE 私网访问配置。基础镜像越大，首次构建通常越慢。
+
+如果只是排查模板构建链路是否正常，可以临时使用已有 E2B 兼容镜像做对照验证。这类镜像已经注入 envd 等运行依赖，通常更容易排除镜像适配问题。
+
+### 2. ACR EE 镜像拉取失败
+
+检查镜像地址、地域、命名空间、仓库权限、VPC 绑定和访问控制配置。使用私有 ACR EE 镜像时，网络配置错误比 SDK 参数错误更常见。
+
+### 3. vSwitch 所在可用区不支持
+
+如果构建或运行过程中遇到 `vSwitch is in unsupported zone`，说明当前选择的 vSwitch 所在可用区不被函数计算支持。
+
+处理方式：
+
+1. 根据错误信息确认当前 vSwitch 所在可用区。
+2. 在函数计算支持的可用区中选择一个 Zone。
+3. 在同一个 VPC 中新建该 Zone 下的 vSwitch。
+4. 使用这个新的 vSwitch 配置函数计算或相关网络配置。
+5. 重新构建模板并创建沙箱验证。
+
+同一个 VPC 内不同可用区的交换机默认内网互通。因此，即使业务资源在其他可用区，也可以在同一个 VPC 中新增一个函数计算支持可用区下的 vSwitch，用于完成函数计算侧网络接入。
+
+### 4. 沙箱创建成功但 `run_code` 失败
+
+`run_code` 会调用镜像的 `python3` 命令执行代码，如果镜像不包含 `python3` 或相关依赖，可能会导致执行失败。建议先确认镜像是否包含代码解释器所需依赖。可以在沙箱中运行：
+
+```bash
+python3 --version
+which python3
+env | sort | head -50
+```


### PR DESCRIPTION
## 变更说明
- 将云沙箱 Templates 下的自定义模板文档替换为本次给定版本
- 清理导入残留锚点，修正标题、列表、表格和代码块格式
- 保持内容口径不做额外改写

## 验证
- git diff --check
- python scripts/prepare-mkdocs.py
- mkdocs build --config-file mkdocs.generated.yml

说明：MkDocs 构建成功；仓库既有链接告警仍存在。本次文档中的 `t1881025.md#section-40g-39j-s9a` 按给定内容保留，构建提示该目标文件在当前仓库中不存在。