### PR TITLE
docs(sandbox): 更新 browser 模板规格与示例，同步中英文

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
@@ -2,6 +2,15 @@
 
 Built-in templates let you create a sandbox quickly. The quickstart and Code Interpreter examples use `code-interpreter-v1` by default.
 
+## Template list
+
+| Template | Use case | Description |
+| --- | --- | --- |
+| base template | Basic commands, file access, SDK connectivity checks | Default base template; does not provide the Code Interpreter service or browser automation |
+| code-interpreter-v1 template | AI Agent code execution, data analysis, file processing | The quickstart and Code Interpreter examples use `code-interpreter-v1` by default |
+| [browser template](02.Built-in%20Templates/Browser%20Template.md) | Browser automation, web scraping, screenshots, UI testing | Provides browser capabilities such as CDP, VNC, screenshots, and page interaction |
+| all-in-one template | Combined code execution and browser automation | Provides both Code Interpreter and browser capabilities |
+
 ## View templates
 
 Use the CLI to view the templates available to the current account:

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
@@ -6,10 +6,10 @@ Built-in templates let you create a sandbox quickly. The quickstart and Code Int
 
 | Template | Use case | Description |
 | --- | --- | --- |
-| base template | Basic commands, file access, SDK connectivity checks | Default base template; does not provide the Code Interpreter service or browser automation |
-| code-interpreter-v1 template | AI Agent code execution, data analysis, file processing | The quickstart and Code Interpreter examples use `code-interpreter-v1` by default |
+| [base template](02.Built-in%20Templates/Base%20Template.md) | Basic commands, file access, SDK connectivity checks | Default base template; does not provide the Code Interpreter service or browser automation |
+| [code-interpreter-v1 template](02.Built-in%20Templates/Code%20Interpreter%20v1%20Template.md) | AI Agent code execution, data analysis, file processing | The quickstart and Code Interpreter examples use `code-interpreter-v1` by default |
 | [browser template](02.Built-in%20Templates/Browser%20Template.md) | Browser automation, web scraping, screenshots, UI testing | Provides browser capabilities such as CDP, VNC, screenshots, and page interaction |
-| all-in-one template | Combined code execution and browser automation | Provides both Code Interpreter and browser capabilities |
+| [all-in-one template](02.Built-in%20Templates/All-in-One%20Template.md) | Combined code execution and browser automation | Provides both Code Interpreter and browser capabilities |
 
 ## View templates
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/All-in-One Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/All-in-One Template.md
@@ -1,0 +1,178 @@
+# All-in-One Template
+
+The all-in-one template merges the capabilities of the browser template and the code-interpreter-v1 template into a single, unified cloud-isolated execution environment. An all-in-one sandbox can do both browser-level automation (CDP / VNC / recording) and code execution, file management, and interactive terminals — the "eyes + brain + hands" of an AI Agent.
+
+The all-in-one template aligns with the experience of using browser automation and Code Interpreter together in E2B.
+
+## Features
+
+| **Feature** | **Description** |
+| --- | --- |
+| Browser automation | Integrates browser template capabilities: CDP protocol, Puppeteer/Playwright compatibility, real-time VNC viewing, and session recording |
+| Code execution | Integrates code-interpreter-v1 template capabilities: Python/JavaScript code execution, context management, and file system operations |
+| Terminal commands | Supports synchronous command execution and an interactive WebSocket terminal (TTY) |
+| Process management | List, query, and stop processes running inside the sandbox |
+| Coordinated execution | Use the browser and the code interpreter in the same session to build end-to-end "browser scrape → code processing" workflows |
+| Secure isolation | Dedicated isolation based on function instances; each sandbox instance has its own file system, browser instance, and process space |
+
+## Use cases
+
+| **Scenario** | **Description** |
+| --- | --- |
+| AI Agent composite tasks | Drive the browser for page interaction and run code to process and analyze data, all in the same session |
+| Data collection and processing | Scrape dynamic pages with the browser first, then run scripts in the sandbox to parse, clean, and export the results |
+| Automated testing | Coordinate browser E2E with backend scripts, making replay and troubleshooting easy in a controlled container environment |
+| Content generation and archiving | Generate screenshots/PDFs/recordings and persist or download the processed results |
+
+## Default configuration
+
+The default configuration of the all-in-one template is as follows:
+
+| **Item** | **Default** | **Description** |
+| --- | --- | --- |
+| Container image | `sandbox-all-in-one:v0.9.30` | Prebuilt all-in-one sandbox image |
+| Default port | 5000 | Port the sandbox service listens on |
+| CPU | 4 vCPU | Default spec, since it must support both the browser and code execution |
+| Memory | 8192 MB (8 GB) | Default spec |
+| Disk size | 10240 MB (10 GB) | 10 GB is recommended to store browser data and execution results |
+
+> **Note**
+>
+> The default CPU and memory specs of the all-in-one template are higher than those of the code-interpreter-v1 template and the browser template, because it must support both the browser runtime and the code execution environment at the same time.
+
+## Difference from the browser template
+
+The browser template provides a browser runtime and exposes CDP and VNC capabilities through port 3000 by default. It suits browser automation tasks such as web access, page interaction, screenshots, data collection, and UI testing. It includes E2B envd-compatible base capabilities but does not provide the Code Interpreter service, so you cannot execute Python directly through a Code Interpreter context.
+
+The all-in-one template layers the Code Interpreter service on top of the browser capabilities, using port 3000 as the browser entry and port 5000 as the code execution and file management entry by default. It can execute Python directly within the same sandbox session, enabling composite flows such as "browser scrapes a dynamic page → Python parses/cleans/analyzes → file export."
+
+| **Comparison** | **Browser template** | **All-in-one template** |
+| --- | --- | --- |
+| Core positioning | Lightweight browser automation environment | Integrated browser automation + code execution environment |
+| Browser capabilities | Supports CDP, VNC, screenshots, page interaction | Supports CDP, VNC, screenshots, page interaction |
+| E2B envd base capabilities | Supported | Supported |
+| Code Interpreter service | Not supported | Supported |
+| Code execution | Cannot execute Python through Code Interpreter | Supports Python / JavaScript code execution |
+| File processing | Supports basic file access, no Code Interpreter file API | Supports the file API and in-context read/write and processing |
+| Typical entries | 3000 (browser entry) | 3000 (browser entry) / 5000 (code entry) |
+| Default spec | 2 vCPU / 2048 MB / 10240 MB disk | 4 vCPU / 8192 MB / 10240 MB disk |
+| Recommended for | Only browser automation is needed | Browser and code execution need to work together |
+
+## Quickstart
+
+### Step 1: Prepare an API key
+
+1. Log in to the [Function Compute console](https://fcnext.console.aliyun.com/).
+2. See [Create an API Key](../../../01.Getting%20Started/02.Create%20an%20API%20Key.md) to create and obtain an API key.
+3. Use the API key and API endpoint through an SDK to create a sandbox (see the examples below).
+
+### Step 2: Obtain the endpoints
+
+An all-in-one sandbox provides the following endpoints:
+
+| **Endpoint** | **Format** | **Purpose** |
+| --- | --- | --- |
+| CDP automation endpoint | `wss://{sbx.get_host(3000)}/ws/automation` | Browser automation (Puppeteer/Playwright) |
+| VNC livestream endpoint | `wss://{sbx.get_host(3000)}/ws/livestream` | View the browser interface in real time |
+| Data-plane REST API | `https://{accountID}.e2b-data.cn-hangzhou.aliyuncs.com/` | Code execution, file management, terminal commands |
+
+> **Note**: The CDP and VNC endpoints obtain the host address through the SDK's `sbx.get_host(3000)`, and the `X-Access-Token` header is required for authentication when connecting.
+
+### Step 3: Use browser automation
+
+```javascript
+const puppeteer = require('puppeteer-core');
+const { Sandbox } = require('e2b');
+
+const BROWSER_SANDBOX_PORT = 3000;
+
+async function main() {
+  const sbx = await Sandbox.create({ template: 'all-in-one-template', apiKey: E2B_API_KEY, timeout: 600 });
+  try {
+    const host = sbx.getHost(BROWSER_SANDBOX_PORT);
+    const cdpEndpoint = `wss://${host}/ws/automation`;
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: cdpEndpoint,
+      headers: { 'X-Access-Token': sbx.envdAccessToken },
+    });
+    const page = await browser.newPage();
+    await page.goto('https://example.com');
+    await page.screenshot({ path: 'example.png' });
+    await browser.close();
+  } finally {
+    await sbx.kill();
+  }
+}
+main();
+```
+
+### Step 4: Use code execution
+
+Create a context and execute code through the data-plane API:
+
+```json
+POST ${BASEURL}/sandboxes/{sandboxId}/contexts
+
+{
+  "language": "python",
+  "cwd": "/home/user"
+}
+```
+
+```json
+POST ${BASEURL}/sandboxes/{sandboxId}/contexts/execute
+
+{
+  "contextId": "{contextId}",
+  "code": "import json\nprint(json.dumps({'status': 'ok'}))",
+  "timeout": 30
+}
+```
+
+### Use both in the same session
+
+The core advantage of the all-in-one template is using the browser and code execution capabilities in the same sandbox session. A typical workflow: the browser scrapes data → Python code processes and analyzes it → the file API exports the results.
+
+> **Note**: The Python example below obtains the access token through `sbx._envd_access_token`, which is an internal SDK implementation detail and may change in future versions. The JS SDK exposes the public field `sbx.envdAccessToken`.
+
+```python
+import asyncio
+from e2b import Sandbox
+from browser_use import BrowserSession, BrowserProfile
+
+BROWSER_SANDBOX_PORT = 3000
+
+async def run_aio_task():
+    # 1. Create the sandbox and obtain the CDP endpoint
+    sbx = Sandbox.create(template="all-in-one-template", api_key=E2B_API_KEY, timeout=600)
+    try:
+        host = sbx.get_host(BROWSER_SANDBOX_PORT)
+        cdp_url = f"wss://{host}/ws/automation"
+
+        browser = BrowserSession(
+            cdp_url=cdp_url,
+            browser_profile=BrowserProfile(headless=True),
+            extra_headers={"X-Access-Token": sbx._envd_access_token},
+        )
+
+        # 2. Create a Python context through the data-plane API and run data-processing code
+        #    POST ${BASEURL}/sandboxes/{sandboxId}/contexts
+        #    POST ${BASEURL}/sandboxes/{sandboxId}/contexts/execute
+
+        # 3. Scrape data with the browser, then process and analyze it with code
+        #    ...
+    finally:
+        sbx.kill()
+
+asyncio.run(run_aio_task())
+```
+
+## Related documents
+
+- [Built-in Templates](../02.Built-in%20Templates.md)
+- [Build Custom Image Templates](../03.Build%20Custom%20Image%20Templates.md)
+- [Lifecycle](../../01.Sandbox/01.Lifecycle.md)
+- [Base Template](Base%20Template.md) (choose when you only need the envd base capabilities)
+- [Code Interpreter v1 Template](Code%20Interpreter%20v1%20Template.md) (choose when you only need code execution)
+- [Browser Template](Browser%20Template.md) (choose when you only need browser automation)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Base Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Base Template.md
@@ -1,0 +1,65 @@
+# Base Template
+
+The base template provides a minimal FC Agent Sandbox runtime that contains only the E2B envd-compatible base service. It suits scenarios where you need to manage the sandbox lifecycle through an E2B-compatible SDK, run basic commands, access the file system, or use it as a baseline for custom capabilities.
+
+The base template aligns with the base experience around E2B Commands, Filesystem, and the Sandbox lifecycle, and is the shared capability foundation of the code-interpreter-v1 template, the browser template, and the all-in-one template.
+
+## Features
+
+| **Feature** | **Description** |
+| --- | --- |
+| envd base service | Built-in E2B envd-compatible service that supports sandbox creation, connection, basic commands, and file access |
+| Lightweight runtime | Does not preinstall the Code Interpreter service or browser automation service |
+| Secure isolation | Each sandbox instance has its own file system and process space |
+| Extensible baseline | Suitable as a base template for custom toolchains, business runtimes, or higher-level capabilities |
+
+## Use cases
+
+| **Scenario** | **Description** |
+| --- | --- |
+| Basic command execution | Run simple shell commands through envd for tasks such as environment checks and file preparation |
+| Custom runtime baseline | Install or wrap your own dependencies and tools on top of a minimal sandbox environment |
+| SDK connectivity checks | Validate API keys, regions, and the template/sandbox creation and destruction flow |
+| Lightweight tasks | Tasks that need neither the Python code interpreter service nor browser automation |
+
+## Default configuration
+
+The default configuration of the base template is as follows:
+
+| **Item** | **Default** | **Description** |
+| --- | --- | --- |
+| Default port | No service port | Provides the envd base service |
+| CPU | 2 vCPU | Minimum requirement |
+| Memory | 2048 MB | Minimum requirement |
+| Disk size | 512 MB | Suitable for lightweight commands and temporary files |
+
+## Quickstart
+
+If you need the code interpreter, browser automation, or both, choose the [code-interpreter-v1 template](Code%20Interpreter%20v1%20Template.md), the [browser template](Browser%20Template.md), or the [all-in-one template](All-in-One%20Template.md) respectively.
+
+When you do not explicitly specify a `template`, a base sandbox is created by default.
+
+```python
+import os
+
+from e2b import Sandbox
+
+sbx = Sandbox.create(
+    api_key=os.environ["E2B_API_KEY"],
+    timeout=600,
+)
+
+result = sbx.commands.run("echo hello from base template")
+print(result.stdout)
+
+sbx.kill()
+```
+
+## Related documents
+
+- [Built-in Templates](../02.Built-in%20Templates.md)
+- [Build Custom Image Templates](../03.Build%20Custom%20Image%20Templates.md)
+- [Lifecycle](../../01.Sandbox/01.Lifecycle.md)
+- [Code Interpreter v1 Template](Code%20Interpreter%20v1%20Template.md)
+- [Browser Template](Browser%20Template.md)
+- [All-in-One Template](All-in-One%20Template.md)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Browser Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Browser Template.md
@@ -30,7 +30,7 @@ The default configuration of the browser template is as follows:
 
 | **Item** | **Default** | **Description** |
 | --- | --- | --- |
-| Container image | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33` | Prebuilt browser image |
+| Container image | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.36` | Prebuilt browser image |
 | Default port | 3000 | Port the sandbox service listens on |
 | CPU | 4 vCPU | Minimum requirement |
 | Memory | 8192 MB | Minimum requirement |
@@ -95,7 +95,7 @@ from e2b import Template, default_build_logger
 API_KEY = "e2b_xxx"  # Replace with your API key
 API_URL = "https://api.cn-beijing.e2b.fc.aliyuncs.com"
 DOMAIN = "cn-beijing.e2b.fc.aliyuncs.com"
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.36"
 OPTS = {"api_key": API_KEY, "api_url": API_URL, "domain": DOMAIN}
 
 TEMPLATE_NAME = "my-browser-template"
@@ -124,7 +124,7 @@ const API_KEY = 'e2b_xxx'; // Replace with your API key
 const API_URL = 'https://api.cn-beijing.e2b.fc.aliyuncs.com';
 const DOMAIN = 'cn-beijing.e2b.fc.aliyuncs.com';
 const FROM_IMAGE =
-  'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33';
+  'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.36';
 const OPTS = { apiKey: API_KEY, apiUrl: API_URL, domain: DOMAIN };
 
 const TPL_NAME = 'my-browser-template';

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Browser Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Browser Template.md
@@ -173,13 +173,16 @@ TARGET_URL = "https://example.com"
 SCREENSHOT_PATH = "browser-example.png"
 
 
-def wait_until_healthy(sbx: Sandbox, timeout: int = 60) -> None:
-    """Poll the /health endpoint inside the sandbox until the browser service is ready or times out."""
+def wait_until_healthy(sbx: Sandbox, host: str, token: str, timeout: int = 60) -> None:
+    """Poll the public gateway /health endpoint until the browser service is ready or times out."""
+    # Go through the public gateway host (3000-<sandboxId>.<domain>); the X-Access-Token header is required.
+    token_header = f"-H 'X-Access-Token: {token}' " if token else ""
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = sbx.commands.run(
             f"curl -sS -o /dev/null -w '%{{http_code}}' -m 4 "
-            f"http://localhost:{BROWSERTOOL_PORT}/health",
+            f"{token_header}"
+            f"https://{host}/health",
             timeout=10,
         )
         code = "".join(result.stdout or []).strip()
@@ -191,19 +194,22 @@ def wait_until_healthy(sbx: Sandbox, timeout: int = 60) -> None:
     raise TimeoutError(f"browser service not ready within {timeout}s")
 
 
-def verify_vnc_handshake(sbx: Sandbox) -> None:
-    """Probe the /ws/livestream WebSocket handshake inside the sandbox; a 101 response means VNC is ready."""
+def verify_vnc_handshake(sbx: Sandbox, host: str, token: str) -> None:
+    """Probe the public gateway /ws/livestream WebSocket handshake; a 101 response means VNC is ready."""
     # After a successful upgrade the connection stays a WebSocket, so curl keeps reading until the -m
     # timeout (exit code 28). This is expected: swallow the exit code with `|| true` and only parse the
     # response headers already received.
+    # Go through the public gateway host (3000-<sandboxId>.<domain>); the X-Access-Token header is required.
+    token_header = f"-H 'X-Access-Token: {token}' " if token else ""
     cmd = (
         "curl -sS -i -m 4 "
         "-H 'Connection: Upgrade' "
         "-H 'Upgrade: websocket' "
         "-H 'Sec-WebSocket-Version: 13' "
         "-H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' "
-        "http://localhost:{port}/ws/livestream || true"
-    ).format(port=BROWSERTOOL_PORT)
+        "{token_header}"
+        "https://{host}/ws/livestream || true"
+    ).format(token_header=token_header, host=host)
     result = sbx.commands.run(cmd, timeout=15)
     out = "".join(result.stdout or [])
     status_line = out.splitlines()[0].strip() if out.strip() else "<no response>"
@@ -245,24 +251,24 @@ try:
     host = sbx.get_host(BROWSERTOOL_PORT)
     cdp_ws_url = f"wss://{host}/ws/automation"
     vnc_ws_url = f"wss://{host}/ws/livestream"
+    # The e2b public gateway requires the X-Access-Token header, otherwise requests/WS upgrades return 403
+    token = sbx._envd_access_token
     print("\n--- WebSocket endpoints ---")
     print(f"  host: {host}")
     print(f"  CDP : {cdp_ws_url}")
     print(f"  VNC : {vnc_ws_url}")
 
     print("\n--- Waiting for health check ---")
-    wait_until_healthy(sbx)
+    wait_until_healthy(sbx, host, token)
 
     print("\n--- Playwright CDP case ---")
-    # The e2b public gateway requires the X-Access-Token header, otherwise the WS upgrade returns 403
     headers = {}
-    token = sbx._envd_access_token
     if token:
         headers["X-Access-Token"] = token
     verify_with_playwright(cdp_ws_url, headers)
 
     print("\n--- VNC livestream case ---")
-    verify_vnc_handshake(sbx)
+    verify_vnc_handshake(sbx, host, token)
 finally:
     if sbx is not None:
         sbx.kill()
@@ -289,8 +295,10 @@ const SCREENSHOT_PATH = 'browser-example.png';
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-/** Poll the /health endpoint inside the sandbox until the browser service is ready or times out. */
-async function waitUntilHealthy(sbx, timeout = 60) {
+/** Poll the public gateway /health endpoint until the browser service is ready or times out. */
+async function waitUntilHealthy(sbx, host, token, timeout = 60) {
+  // Go through the public gateway host (3000-<sandboxId>.<domain>); the X-Access-Token header is required.
+  const tokenHeader = token ? `-H 'X-Access-Token: ${token}' ` : '';
   const deadline = Date.now() + timeout * 1000;
   while (Date.now() < deadline) {
     // While the service is down, curl exits non-zero (connection failure) and e2b throws a
@@ -299,7 +307,8 @@ async function waitUntilHealthy(sbx, timeout = 60) {
     try {
       result = await sbx.commands.run(
         `curl -sS -o /dev/null -w '%{http_code}' -m 4 ` +
-          `http://localhost:${BROWSERTOOL_PORT}/health`,
+          tokenHeader +
+          `https://${host}/health`,
         { timeoutMs: 10_000 },
       );
     } catch (e) {
@@ -316,18 +325,21 @@ async function waitUntilHealthy(sbx, timeout = 60) {
   throw new Error(`browser service not ready within ${timeout}s`);
 }
 
-/** Probe the /ws/livestream WebSocket handshake inside the sandbox; a 101 response means VNC is ready. */
-async function verifyVncHandshake(sbx) {
+/** Probe the public gateway /ws/livestream WebSocket handshake; a 101 response means VNC is ready. */
+async function verifyVncHandshake(sbx, host, token) {
   // After a successful upgrade the connection stays a WebSocket, so curl keeps reading until the -m
   // timeout (exit code 28). This is expected: swallow the exit code with `|| true` and only parse the
   // response headers already received.
+  // Go through the public gateway host (3000-<sandboxId>.<domain>); the X-Access-Token header is required.
+  const tokenHeader = token ? `-H 'X-Access-Token: ${token}' ` : '';
   const cmd =
     `curl -sS -i -m 4 ` +
     `-H 'Connection: Upgrade' ` +
     `-H 'Upgrade: websocket' ` +
     `-H 'Sec-WebSocket-Version: 13' ` +
     `-H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' ` +
-    `http://localhost:${BROWSERTOOL_PORT}/ws/livestream || true`;
+    tokenHeader +
+    `https://${host}/ws/livestream || true`;
   const result = await sbx.commands.run(cmd, { timeoutMs: 15_000 });
   const out = result.stdout || '';
   const statusLine = out.trim() ? out.split('\n')[0].trim() : '<no response>';
@@ -371,25 +383,25 @@ async function main() {
     const host = sbx.getHost(BROWSERTOOL_PORT);
     const cdpWsUrl = `wss://${host}/ws/automation`;
     const vncWsUrl = `wss://${host}/ws/livestream`;
+    // The e2b public gateway requires the X-Access-Token header, otherwise requests/WS upgrades return 403
+    const token = sbx.envdAccessToken;
     console.log('\n--- WebSocket endpoints ---');
     console.log(`  host: ${host}`);
     console.log(`  CDP : ${cdpWsUrl}`);
     console.log(`  VNC : ${vncWsUrl}`);
 
     console.log('\n--- Waiting for health check ---');
-    await waitUntilHealthy(sbx);
+    await waitUntilHealthy(sbx, host, token);
 
     console.log('\n--- Playwright CDP case ---');
-    // The e2b public gateway requires the X-Access-Token header, otherwise the WS upgrade returns 403
     const headers = {};
-    const token = sbx.envdAccessToken;
     if (token) {
       headers['X-Access-Token'] = token;
     }
     await verifyWithPlaywright(cdpWsUrl, headers);
 
     console.log('\n--- VNC livestream case ---');
-    await verifyVncHandshake(sbx);
+    await verifyVncHandshake(sbx, host, token);
   } finally {
     if (sbx !== null) {
       await sbx.kill();

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Browser Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Browser Template.md
@@ -1,0 +1,575 @@
+# Browser Template
+
+The browser template provides a cloud-native browser runtime. It lets you remotely control a browser instance running in an isolated cloud container over the standard Chrome DevTools Protocol (CDP) over WebSocket, with native compatibility for mainstream automation frameworks such as Puppeteer and Playwright.
+
+The browser template aligns with the E2B browser automation experience and offers CDP, VNC, screenshots, page interaction, and more.
+
+## Features
+
+| **Feature** | **Description** |
+| --- | --- |
+| Browser automation | Ships with Chromium/Chrome, supports full web standards, natively compatible with Puppeteer, Playwright, and other automation frameworks |
+| CDP remote control | Precisely drive dynamically rendered pages (SPAs) over the standard CDP protocol over WebSocket, while reliably maintaining login state and sessions |
+| Real-time VNC | Built-in VNC service lets you view the browser desktop in real time through a noVNC client, making debugging and monitoring easy |
+| Session recording | Supports VNC recording to capture the browser session as an MKV video file for playback and auditing |
+| Secure isolation | Each browser sandbox instance has its own file system and process space |
+| Encrypted transport | All data-plane endpoints (CDP and VNC) use the WSS (WebSocket Secure) protocol, encrypted end to end |
+
+## Use cases
+
+| **Scenario** | **Description** |
+| --- | --- |
+| AI Agent enablement | Acts as the "eyes" and "hands" of an LLM, giving it the ability to browse the web, extract information, perform online actions, and other complex tasks |
+| Data collection | Stable, efficient web scraping that copes with dynamic loading and anti-bot challenges |
+| Automated testing | Run end-to-end (E2E) and visual regression tests on demand in the cloud, without maintaining a local test environment |
+| Content generation | Automatically turn dynamic web pages or dashboards into PDFs or screenshots for reports and archiving |
+
+## Default configuration
+
+The default configuration of the browser template is as follows:
+
+| **Item** | **Default** | **Description** |
+| --- | --- | --- |
+| Container image | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33` | Prebuilt browser image |
+| Default port | 3000 | Port the sandbox service listens on |
+| CPU | 4 vCPU | Minimum requirement |
+| Memory | 8192 MB | Minimum requirement |
+| Disk size | 10240 MB | 10 GB is recommended for sufficient temporary storage; Function Compute provides it by default |
+
+## Quickstart
+
+### Step 1: Create a browser sandbox
+
+1. Log in to the [Function Compute console](https://fcnext.console.aliyun.com/).
+2. On the **FC Agent Sandbox** tab, choose **API Keys** and generate an API key.
+3. After creation, on the service details page open the **VNC Debug** tab and choose **New Sandbox** to obtain the CDP connection endpoint.
+
+You can also create it through the OpenAPI or an SDK.
+
+The full workflow for the browser template has two phases: first **build the template** (materialize a named template from the browser image), then **run the template** (create a sandbox, wait for the health check, automate over CDP and take a screenshot, and verify VNC). The Python and Node.js implementations are shown below.
+
+> **Note**: Replace `API_KEY` in the examples with the API key you generated in the console, and replace `API_URL` / `DOMAIN` with the endpoint of the corresponding region. When you connect to the CDP/VNC endpoints, you must include the `X-Access-Token` header for authentication: the Python SDK exposes it through the internal attribute `sbx._envd_access_token` (which may be renamed or removed in future versions), and the JS SDK exposes the public field `sbx.envdAccessToken`.
+
+### Step 2: Prepare the local environment
+
+**Python**:
+
+```bash
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install e2b e2b-code-interpreter 'playwright>=1.49.0'
+playwright install chromium
+```
+
+**Node.js**: use the following `package.json`, then run `npm install`.
+
+```json
+{
+  "name": "browser-template-demo",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@e2b/code-interpreter": "^2.6.1",
+    "e2b": "^2.31.0",
+    "playwright-core": "^1.49.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.0",
+    "tsx": "^4.23.0",
+    "typescript": "^6.0.3"
+  }
+}
+```
+
+### Step 3: Build the browser template
+
+Build a named template from the browser image, specifying the CPU and memory (4 vCPU / 8192 MB recommended) at build time.
+
+**Python**:
+
+```python
+"""Browser template build example."""
+
+from e2b import Template, default_build_logger
+
+API_KEY = "e2b_xxx"  # Replace with your API key
+API_URL = "https://api.cn-beijing.e2b.fc.aliyuncs.com"
+DOMAIN = "cn-beijing.e2b.fc.aliyuncs.com"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33"
+OPTS = {"api_key": API_KEY, "api_url": API_URL, "domain": DOMAIN}
+
+TEMPLATE_NAME = "my-browser-template"
+
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name=TEMPLATE_NAME,
+    cpu_count=4,
+    memory_mb=8192,
+    skip_cache=False,
+    on_build_logs=default_build_logger(),
+    **OPTS,
+)
+
+print(f"template_id: {build.template_id}")
+print(f"build_id: {build.build_id}")
+```
+
+**Node.js**:
+
+```javascript
+// Browser template build example.
+import { Template, defaultBuildLogger } from 'e2b';
+
+const API_KEY = 'e2b_xxx'; // Replace with your API key
+const API_URL = 'https://api.cn-beijing.e2b.fc.aliyuncs.com';
+const DOMAIN = 'cn-beijing.e2b.fc.aliyuncs.com';
+const FROM_IMAGE =
+  'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33';
+const OPTS = { apiKey: API_KEY, apiUrl: API_URL, domain: DOMAIN };
+
+const TPL_NAME = 'my-browser-template';
+
+async function main() {
+  const build = await Template.build(Template().fromImage(FROM_IMAGE), TPL_NAME, {
+    ...OPTS,
+    cpuCount: 4,
+    memoryMB: 8192,
+    skipCache: false,
+    onBuildLogs: defaultBuildLogger(),
+  });
+
+  console.log(`template_id: ${build.templateId}`);
+  console.log(`build_id: ${build.buildId}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+### Step 4: Run the template and execute an automation script
+
+After creating the sandbox, first poll `/health` to wait for the browser service to become ready, then connect Playwright over the CDP endpoint to open the target page and take a screenshot, and finally verify the VNC (livestream) endpoint handshake.
+
+**Python**:
+
+```python
+"""Browser template run example: create sandbox -> wait for health check -> CDP automation -> screenshot -> VNC check."""
+
+import time
+
+from e2b_code_interpreter import Sandbox
+
+API_KEY = "e2b_xxx"  # Replace with your API key
+API_URL = "https://api.cn-beijing.e2b.fc.aliyuncs.com"
+DOMAIN = "cn-beijing.e2b.fc.aliyuncs.com"
+OPTS = {"api_key": API_KEY, "api_url": API_URL, "domain": DOMAIN}
+
+TEMPLATE_NAME = "my-browser-template"
+
+BROWSERTOOL_PORT = 3000
+TARGET_URL = "https://example.com"
+SCREENSHOT_PATH = "browser-example.png"
+
+
+def wait_until_healthy(sbx: Sandbox, timeout: int = 60) -> None:
+    """Poll the /health endpoint inside the sandbox until the browser service is ready or times out."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = sbx.commands.run(
+            f"curl -sS -o /dev/null -w '%{{http_code}}' -m 4 "
+            f"http://localhost:{BROWSERTOOL_PORT}/health",
+            timeout=10,
+        )
+        code = "".join(result.stdout or []).strip()
+        if code == "200":
+            print(f"  ✓ /health ready (HTTP {code})")
+            return
+        print(f"  ...waiting for the browser service (HTTP {code!r})")
+        time.sleep(2)
+    raise TimeoutError(f"browser service not ready within {timeout}s")
+
+
+def verify_vnc_handshake(sbx: Sandbox) -> None:
+    """Probe the /ws/livestream WebSocket handshake inside the sandbox; a 101 response means VNC is ready."""
+    # After a successful upgrade the connection stays a WebSocket, so curl keeps reading until the -m
+    # timeout (exit code 28). This is expected: swallow the exit code with `|| true` and only parse the
+    # response headers already received.
+    cmd = (
+        "curl -sS -i -m 4 "
+        "-H 'Connection: Upgrade' "
+        "-H 'Upgrade: websocket' "
+        "-H 'Sec-WebSocket-Version: 13' "
+        "-H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' "
+        "http://localhost:{port}/ws/livestream || true"
+    ).format(port=BROWSERTOOL_PORT)
+    result = sbx.commands.run(cmd, timeout=15)
+    out = "".join(result.stdout or [])
+    status_line = out.splitlines()[0].strip() if out.strip() else "<no response>"
+    print(f"  /ws/livestream response: {status_line!r}")
+    assert "101" in out and "Switching Protocols" in out, (
+        f"VNC endpoint failed to upgrade to WebSocket: {out[:200]!r}"
+    )
+    print("  ✓ VNC (livestream) endpoint handshake passed")
+
+
+def verify_with_playwright(cdp_ws_url: str, headers: dict) -> None:
+    """Connect to browsertool over CDP, open the target page and validate the title, then take a screenshot."""
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp(cdp_ws_url, headers=headers)
+        # Reuse the default context that browsertool already launched
+        context = browser.contexts[0] if browser.contexts else browser.new_context()
+        page = context.new_page()
+        try:
+            page.goto(TARGET_URL, wait_until="domcontentloaded", timeout=30000)
+            title = page.title()
+            print(f"  page.title() = {title!r}")
+            assert "Example" in title, f"unexpected title: {title!r}"
+
+            page.screenshot(path=SCREENSHOT_PATH, full_page=True)
+            print(f"  ✓ Screenshot saved: {SCREENSHOT_PATH}")
+            print("  ✓ Playwright over CDP verification passed")
+        finally:
+            page.close()
+            browser.close()
+
+
+sbx = None
+try:
+    sbx = Sandbox.create(template=TEMPLATE_NAME, timeout=900, **OPTS)
+    print(f"sandbox_id: {sbx.sandbox_id}")
+
+    host = sbx.get_host(BROWSERTOOL_PORT)
+    cdp_ws_url = f"wss://{host}/ws/automation"
+    vnc_ws_url = f"wss://{host}/ws/livestream"
+    print("\n--- WebSocket endpoints ---")
+    print(f"  host: {host}")
+    print(f"  CDP : {cdp_ws_url}")
+    print(f"  VNC : {vnc_ws_url}")
+
+    print("\n--- Waiting for health check ---")
+    wait_until_healthy(sbx)
+
+    print("\n--- Playwright CDP case ---")
+    # The e2b public gateway requires the X-Access-Token header, otherwise the WS upgrade returns 403
+    headers = {}
+    token = sbx._envd_access_token
+    if token:
+        headers["X-Access-Token"] = token
+    verify_with_playwright(cdp_ws_url, headers)
+
+    print("\n--- VNC livestream case ---")
+    verify_vnc_handshake(sbx)
+finally:
+    if sbx is not None:
+        sbx.kill()
+        print("\nSandbox destroyed")
+```
+
+**Node.js**:
+
+```javascript
+// Browser template run example: create sandbox -> wait for health check -> CDP automation -> screenshot -> VNC check.
+import { Sandbox } from '@e2b/code-interpreter';
+import { chromium } from 'playwright-core';
+
+const API_KEY = 'e2b_xxx'; // Replace with your API key
+const API_URL = 'https://api.cn-beijing.e2b.fc.aliyuncs.com';
+const DOMAIN = 'cn-beijing.e2b.fc.aliyuncs.com';
+const OPTS = { apiKey: API_KEY, apiUrl: API_URL, domain: DOMAIN };
+
+const TPL_NAME = 'my-browser-template';
+
+const BROWSERTOOL_PORT = 3000;
+const TARGET_URL = 'https://example.com';
+const SCREENSHOT_PATH = 'browser-example.png';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Poll the /health endpoint inside the sandbox until the browser service is ready or times out. */
+async function waitUntilHealthy(sbx, timeout = 60) {
+  const deadline = Date.now() + timeout * 1000;
+  while (Date.now() < deadline) {
+    // While the service is down, curl exits non-zero (connection failure) and e2b throws a
+    // CommandExitError. That exception also carries stdout, so catch it and treat it as not ready.
+    let result;
+    try {
+      result = await sbx.commands.run(
+        `curl -sS -o /dev/null -w '%{http_code}' -m 4 ` +
+          `http://localhost:${BROWSERTOOL_PORT}/health`,
+        { timeoutMs: 10_000 },
+      );
+    } catch (e) {
+      result = e;
+    }
+    const code = (result.stdout || '').trim();
+    if (code === '200') {
+      console.log(`  ✓ /health ready (HTTP ${code})`);
+      return;
+    }
+    console.log(`  ...waiting for the browser service (HTTP ${JSON.stringify(code)})`);
+    await sleep(2000);
+  }
+  throw new Error(`browser service not ready within ${timeout}s`);
+}
+
+/** Probe the /ws/livestream WebSocket handshake inside the sandbox; a 101 response means VNC is ready. */
+async function verifyVncHandshake(sbx) {
+  // After a successful upgrade the connection stays a WebSocket, so curl keeps reading until the -m
+  // timeout (exit code 28). This is expected: swallow the exit code with `|| true` and only parse the
+  // response headers already received.
+  const cmd =
+    `curl -sS -i -m 4 ` +
+    `-H 'Connection: Upgrade' ` +
+    `-H 'Upgrade: websocket' ` +
+    `-H 'Sec-WebSocket-Version: 13' ` +
+    `-H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' ` +
+    `http://localhost:${BROWSERTOOL_PORT}/ws/livestream || true`;
+  const result = await sbx.commands.run(cmd, { timeoutMs: 15_000 });
+  const out = result.stdout || '';
+  const statusLine = out.trim() ? out.split('\n')[0].trim() : '<no response>';
+  console.log(`  /ws/livestream response: ${JSON.stringify(statusLine)}`);
+  if (!(out.includes('101') && out.includes('Switching Protocols'))) {
+    throw new Error(`VNC endpoint failed to upgrade to WebSocket: ${JSON.stringify(out.slice(0, 200))}`);
+  }
+  console.log('  ✓ VNC (livestream) endpoint handshake passed');
+}
+
+/** Connect to browsertool over CDP, open the target page and validate the title, then take a screenshot. */
+async function verifyWithPlaywright(cdpWsUrl, headers) {
+  const browser = await chromium.connectOverCDP(cdpWsUrl, { headers });
+  // Reuse the default context that browsertool already launched
+  const contexts = browser.contexts();
+  const context = contexts.length ? contexts[0] : await browser.newContext();
+  const page = await context.newPage();
+  try {
+    await page.goto(TARGET_URL, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+    const title = await page.title();
+    console.log(`  page.title() = ${JSON.stringify(title)}`);
+    if (!title.includes('Example')) {
+      throw new Error(`unexpected title: ${JSON.stringify(title)}`);
+    }
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+    console.log(`  ✓ Screenshot saved: ${SCREENSHOT_PATH}`);
+    console.log('  ✓ Playwright over CDP verification passed');
+  } finally {
+    await page.close();
+    await browser.close();
+  }
+}
+
+async function main() {
+  let sbx = null;
+  try {
+    sbx = await Sandbox.create(TPL_NAME, { ...OPTS, timeoutMs: 900_000 });
+    console.log(`sandbox_id: ${sbx.sandboxId}`);
+
+    const host = sbx.getHost(BROWSERTOOL_PORT);
+    const cdpWsUrl = `wss://${host}/ws/automation`;
+    const vncWsUrl = `wss://${host}/ws/livestream`;
+    console.log('\n--- WebSocket endpoints ---');
+    console.log(`  host: ${host}`);
+    console.log(`  CDP : ${cdpWsUrl}`);
+    console.log(`  VNC : ${vncWsUrl}`);
+
+    console.log('\n--- Waiting for health check ---');
+    await waitUntilHealthy(sbx);
+
+    console.log('\n--- Playwright CDP case ---');
+    // The e2b public gateway requires the X-Access-Token header, otherwise the WS upgrade returns 403
+    const headers = {};
+    const token = sbx.envdAccessToken;
+    if (token) {
+      headers['X-Access-Token'] = token;
+    }
+    await verifyWithPlaywright(cdpWsUrl, headers);
+
+    console.log('\n--- VNC livestream case ---');
+    await verifyVncHandshake(sbx);
+  } finally {
+    if (sbx !== null) {
+      await sbx.kill();
+      console.log('\nSandbox destroyed');
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+## WebSocket endpoints
+
+The browser template provides two WebSocket endpoints for different automation scenarios:
+
+| **Endpoint** | **Path** | **Purpose** |
+| --- | --- | --- |
+| Health check endpoint | `https://<sandbox-host>/health` | Determine whether the browser service has finished starting |
+| CDP automation endpoint | `wss://<sandbox-host>/ws/automation` | Browser automation, compatible with Puppeteer and Playwright |
+| VNC livestream endpoint | `wss://<sandbox-host>/ws/livestream` | View the browser desktop in real time, viewable through a noVNC client |
+
+> **Note**: `<sandbox-host>` is obtained through the SDK's `sbx.get_host(3000)`. All endpoints require the `X-Access-Token` header for authentication.
+
+Inside the sandbox you can first probe whether the CDP WebSocket handshake works. A `101 Switching Protocols` response means the CDP endpoint can be upgraded to a WebSocket connection:
+
+```bash
+curl -sS -m 4 -i \
+  -H 'Connection: Upgrade' \
+  -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' \
+  -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+  http://localhost:3000/ws/automation
+```
+
+You can use the `wscat` tool to interact with the CDP endpoint directly and send raw CDP commands for debugging:
+
+```bash
+# Install wscat
+npm install -g wscat
+
+# Connect to the CDP proxy (host is obtained through sbx.get_host(3000))
+wscat -c "wss://<sandbox-host>/ws/automation" -H "X-Access-Token:<access-token>"
+
+# Send a CDP command
+{"id":1,"method":"Runtime.evaluate","params":{"expression":"navigator.userAgent"}}
+```
+
+## Real-time VNC viewing
+
+The browser template supports viewing the remote browser desktop in real time through VNC, which makes it easy to monitor automation tasks during development and debugging.
+
+### Use the online noVNC client
+
+1. Open the online client provided by noVNC: [https://novnc.com/noVNC/vnc.html](https://novnc.com/noVNC/vnc.html)
+2. In the connection settings, under **Advanced** > **WebSocket**, fill in the following:
+   - **Host**: the host address obtained through `sbx.get_host(3000)`
+   - **Port**: `443`
+   - **Path**: `ws/livestream`
+3. Click **Connect** to see the browser interface.
+
+> **Note**: The noVNC connection also requires authentication through `X-Access-Token`.
+
+> **Note**
+>
+> After connecting, the initial screen may be black or gray. This is normal because the browser is waiting for instructions. Once your automation script runs `page.goto()` or similar operations, the interface will display the corresponding content.
+
+## Framework integration
+
+The following examples focus on how to integrate frameworks. Before running them, follow the quickstart to create a browser sandbox and obtain the `cdp_url` and `X-Access-Token`.
+
+### BrowserUse integration
+
+BrowserUse is a browser automation framework designed specifically for AI Agents, and can run in the cloud through the browser template:
+
+```python
+import asyncio
+from e2b import Sandbox
+from browser_use import Agent, BrowserSession
+from browser_use.llm import ChatDeepSeek
+from browser_use.browser import BrowserProfile
+
+BROWSER_SANDBOX_PORT = 3000
+
+async def main():
+    sbx = Sandbox.create(template="my-browser-template", api_key=E2B_API_KEY, timeout=600)
+    host = sbx.get_host(BROWSER_SANDBOX_PORT)
+    cdp_url = f"wss://{host}/ws/automation"
+
+    browser_session = BrowserSession(
+        cdp_url=cdp_url,
+        browser_profile=BrowserProfile(
+            headless=False,
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            timeout=3000000,
+            keep_alive=True,
+        ),
+        extra_headers={"X-Access-Token": sbx._envd_access_token},
+    )
+
+    llm = ChatDeepSeek(api_key="sk-your-deepseek-sk")
+
+    agent = Agent(
+        task="Visit https://www.aliyun.com/product/list and analyze the product categories Alibaba Cloud offers",
+        llm=llm,
+        browser_session=browser_session,
+        use_vision=True
+    )
+    result = await agent.run()
+    print(result)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### LangChain integration
+
+Using the E2B SDK, you can easily integrate the browser template into a LangChain Agent:
+
+```python
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+from langchain_openai import ChatOpenAI
+from e2b import Sandbox
+from playwright.async_api import async_playwright
+
+BROWSER_SANDBOX_PORT = 3000
+
+# Create the sandbox and obtain the CDP endpoint
+sbx = Sandbox.create(template="my-browser-template", api_key=E2B_API_KEY, timeout=600)
+host = sbx.get_host(BROWSER_SANDBOX_PORT)
+cdp_url = f"wss://{host}/ws/automation"
+headers = {"X-Access-Token": sbx._envd_access_token}
+
+@tool
+def navigate_and_extract(url: str) -> str:
+    """Navigate to the given URL and extract the page's text content"""
+    import asyncio
+    async def _run():
+        async with async_playwright() as p:
+            browser = await p.chromium.connect_over_cdp(cdp_url, headers=headers)
+            page = browser.contexts[0].pages[0] if browser.contexts[0].pages else await browser.contexts[0].new_page()
+            await page.goto(url, wait_until="networkidle")
+            content = await page.content()
+            return content[:5000]
+    return asyncio.run(_run())
+
+llm = ChatOpenAI(model="qwen-max", api_key="sk-your-key", base_url="https://dashscope.aliyuncs.com/compatible-mode/v1")
+
+agent = create_react_agent(
+    model=llm,
+    tools=[navigate_and_extract],
+)
+
+async def run_agent():
+    result = await agent.ainvoke({
+        "messages": [
+            HumanMessage(content="Visit Sina Finance and look up today's stock price of Tencent Holdings")
+        ]
+    })
+    print(result)
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(run_agent())
+```
+
+## Limitations
+
+| **Item** | **Constraint** |
+| --- | --- |
+| Session lifetime | A single sandbox session lasts at most 6 hours by default, after which it is automatically destroyed |
+| Idle timeout | Configurable through the `sandboxIdleTimeoutSeconds` parameter; the sandbox terminates early after being idle for the specified time |
+| Browser support | Currently ships with Chromium/Chrome |
+| Code interpreter | The browser template includes E2B envd-compatible base capabilities but does not provide the Code Interpreter service; you cannot execute Python directly through a Code Interpreter context |
+
+## Related documents
+
+- [Built-in Templates](../02.Built-in%20Templates.md)
+- [Build Custom Image Templates](../03.Build%20Custom%20Image%20Templates.md)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Code Interpreter v1 Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Code Interpreter v1 Template.md
@@ -1,0 +1,267 @@
+# code-interpreter-v1 Template
+
+The code-interpreter-v1 template provides a securely isolated code execution sandbox. It lets you safely execute code in languages such as Python and JavaScript in the cloud, and offers a complete data-plane API for file management, terminal command execution, context management, and more.
+
+The code-interpreter-v1 template aligns with E2B Code Interpreter's code context, code execution, file access, and command capabilities.
+
+## Features
+
+| **Feature** | **Description** |
+| --- | --- |
+| Multi-language code execution | Securely executes Python, JavaScript, and other code, with context preserved through a Jupyter kernel |
+| File system operations | Full file CRUD: upload, download, read, write, create directories, move, delete; supports text and binary files |
+| Terminal command execution | Supports synchronous command execution and an interactive WebSocket terminal (TTY) with color, cursor control, and terminal resizing |
+| Context management | Independent code execution environments; supports creating multiple contexts (kernels), each keeping its own variable state |
+| Process management | List, query, and stop processes running inside the sandbox |
+| Secure isolation | Dedicated isolation based on function instances; each sandbox instance has its own file system and process space |
+
+## Use cases
+
+| **Scenario** | **Description** |
+| --- | --- |
+| AI Agent code sandbox | Provides a safe code execution environment for AI Agents, preventing untrusted code from accessing or tampering with host system resources |
+| Data analysis | Run Python data-analysis scripts in the sandbox, using libraries such as pandas and numpy to process data |
+| File processing | Upload files to the sandbox, perform format conversion or data cleaning, and download the results |
+| Script execution and automation | Run shell commands, install dependencies, and run automation scripts |
+
+## Default configuration
+
+The default configuration of the code-interpreter-v1 template is as follows:
+
+| **Item** | **Default** | **Description** |
+| --- | --- | --- |
+| Container image | `sandbox-code-interpreter:v0.9.30` | Prebuilt code interpreter sandbox image |
+| Default port | 5000 | Port the sandbox service listens on |
+| CPU | 2 vCPU | Minimum requirement |
+| Memory | 2048 MB | Minimum requirement |
+| Disk size | 512 MB | 512 MB or 10240 MB available |
+
+## Architecture
+
+The Code Interpreter API is split into a control plane and a data plane:
+
+| **Plane** | **Description** |
+| --- | --- |
+| Control-plane OpenAPI | Handles creation and lifecycle management of sandbox template and sandbox instance resources |
+| Data-plane OpenAPI | Handles concrete calls such as code execution, file operations, terminal commands, and process management |
+
+Data-plane base URL format: `https://{alibaba-cloud-primary-account-id}.e2b-data.cn-hangzhou.aliyuncs.com/`
+
+## SDK usage
+
+Whether you need to explicitly specify a `template` for the code-interpreter-v1 template depends on the SDK:
+
+| **SDK** | **template parameter** | **Description** |
+| --- | --- | --- |
+| `e2b_code_interpreter` SDK | Not required | The dedicated SDK creates a `code-interpreter-v1` sandbox by default |
+| `e2b` SDK | Must specify `code-interpreter-v1` | The general SDK creates a base sandbox by default, so you must explicitly select the code-interpreter-v1 template |
+
+**Using the `e2b_code_interpreter` SDK:**
+
+```python
+import os
+from e2b_code_interpreter import Sandbox
+
+sbx = Sandbox.create(api_key=os.environ["E2B_API_KEY"])
+execution = sbx.run_code("print('hello from code interpreter')")
+print(execution.logs.stdout)
+sbx.kill()
+```
+
+**Using the `e2b` SDK:**
+
+```python
+import os
+from e2b import Sandbox
+
+sbx = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+)
+result = sbx.commands.run("python --version")
+print(result.stdout)
+sbx.kill()
+```
+
+## Workflow
+
+1. **Create a code-interpreter-v1 sandbox template**: create the template through the console or the OpenAPI.
+2. **Start a sandbox instance**: create a sandbox instance from the template and obtain the sandbox ID.
+3. **Create an execution context**: create a code execution context inside the sandbox (specify the language).
+4. **Execute code**: run Python or JavaScript code through the context.
+
+## Core API overview
+
+### Sandbox instance management
+
+| **Operation** | **Method** | **Path** |
+| --- | --- | --- |
+| Create sandbox instance | POST | `/sandboxes` |
+| Stop sandbox instance | POST | `/sandboxes/{sandboxId}/stop` |
+| Delete sandbox instance | DELETE | `/sandboxes/{sandboxId}` |
+| Health check | GET | `/sandboxes/{sandboxId}/health` |
+
+Example request to create a sandbox instance:
+
+```json
+POST ${BASEURL}/sandboxes
+
+{
+  "templateName": "my-code-interpreter",
+  "sandboxId": "optional-custom-id"
+}
+```
+
+Example response:
+
+```json
+{
+  "sandboxId": "01JCED8Z9Y6XQVK8M2NRST5WXY",
+  "templateId": "01JCED8Z9Y6XQVK8M2NRST5ABC",
+  "templateName": "my-code-interpreter",
+  "templateType": "CodeInterpreter",
+  "status": "READY",
+  "sandboxIdleTimeoutInSeconds": 3600,
+  "createdAt": "2024-12-02T10:30:00Z"
+}
+```
+
+### Context management
+
+| **Operation** | **Method** | **Path** |
+| --- | --- | --- |
+| List all contexts | GET | `/sandboxes/{sandboxId}/contexts` |
+| Create a new context | POST | `/sandboxes/{sandboxId}/contexts` |
+| Get context details | GET | `/sandboxes/{sandboxId}/contexts/{contextId}` |
+| Delete a context | DELETE | `/sandboxes/{sandboxId}/contexts/{contextId}` |
+
+Example request to create a context:
+
+```json
+POST ${BASEURL}/sandboxes/{sandboxId}/contexts
+
+{
+  "language": "python",
+  "cwd": "/home/user"
+}
+```
+
+### Code execution
+
+Execute code synchronously through a context:
+
+```json
+POST ${BASEURL}/sandboxes/{sandboxId}/contexts/execute
+
+{
+  "contextId": "kernel-12345-67890",
+  "code": "print('hello from sandbox')",
+  "timeout": 30
+}
+```
+
+Example response:
+
+```json
+{
+  "results": [
+    { "type": "stdout", "text": "hello from sandbox" },
+    { "type": "result", "text": "None" },
+    { "type": "endOfExecution", "status": "ok" }
+  ],
+  "contextId": "kernel-12345-67890"
+}
+```
+
+### File system operations
+
+| **Operation** | **Method** | **Path** |
+| --- | --- | --- |
+| Read a file | GET | `/sandboxes/{sandboxId}/files?path={path}` |
+| Write a file | POST | `/sandboxes/{sandboxId}/files` |
+| List a directory | GET | `/sandboxes/{sandboxId}/filesystem?path={path}` |
+| Get file info | GET | `/sandboxes/{sandboxId}/filesystem/stat?path={path}` |
+| Download a file | GET | `/sandboxes/{sandboxId}/filesystem/download?path={path}` |
+| Upload a file | POST | `/sandboxes/{sandboxId}/filesystem/upload` (multipart/form-data, max 100 MB) |
+| Create a directory | POST | `/sandboxes/{sandboxId}/filesystem/mkdir` |
+| Move/rename | POST | `/sandboxes/{sandboxId}/filesystem/move` |
+| Delete file/directory | POST | `/sandboxes/{sandboxId}/filesystem/remove` |
+
+Text files return the `content` field as UTF-8; binary files are returned base64-encoded. File uploads use `multipart/form-data` and support up to 100 MB.
+
+### Terminal and process management
+
+| **Operation** | **Method** | **Path** |
+| --- | --- | --- |
+| Execute command synchronously | POST | `/sandboxes/{sandboxId}/processes/cmd` (30-second timeout) |
+| Interactive terminal | GET | `/sandboxes/{sandboxId}/processes/tty?protocol=json` (WebSocket) |
+| List all processes | GET | `/sandboxes/{sandboxId}/processes` |
+| Get process details | GET | `/sandboxes/{sandboxId}/processes/{pid}` |
+| Stop a process | DELETE | `/sandboxes/{sandboxId}/processes/{pid}` |
+
+Example of synchronous command execution:
+
+```json
+POST ${BASEURL}/sandboxes/{sandboxId}/processes/cmd
+
+{
+  "command": "ls -la /home/user",
+  "cwd": "/home/user"
+}
+```
+
+Example response:
+
+```json
+{
+  "executionId": "tty_exec_001",
+  "status": "completed",
+  "result": {
+    "exitCode": 0,
+    "stdout": "total 24\ndrwxr-xr-x 3 user user 4096 Jan 15 10:30 .",
+    "stderr": "",
+    "cwd": "/home/user",
+    "executionTimeMs": 150
+  },
+  "executionTimeMs": 150
+}
+```
+
+The interactive terminal supports two protocol modes: `json` (structured messages) and `text` (xterm.js compatible). The client must send a heartbeat every 30 seconds; the connection closes after 2 minutes without a heartbeat.
+
+## Sandbox instance states
+
+A sandbox instance goes through the following states during its lifecycle:
+
+| **State** | **Description** |
+| --- | --- |
+| `CREATING` | Being created |
+| `READY` | Ready to use |
+| `TERMINATED` | Stopped |
+
+## Limitations
+
+| **Item** | **Constraint** |
+| --- | --- |
+| Sandbox lifetime | A single sandbox instance lasts at most 6 hours |
+| Idle timeout | Configurable through the `sandboxIdleTimeoutSeconds` parameter |
+| File upload size | Up to 100 MB per upload |
+| Code execution timeout | Up to 30 seconds per synchronous execution |
+| Hidden files | Creating hidden files that start with `.` is not allowed |
+
+## Best practices
+
+**Clean up resources promptly**: after a task finishes, delete files, contexts, and sandbox instances you no longer need, and monitor storage usage.
+
+**Configure timeouts sensibly**: use shorter timeouts for short-lived tasks (5–10 minutes) and extend them for long-running tasks (30 minutes–6 hours).
+
+**Error handling**: use exponential backoff to retry 5xx server errors, and wait before retrying 429 rate-limit errors.
+
+## Related documents
+
+- [Built-in Templates](../02.Built-in%20Templates.md)
+- [Build Custom Image Templates](../03.Build%20Custom%20Image%20Templates.md)
+- [Lifecycle](../../01.Sandbox/01.Lifecycle.md)
+- [Base Template](Base%20Template.md) (choose when you only need the envd base capabilities)
+- [Browser Template](Browser%20Template.md) (choose when you only need browser automation)
+- [All-in-One Template](All-in-One%20Template.md) (choose when you need both browser and code execution)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -6,6 +6,10 @@ Built-in templates provide a baseline runtime environment. When you need to prei
 
 If you use your own image to create a template, prepare an ACR EE instance under the same UID and in the same region as FC Agent Sandbox. ACR EE Economy Edition is not supported. Attach a VPC to the ACR EE instance so FC Agent Sandbox can pull the image over VPC.
 
+### Image requirements
+
+Use a Linux system based on the AMD64 architecture. Recommended base images: Ubuntu 20.04, Debian 12 (bookworm) or later.
+
 Push the image to that ACR EE repository and use the VPC-accessible internal image address, for example:
 
 ```text

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/browser-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/browser-模板.md
@@ -46,142 +46,360 @@ browser 模板的默认配置如下：
 
 您也可以通过 OpenAPI 或 SDK 进行创建。
 
+browser 模板的完整用法分为两个阶段：先**构建模板**（从 browser 镜像固化出一个带名称的模板），再**运行模板**（创建沙箱、等待健康检查、通过 CDP 自动化并截图、校验 VNC）。下面分别给出 Python 与 Node.js 两种实现。
+
+> **说明**：示例中的 `API_KEY` 需替换为您在控制台生成的 API Key，`API_URL` / `DOMAIN` 需替换为对应地域的接入地址。连接 CDP/VNC 端点时需在请求头中携带 `X-Access-Token` 进行身份验证：Python SDK 可通过内部属性 `sbx._envd_access_token` 获取（后续版本可能重命名或移除），JS SDK 可使用公开字段 `sbx.envdAccessToken`。
+
 ### 第二步：准备本地环境
 
-如果您使用 Python SDK 和 Playwright 验证 CDP 连接，可以按以下方式准备本地环境：
+**Python**：
 
 ```bash
 uv venv .venv --python 3.12
 source .venv/bin/activate
-uv pip install 'e2b<2.25.0' 'playwright>=1.49.0' 'python-dotenv>=1.0.0'
+uv pip install e2b e2b-code-interpreter 'playwright>=1.49.0'
+playwright install chromium
 ```
 
-创建 `.env` 文件并配置以下变量：
+**Node.js**：使用如下 `package.json`，然后执行 `npm install`。
 
-```bash
-E2B_API_KEY=e2b_xxx
-E2B_API_URL=https://api.<region>.e2b.fc.aliyuncs.com
-E2B_DOMAIN=<region>.e2b.fc.aliyuncs.com
+```json
+{
+  "name": "browser-template-demo",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@e2b/code-interpreter": "^2.6.1",
+    "e2b": "^2.31.0",
+    "playwright-core": "^1.49.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.0",
+    "tsx": "^4.23.0",
+    "typescript": "^6.0.3"
+  }
+}
 ```
 
-> **说明**：如果同名环境变量已经存在，建议以 `.env` 中的区域配置为准，避免 SDK 连接到错误区域。
+### 第三步：构建 browser 模板
 
-### 第三步：创建沙箱并获取连接端点
+从 browser 镜像构建一个带名称的模板，构建时指定 CPU 与内存规格（推荐 4 vCPU / 8192 MB）。
 
-创建沙箱实例后，通过 SDK 的 `get_host(port)` 方法获取 WebSocket 连接端点。
-
-如果已经通过控制台或 OpenAPI 创建好 browser 模板，可以直接把示例中的 `template` 替换为已有模板名称。如果需要通过 SDK 临时构建模板，可以使用 `Template().from_image()` 从 browser 镜像构建：
+**Python**：
 
 ```python
-import os
+"""browser 模板构建示例。"""
+
+from e2b import Template, default_build_logger
+
+API_KEY = "e2b_xxx"  # 替换为您的 API Key
+API_URL = "https://api.cn-beijing.e2b.fc.aliyuncs.com"
+DOMAIN = "cn-beijing.e2b.fc.aliyuncs.com"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33"
+OPTS = {"api_key": API_KEY, "api_url": API_URL, "domain": DOMAIN}
+
+TEMPLATE_NAME = "my-browser-template"
+
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name=TEMPLATE_NAME,
+    cpu_count=4,
+    memory_mb=8192,
+    skip_cache=False,
+    on_build_logs=default_build_logger(),
+    **OPTS,
+)
+
+print(f"template_id: {build.template_id}")
+print(f"build_id: {build.build_id}")
+```
+
+**Node.js**：
+
+```javascript
+// browser 模板构建示例。
+import { Template, defaultBuildLogger } from 'e2b';
+
+const API_KEY = 'e2b_xxx'; // 替换为您的 API Key
+const API_URL = 'https://api.cn-beijing.e2b.fc.aliyuncs.com';
+const DOMAIN = 'cn-beijing.e2b.fc.aliyuncs.com';
+const FROM_IMAGE =
+  'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33';
+const OPTS = { apiKey: API_KEY, apiUrl: API_URL, domain: DOMAIN };
+
+const TPL_NAME = 'my-browser-template';
+
+async function main() {
+  const build = await Template.build(Template().fromImage(FROM_IMAGE), TPL_NAME, {
+    ...OPTS,
+    cpuCount: 4,
+    memoryMB: 8192,
+    skipCache: false,
+    onBuildLogs: defaultBuildLogger(),
+  });
+
+  console.log(`template_id: ${build.templateId}`);
+  console.log(`build_id: ${build.buildId}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+### 第四步：运行模板并执行自动化脚本
+
+创建沙箱后，先轮询 `/health` 等待 browser 服务就绪，再通过 CDP 端点连接 Playwright 打开目标页并截图，最后校验 VNC（livestream）端点握手。
+
+**Python**：
+
+```python
+"""browser 模板运行示例：创建沙箱 -> 等待健康检查 -> CDP 自动化 -> 截图 -> VNC 校验。"""
+
 import time
-from pathlib import Path
 
-from dotenv import load_dotenv
-from e2b import Sandbox, Template
+from e2b_code_interpreter import Sandbox
 
-load_dotenv(Path(__file__).resolve().parent / ".env", override=True)
+API_KEY = "e2b_xxx"  # 替换为您的 API Key
+API_URL = "https://api.cn-beijing.e2b.fc.aliyuncs.com"
+DOMAIN = "cn-beijing.e2b.fc.aliyuncs.com"
+OPTS = {"api_key": API_KEY, "api_url": API_URL, "domain": DOMAIN}
 
-IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.32"
-TEMPLATE_NAME = f"browser-sandbox-{int(time.time())}"
-BROWSER_SANDBOX_PORT = 3000
+TEMPLATE_NAME = "my-browser-template"
+
+BROWSERTOOL_PORT = 3000
+TARGET_URL = "https://example.com"
+SCREENSHOT_PATH = "browser-example.png"
 
 
-registry_template = Template().from_image(image=IMAGE)
-build_info = Template.build(
-    registry_template,
-    TEMPLATE_NAME,
-    api_key=os.environ["E2B_API_KEY"],
-    cpu_count=2,
-    memory_mb=2048,
-)
+def wait_until_healthy(sbx: Sandbox, timeout: int = 60) -> None:
+    """轮询沙箱内 /health 端点，直到 browser 服务就绪或超时。"""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = sbx.commands.run(
+            f"curl -sS -o /dev/null -w '%{{http_code}}' -m 4 "
+            f"http://localhost:{BROWSERTOOL_PORT}/health",
+            timeout=10,
+        )
+        code = "".join(result.stdout or []).strip()
+        if code == "200":
+            print(f"  ✓ /health 就绪 (HTTP {code})")
+            return
+        print(f"  ...等待 browser 服务就绪 (HTTP {code!r})")
+        time.sleep(2)
+    raise TimeoutError(f"browser 服务在 {timeout}s 内未就绪")
 
-sbx = Sandbox.create(
-    template=build_info.name,
-    api_key=os.environ["E2B_API_KEY"],
-    timeout=600,
-    allow_internet_access=True,
-)
 
-host = sbx.get_host(BROWSER_SANDBOX_PORT)
+def verify_vnc_handshake(sbx: Sandbox) -> None:
+    """在沙箱内探测 /ws/livestream 的 WebSocket 握手，返回 101 即视为 VNC 就绪。"""
+    # 升级成功后连接会保持为 WebSocket，curl 会一直读到 -m 超时（退出码 28），
+    # 这属于预期行为，用 `|| true` 吞掉退出码，只解析已收到的响应头。
+    cmd = (
+        "curl -sS -i -m 4 "
+        "-H 'Connection: Upgrade' "
+        "-H 'Upgrade: websocket' "
+        "-H 'Sec-WebSocket-Version: 13' "
+        "-H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' "
+        "http://localhost:{port}/ws/livestream || true"
+    ).format(port=BROWSERTOOL_PORT)
+    result = sbx.commands.run(cmd, timeout=15)
+    out = "".join(result.stdout or [])
+    status_line = out.splitlines()[0].strip() if out.strip() else "<无响应>"
+    print(f"  /ws/livestream 响应: {status_line!r}")
+    assert "101" in out and "Switching Protocols" in out, (
+        f"VNC 端点未能升级为 WebSocket: {out[:200]!r}"
+    )
+    print("  ✓ VNC (livestream) 端点握手通过")
 
-# CDP 自动化端点
-cdp_ws_url = f"wss://{host}/ws/automation"
 
-# VNC 实时流端点
-vnc_ws_url = f"wss://{host}/ws/livestream"
+def verify_with_playwright(cdp_ws_url: str, headers: dict) -> None:
+    """通过 CDP 连接 browsertool，打开目标页并校验 title，同时截图。"""
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp(cdp_ws_url, headers=headers)
+        # 复用 browsertool 已 launch 的默认 context
+        context = browser.contexts[0] if browser.contexts else browser.new_context()
+        page = context.new_page()
+        try:
+            page.goto(TARGET_URL, wait_until="domcontentloaded", timeout=30000)
+            title = page.title()
+            print(f"  page.title() = {title!r}")
+            assert "Example" in title, f"unexpected title: {title!r}"
+
+            page.screenshot(path=SCREENSHOT_PATH, full_page=True)
+            print(f"  ✓ 截图已保存: {SCREENSHOT_PATH}")
+            print("  ✓ Playwright over CDP 验证通过")
+        finally:
+            page.close()
+            browser.close()
+
+
+sbx = None
+try:
+    sbx = Sandbox.create(template=TEMPLATE_NAME, timeout=900, **OPTS)
+    print(f"sandbox_id: {sbx.sandbox_id}")
+
+    host = sbx.get_host(BROWSERTOOL_PORT)
+    cdp_ws_url = f"wss://{host}/ws/automation"
+    vnc_ws_url = f"wss://{host}/ws/livestream"
+    print("\n--- WebSocket 端点 ---")
+    print(f"  host: {host}")
+    print(f"  CDP : {cdp_ws_url}")
+    print(f"  VNC : {vnc_ws_url}")
+
+    print("\n--- 等待健康检查 ---")
+    wait_until_healthy(sbx)
+
+    print("\n--- Playwright CDP 用例 ---")
+    # e2b 公网网关要求 X-Access-Token 头，否则 WS 升级 403
+    headers = {}
+    token = sbx._envd_access_token
+    if token:
+        headers["X-Access-Token"] = token
+    verify_with_playwright(cdp_ws_url, headers)
+
+    print("\n--- VNC livestream 用例 ---")
+    verify_vnc_handshake(sbx)
+finally:
+    if sbx is not None:
+        sbx.kill()
+        print("\n沙箱已销毁")
 ```
 
-> **说明**：连接 CDP/VNC 端点时需要在请求头中携带 `X-Access-Token` 进行身份验证。使用 SDK 时可通过 `sbx._envd_access_token` 获取该 Token。注意 `_envd_access_token` 属于 SDK 内部属性，后续版本可能重命名或移除；JS SDK 可使用公开字段 `sbx.envdAccessToken`。
-
-### 第四步：连接并执行自动化脚本
-
-将上一步获取的 CDP 端点传入自动化框架脚本中，即可连接到 browser 沙箱并执行任务。
-
-**Python Playwright 连接示例**：
-
-```python
-from playwright.sync_api import sync_playwright
-
-headers = {"X-Access-Token": sbx._envd_access_token}
-
-with sync_playwright() as playwright:
-    browser = playwright.chromium.connect_over_cdp(cdp_ws_url, headers=headers)
-    context = browser.contexts[0] if browser.contexts else browser.new_context()
-    page = context.new_page()
-    page.goto("https://example.com", wait_until="domcontentloaded", timeout=30000)
-    print(page.title())
-    page.close()
-    browser.close()
-
-sbx.kill()
-```
-
-**Puppeteer 连接示例**：
+**Node.js**：
 
 ```javascript
-const puppeteer = require('puppeteer-core');
+// browser 模板运行示例：创建沙箱 -> 等待健康检查 -> CDP 自动化 -> 截图 -> VNC 校验。
+import { Sandbox } from '@e2b/code-interpreter';
+import { chromium } from 'playwright-core';
 
-const cdpEndpoint = 'wss://<sandbox-host>/ws/automation';
-const accessToken = '<access-token>';
+const API_KEY = 'e2b_xxx'; // 替换为您的 API Key
+const API_URL = 'https://api.cn-beijing.e2b.fc.aliyuncs.com';
+const DOMAIN = 'cn-beijing.e2b.fc.aliyuncs.com';
+const OPTS = { apiKey: API_KEY, apiUrl: API_URL, domain: DOMAIN };
 
-async function main() {
-  const browser = await puppeteer.connect({
-    browserWSEndpoint: cdpEndpoint,
-    headers: { 'X-Access-Token': accessToken },
-  });
+const TPL_NAME = 'my-browser-template';
 
-  const page = await browser.newPage();
-  await page.goto('https://example.com');
-  await page.screenshot({ path: 'example.png' });
-  console.log('Screenshot taken!');
-  await browser.close();
+const BROWSERTOOL_PORT = 3000;
+const TARGET_URL = 'https://example.com';
+const SCREENSHOT_PATH = 'browser-example.png';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** 轮询沙箱内 /health 端点，直到 browser 服务就绪或超时。 */
+async function waitUntilHealthy(sbx, timeout = 60) {
+  const deadline = Date.now() + timeout * 1000;
+  while (Date.now() < deadline) {
+    // 服务未起时 curl 会以非 0 退出（连接失败），e2b 会抛 CommandExitError，
+    // 该异常同样携带 stdout，捕获后按未就绪处理继续轮询。
+    let result;
+    try {
+      result = await sbx.commands.run(
+        `curl -sS -o /dev/null -w '%{http_code}' -m 4 ` +
+          `http://localhost:${BROWSERTOOL_PORT}/health`,
+        { timeoutMs: 10_000 },
+      );
+    } catch (e) {
+      result = e;
+    }
+    const code = (result.stdout || '').trim();
+    if (code === '200') {
+      console.log(`  ✓ /health 就绪 (HTTP ${code})`);
+      return;
+    }
+    console.log(`  ...等待 browser 服务就绪 (HTTP ${JSON.stringify(code)})`);
+    await sleep(2000);
+  }
+  throw new Error(`browser 服务在 ${timeout}s 内未就绪`);
 }
 
-main();
-```
-
-**Playwright 连接示例**：
-
-```javascript
-const { chromium } = require('playwright-core');
-
-const cdpEndpoint = 'wss://<sandbox-host>/ws/automation';
-const accessToken = '<access-token>';
-
-async function main() {
-  const browser = await chromium.connectOverCDP(cdpEndpoint, {
-    headers: { 'X-Access-Token': accessToken },
-  });
-
-  const page = await browser.newPage();
-  await page.goto('https://example.com');
-  await page.screenshot({ path: 'example.png' });
-  console.log('Screenshot taken!');
-  await browser.close();
+/** 在沙箱内探测 /ws/livestream 的 WebSocket 握手，返回 101 即视为 VNC 就绪。 */
+async function verifyVncHandshake(sbx) {
+  // 升级成功后连接会保持为 WebSocket，curl 会一直读到 -m 超时（退出码 28），
+  // 这属于预期行为，用 `|| true` 吞掉退出码，只解析已收到的响应头。
+  const cmd =
+    `curl -sS -i -m 4 ` +
+    `-H 'Connection: Upgrade' ` +
+    `-H 'Upgrade: websocket' ` +
+    `-H 'Sec-WebSocket-Version: 13' ` +
+    `-H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' ` +
+    `http://localhost:${BROWSERTOOL_PORT}/ws/livestream || true`;
+  const result = await sbx.commands.run(cmd, { timeoutMs: 15_000 });
+  const out = result.stdout || '';
+  const statusLine = out.trim() ? out.split('\n')[0].trim() : '<无响应>';
+  console.log(`  /ws/livestream 响应: ${JSON.stringify(statusLine)}`);
+  if (!(out.includes('101') && out.includes('Switching Protocols'))) {
+    throw new Error(`VNC 端点未能升级为 WebSocket: ${JSON.stringify(out.slice(0, 200))}`);
+  }
+  console.log('  ✓ VNC (livestream) 端点握手通过');
 }
 
-main();
+/** 通过 CDP 连接 browsertool，打开目标页并校验 title，同时截图。 */
+async function verifyWithPlaywright(cdpWsUrl, headers) {
+  const browser = await chromium.connectOverCDP(cdpWsUrl, { headers });
+  // 复用 browsertool 已 launch 的默认 context
+  const contexts = browser.contexts();
+  const context = contexts.length ? contexts[0] : await browser.newContext();
+  const page = await context.newPage();
+  try {
+    await page.goto(TARGET_URL, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+    const title = await page.title();
+    console.log(`  page.title() = ${JSON.stringify(title)}`);
+    if (!title.includes('Example')) {
+      throw new Error(`unexpected title: ${JSON.stringify(title)}`);
+    }
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+    console.log(`  ✓ 截图已保存: ${SCREENSHOT_PATH}`);
+    console.log('  ✓ Playwright over CDP 验证通过');
+  } finally {
+    await page.close();
+    await browser.close();
+  }
+}
+
+async function main() {
+  let sbx = null;
+  try {
+    sbx = await Sandbox.create(TPL_NAME, { ...OPTS, timeoutMs: 900_000 });
+    console.log(`sandbox_id: ${sbx.sandboxId}`);
+
+    const host = sbx.getHost(BROWSERTOOL_PORT);
+    const cdpWsUrl = `wss://${host}/ws/automation`;
+    const vncWsUrl = `wss://${host}/ws/livestream`;
+    console.log('\n--- WebSocket 端点 ---');
+    console.log(`  host: ${host}`);
+    console.log(`  CDP : ${cdpWsUrl}`);
+    console.log(`  VNC : ${vncWsUrl}`);
+
+    console.log('\n--- 等待健康检查 ---');
+    await waitUntilHealthy(sbx);
+
+    console.log('\n--- Playwright CDP 用例 ---');
+    // e2b 公网网关要求 X-Access-Token 头，否则 WS 升级 403
+    const headers = {};
+    const token = sbx.envdAccessToken;
+    if (token) {
+      headers['X-Access-Token'] = token;
+    }
+    await verifyWithPlaywright(cdpWsUrl, headers);
+
+    console.log('\n--- VNC livestream 用例 ---');
+    await verifyVncHandshake(sbx);
+  } finally {
+    if (sbx !== null) {
+      await sbx.kill();
+      console.log('\n沙箱已销毁');
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
 ```
 
 ## WebSocket 端点说明
@@ -257,7 +475,7 @@ from browser_use.browser import BrowserProfile
 BROWSER_SANDBOX_PORT = 3000
 
 async def main():
-    sbx = Sandbox.create(template="browser-sandbox-template", api_key=E2B_API_KEY, timeout=600)
+    sbx = Sandbox.create(template="my-browser-template", api_key=E2B_API_KEY, timeout=600)
     host = sbx.get_host(BROWSER_SANDBOX_PORT)
     cdp_url = f"wss://{host}/ws/automation"
 
@@ -302,7 +520,7 @@ from playwright.async_api import async_playwright
 BROWSER_SANDBOX_PORT = 3000
 
 # 创建沙箱并获取 CDP 端点
-sbx = Sandbox.create(template="browser-sandbox-template", api_key=E2B_API_KEY, timeout=600)
+sbx = Sandbox.create(template="my-browser-template", api_key=E2B_API_KEY, timeout=600)
 host = sbx.get_host(BROWSER_SANDBOX_PORT)
 cdp_url = f"wss://{host}/ws/automation"
 headers = {"X-Access-Token": sbx._envd_access_token}

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/browser-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/browser-模板.md
@@ -30,7 +30,7 @@ browser 模板的默认配置如下：
 
 | **配置项** | **默认值** | **说明** |
 | --- | --- | --- |
-| 容器镜像 | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33` | 预置 browser 镜像 |
+| 容器镜像 | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.36` | 预置 browser 镜像 |
 | 默认端口 | 3000 | 沙箱服务监听端口 |
 | CPU | 4 vCPU | 最低要求 |
 | 内存 | 8192 MB | 最低要求 |
@@ -95,7 +95,7 @@ from e2b import Template, default_build_logger
 API_KEY = "e2b_xxx"  # 替换为您的 API Key
 API_URL = "https://api.cn-beijing.e2b.fc.aliyuncs.com"
 DOMAIN = "cn-beijing.e2b.fc.aliyuncs.com"
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.36"
 OPTS = {"api_key": API_KEY, "api_url": API_URL, "domain": DOMAIN}
 
 TEMPLATE_NAME = "my-browser-template"
@@ -124,7 +124,7 @@ const API_KEY = 'e2b_xxx'; // 替换为您的 API Key
 const API_URL = 'https://api.cn-beijing.e2b.fc.aliyuncs.com';
 const DOMAIN = 'cn-beijing.e2b.fc.aliyuncs.com';
 const FROM_IMAGE =
-  'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33';
+  'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.36';
 const OPTS = { apiKey: API_KEY, apiUrl: API_URL, domain: DOMAIN };
 
 const TPL_NAME = 'my-browser-template';

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/browser-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/browser-模板.md
@@ -30,10 +30,10 @@ browser 模板的默认配置如下：
 
 | **配置项** | **默认值** | **说明** |
 | --- | --- | --- |
-| 容器镜像 | `fc-e2b-registry.us-west-1.cr.aliyuncs.com/runtime/browser:v0.0.32` | 预置 browser 镜像 |
+| 容器镜像 | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.33` | 预置 browser 镜像 |
 | 默认端口 | 3000 | 沙箱服务监听端口 |
-| CPU | 2 vCPU | 最低要求 |
-| 内存 | 2048 MB | 最低要求 |
+| CPU | 4 vCPU | 最低要求 |
+| 内存 | 8192 MB | 最低要求 |
 | 磁盘大小 | 10240 MB | 建议 10 GB 以获得充足的临时存储空间，函数计算将默认提供 |
 
 ## 快速入门
@@ -82,7 +82,7 @@ from e2b import Sandbox, Template
 
 load_dotenv(Path(__file__).resolve().parent / ".env", override=True)
 
-IMAGE = "fc-e2b-registry.us-west-1.cr.aliyuncs.com/runtime/browser:v0.0.32"
+IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.32"
 TEMPLATE_NAME = f"browser-sandbox-{int(time.time())}"
 BROWSER_SANDBOX_PORT = 3000
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/browser-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/browser-模板.md
@@ -173,13 +173,16 @@ TARGET_URL = "https://example.com"
 SCREENSHOT_PATH = "browser-example.png"
 
 
-def wait_until_healthy(sbx: Sandbox, timeout: int = 60) -> None:
-    """轮询沙箱内 /health 端点，直到 browser 服务就绪或超时。"""
+def wait_until_healthy(sbx: Sandbox, host: str, token: str, timeout: int = 60) -> None:
+    """轮询公网网关 /health 端点，直到 browser 服务就绪或超时。"""
+    # 走公网网关 host（3000-<sandboxId>.<domain>），需带 X-Access-Token 头。
+    token_header = f"-H 'X-Access-Token: {token}' " if token else ""
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = sbx.commands.run(
             f"curl -sS -o /dev/null -w '%{{http_code}}' -m 4 "
-            f"http://localhost:{BROWSERTOOL_PORT}/health",
+            f"{token_header}"
+            f"https://{host}/health",
             timeout=10,
         )
         code = "".join(result.stdout or []).strip()
@@ -191,18 +194,21 @@ def wait_until_healthy(sbx: Sandbox, timeout: int = 60) -> None:
     raise TimeoutError(f"browser 服务在 {timeout}s 内未就绪")
 
 
-def verify_vnc_handshake(sbx: Sandbox) -> None:
-    """在沙箱内探测 /ws/livestream 的 WebSocket 握手，返回 101 即视为 VNC 就绪。"""
+def verify_vnc_handshake(sbx: Sandbox, host: str, token: str) -> None:
+    """探测公网网关 /ws/livestream 的 WebSocket 握手，返回 101 即视为 VNC 就绪。"""
     # 升级成功后连接会保持为 WebSocket，curl 会一直读到 -m 超时（退出码 28），
     # 这属于预期行为，用 `|| true` 吞掉退出码，只解析已收到的响应头。
+    # 走公网网关 host（3000-<sandboxId>.<domain>），需带 X-Access-Token 头。
+    token_header = f"-H 'X-Access-Token: {token}' " if token else ""
     cmd = (
         "curl -sS -i -m 4 "
         "-H 'Connection: Upgrade' "
         "-H 'Upgrade: websocket' "
         "-H 'Sec-WebSocket-Version: 13' "
         "-H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' "
-        "http://localhost:{port}/ws/livestream || true"
-    ).format(port=BROWSERTOOL_PORT)
+        "{token_header}"
+        "https://{host}/ws/livestream || true"
+    ).format(token_header=token_header, host=host)
     result = sbx.commands.run(cmd, timeout=15)
     out = "".join(result.stdout or [])
     status_line = out.splitlines()[0].strip() if out.strip() else "<无响应>"
@@ -244,24 +250,24 @@ try:
     host = sbx.get_host(BROWSERTOOL_PORT)
     cdp_ws_url = f"wss://{host}/ws/automation"
     vnc_ws_url = f"wss://{host}/ws/livestream"
+    # e2b 公网网关要求 X-Access-Token 头，否则请求/WS 升级 403
+    token = sbx._envd_access_token
     print("\n--- WebSocket 端点 ---")
     print(f"  host: {host}")
     print(f"  CDP : {cdp_ws_url}")
     print(f"  VNC : {vnc_ws_url}")
 
     print("\n--- 等待健康检查 ---")
-    wait_until_healthy(sbx)
+    wait_until_healthy(sbx, host, token)
 
     print("\n--- Playwright CDP 用例 ---")
-    # e2b 公网网关要求 X-Access-Token 头，否则 WS 升级 403
     headers = {}
-    token = sbx._envd_access_token
     if token:
         headers["X-Access-Token"] = token
     verify_with_playwright(cdp_ws_url, headers)
 
     print("\n--- VNC livestream 用例 ---")
-    verify_vnc_handshake(sbx)
+    verify_vnc_handshake(sbx, host, token)
 finally:
     if sbx is not None:
         sbx.kill()
@@ -288,8 +294,10 @@ const SCREENSHOT_PATH = 'browser-example.png';
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-/** 轮询沙箱内 /health 端点，直到 browser 服务就绪或超时。 */
-async function waitUntilHealthy(sbx, timeout = 60) {
+/** 轮询公网网关 /health 端点，直到 browser 服务就绪或超时。 */
+async function waitUntilHealthy(sbx, host, token, timeout = 60) {
+  // 走公网网关 host（3000-<sandboxId>.<domain>），需带 X-Access-Token 头。
+  const tokenHeader = token ? `-H 'X-Access-Token: ${token}' ` : '';
   const deadline = Date.now() + timeout * 1000;
   while (Date.now() < deadline) {
     // 服务未起时 curl 会以非 0 退出（连接失败），e2b 会抛 CommandExitError，
@@ -298,7 +306,8 @@ async function waitUntilHealthy(sbx, timeout = 60) {
     try {
       result = await sbx.commands.run(
         `curl -sS -o /dev/null -w '%{http_code}' -m 4 ` +
-          `http://localhost:${BROWSERTOOL_PORT}/health`,
+          tokenHeader +
+          `https://${host}/health`,
         { timeoutMs: 10_000 },
       );
     } catch (e) {
@@ -315,17 +324,20 @@ async function waitUntilHealthy(sbx, timeout = 60) {
   throw new Error(`browser 服务在 ${timeout}s 内未就绪`);
 }
 
-/** 在沙箱内探测 /ws/livestream 的 WebSocket 握手，返回 101 即视为 VNC 就绪。 */
-async function verifyVncHandshake(sbx) {
+/** 探测公网网关 /ws/livestream 的 WebSocket 握手，返回 101 即视为 VNC 就绪。 */
+async function verifyVncHandshake(sbx, host, token) {
   // 升级成功后连接会保持为 WebSocket，curl 会一直读到 -m 超时（退出码 28），
   // 这属于预期行为，用 `|| true` 吞掉退出码，只解析已收到的响应头。
+  // 走公网网关 host（3000-<sandboxId>.<domain>），需带 X-Access-Token 头。
+  const tokenHeader = token ? `-H 'X-Access-Token: ${token}' ` : '';
   const cmd =
     `curl -sS -i -m 4 ` +
     `-H 'Connection: Upgrade' ` +
     `-H 'Upgrade: websocket' ` +
     `-H 'Sec-WebSocket-Version: 13' ` +
     `-H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' ` +
-    `http://localhost:${BROWSERTOOL_PORT}/ws/livestream || true`;
+    tokenHeader +
+    `https://${host}/ws/livestream || true`;
   const result = await sbx.commands.run(cmd, { timeoutMs: 15_000 });
   const out = result.stdout || '';
   const statusLine = out.trim() ? out.split('\n')[0].trim() : '<无响应>';
@@ -369,25 +381,25 @@ async function main() {
     const host = sbx.getHost(BROWSERTOOL_PORT);
     const cdpWsUrl = `wss://${host}/ws/automation`;
     const vncWsUrl = `wss://${host}/ws/livestream`;
+    // e2b 公网网关要求 X-Access-Token 头，否则请求/WS 升级 403
+    const token = sbx.envdAccessToken;
     console.log('\n--- WebSocket 端点 ---');
     console.log(`  host: ${host}`);
     console.log(`  CDP : ${cdpWsUrl}`);
     console.log(`  VNC : ${vncWsUrl}`);
 
     console.log('\n--- 等待健康检查 ---');
-    await waitUntilHealthy(sbx);
+    await waitUntilHealthy(sbx, host, token);
 
     console.log('\n--- Playwright CDP 用例 ---');
-    // e2b 公网网关要求 X-Access-Token 头，否则 WS 升级 403
     const headers = {};
-    const token = sbx.envdAccessToken;
     if (token) {
       headers['X-Access-Token'] = token;
     }
     await verifyWithPlaywright(cdpWsUrl, headers);
 
     console.log('\n--- VNC livestream 用例 ---');
-    await verifyVncHandshake(sbx);
+    await verifyVncHandshake(sbx, host, token);
   } finally {
     if (sbx !== null) {
       await sbx.kill();

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/03.构建自定义镜像模板.md
@@ -9,6 +9,10 @@
 1. 在与云沙箱相同 UID、相同地域下，[创建 ACR EE 实例](https://www.aliyun.com/product/acr)（经济版暂不支持）。
 2. 为 ACR EE 实例添加专有网络，确保云沙箱可以通过 VPC 拉取镜像。
 
+### 镜像要求
+
+基于 AMD64 架构的 Linux 系统，推荐基础镜像：ubuntu 20.04，Debian 12 (bookworm) 及以上
+
 ### 镜像推送
 
 将镜像推送到该 ACR EE 仓库，得到支持 VPC 访问的内网镜像地址，例如 `test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12`。


### PR DESCRIPTION
## 概述

更新云沙箱 browser 内置模板与自定义镜像模板文档，重写 browser 模板示例代码，并同步补齐英文版。

## 改动内容

### browser 模板（中英文）
- **规格更新**：容器镜像切换至 `cn-beijing` 仓库并升级至 `v0.0.36`；CPU 提升至 4 vCPU、内存提升至 8192 MB。
- **示例重写**：快速入门拆分为"构建模板 / 运行模板"两阶段，补充 Python 与 Node.js 完整示例（`/health` 轮询、CDP over Playwright 自动化截图、VNC livestream 握手校验）。
- **新增英文页** `Browser Template.md`，内容与中文完整对应（未包含 Puppeteer 示例）。
- **入口可发现性**：英文 `Built-in Templates.md` 新增模板列表表格并链接 browser 模板页。

### 自定义镜像模板（中英文）
- 新增"镜像要求"说明：基于 AMD64 架构的 Linux，推荐基础镜像 Ubuntu 20.04、Debian 12 (bookworm) 及以上。

## 说明
- 示例中的真实 API Key 已替换为占位符 `e2b_xxx`。
- 英文侧 base / code-interpreter-v1 / all-in-one 子页尚未创建，入口表格中先以纯文本列出，避免死链，后续补齐。

## 测试计划
- [ ] 中英文 browser 镜像版本一致（`v0.0.36`）
- [ ] 英文入口页可跳转到 browser 模板页
- [ ] 文档内代码示例语法正确、无残留真实密钥