### PR TITLE
docs(cloud-sandbox): add bilingual SDK examples

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/02.Create a Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/02.Create a Sandbox.md
@@ -7,7 +7,7 @@ Creating a Sandbox is the first step in using FC Agent Sandbox. After the Sandbo
 ```typescript
 import { Sandbox } from "e2b";
 
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
@@ -19,6 +19,27 @@ try {
 } finally {
   await sandbox.kill();
 }
+```
+
+Python example:
+
+```python
+import os
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    result = sandbox.commands.run("echo hello")
+    print(result.stdout.strip())
+finally:
+    sandbox.kill()
 ```
 
 ## Specify a Template
@@ -34,9 +55,21 @@ const sandbox = await Sandbox.create("code-interpreter-v1", {
 });
 ```
 
+In the Python SDK, pass the template name or template ID through the `template` parameter:
+
+```python
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    timeout=10 * 60,
+)
+```
+
 Common `Sandbox.create()` parameters include:
 
-- `template`: Template name or template ID.
+- `template` / first argument: Template name or template ID.
 - `timeoutMs`: Sandbox timeout in milliseconds.
 - `envs`: Environment variables injected into the Sandbox runtime.
 - `metadata`: Custom metadata written to the Sandbox control plane.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/03.Connect to a Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/03.Connect to a Sandbox.md
@@ -7,13 +7,30 @@ Connecting to a Sandbox lets you reuse the same Sandbox across different process
 ```typescript
 import { Sandbox } from "e2b";
 
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
 });
 
 console.log(sandbox.sandboxId);
+```
+
+Python example:
+
+```python
+import os
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+print(sandbox.sandbox_id)
 ```
 
 ## Connect to an existing sandbox
@@ -27,6 +44,20 @@ const sandbox = await Sandbox.connect(process.env.SANDBOX_ID, {
 
 const result = await sandbox.commands.run("pwd");
 console.log(result.stdout.trim());
+```
+
+Python example:
+
+```python
+sandbox = Sandbox.connect(
+    os.environ["SANDBOX_ID"],
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+result = sandbox.commands.run("pwd")
+print(result.stdout.strip())
 ```
 
 If the target Sandbox is paused, `Sandbox.connect()` automatically resumes it before returning a usable Sandbox object.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/04.List Sandboxes.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/04.List Sandboxes.md
@@ -13,9 +13,30 @@ const paginator = Sandbox.list({
   domain: process.env.E2B_DOMAIN,
 });
 
-for await (const sandbox of paginator) {
-  console.log(sandbox.sandboxId, sandbox.state);
+while (paginator.hasNext) {
+  const sandboxes = await paginator.nextItems();
+  for (const sandbox of sandboxes) {
+    console.log(sandbox.sandboxId, sandbox.state);
+  }
 }
+```
+
+Python example:
+
+```python
+import os
+
+from e2b import Sandbox
+
+paginator = Sandbox.list(
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+while paginator.has_next:
+    for sandbox in paginator.next_items():
+        print(sandbox.sandbox_id, sandbox.state)
 ```
 
 Pagination objects may differ across SDK versions. In application code, prefer the iteration interface provided by the SDK instead of assuming the return value is always an array.
@@ -27,6 +48,15 @@ const info = await sandbox.getInfo();
 console.log(info.sandboxId);
 console.log(info.templateId);
 console.log(info.metadata);
+```
+
+Python example:
+
+```python
+info = sandbox.get_info()
+print(info.sandbox_id)
+print(info.template_id)
+print(info.metadata)
 ```
 
 ## Recommendations

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/05.Kill a Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/05.Kill a Sandbox.md
@@ -8,10 +8,16 @@ Killing a Sandbox releases its resources. Explicitly kill the Sandbox when a tas
 await sandbox.kill();
 ```
 
+Python example:
+
+```python
+sandbox.kill()
+```
+
 Release resources in `finally`:
 
 ```typescript
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
@@ -22,6 +28,22 @@ try {
 } finally {
   await sandbox.kill();
 }
+```
+
+Python example:
+
+```python
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    sandbox.commands.run("python3 -m pytest")
+finally:
+    sandbox.kill()
 ```
 
 ## Difference from pause

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/06.Pause and Resume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/06.Pause and Resume.md
@@ -10,6 +10,12 @@ Pause the current Sandbox:
 sandbox.pause()
 ```
 
+TypeScript example:
+
+```typescript
+await sandbox.pause();
+```
+
 After a Sandbox is paused, it is no longer in an active running state. You can resume using it later by reconnecting to the existing Sandbox.
 
 ## Auto-resume on Connect
@@ -27,6 +33,16 @@ sandbox = Sandbox.connect(
     api_url=os.environ["E2B_API_URL"],
     domain=os.environ["E2B_DOMAIN"],
 )
+```
+
+TypeScript example:
+
+```typescript
+const sandbox = await Sandbox.connect(sandboxId, {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
 ```
 
 ## Recommendations

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/08.Environment Variables.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/08.Environment Variables.md
@@ -5,7 +5,7 @@ Environment variables let you inject runtime configuration into a Sandbox. They 
 ## Inject Environment Variables When Creating a Sandbox
 
 ```typescript
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
@@ -19,6 +19,24 @@ const result = await sandbox.commands.run("echo $TASK_ID");
 console.log(result.stdout.trim());
 ```
 
+Python example:
+
+```python
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    envs={
+        "NODE_ENV": "production",
+        "TASK_ID": "task-001",
+    },
+)
+
+result = sandbox.commands.run("echo $TASK_ID")
+print(result.stdout.strip())
+```
+
 ## Override Environment Variables When Running a Command
 
 ```typescript
@@ -29,6 +47,19 @@ const result = await sandbox.commands.run("echo $TASK_ID", {
 });
 
 console.log(result.stdout.trim());
+```
+
+Python example:
+
+```python
+result = sandbox.commands.run(
+    "echo $TASK_ID",
+    envs={
+        "TASK_ID": "task-002",
+    },
+)
+
+print(result.stdout.strip())
 ```
 
 ## Recommendations

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/09.Metadata.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/09.Metadata.md
@@ -5,7 +5,7 @@ Metadata lets you label Sandboxes in the control plane so your application can t
 ## Write Metadata When Creating a Sandbox
 
 ```typescript
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
@@ -17,6 +17,24 @@ const sandbox = await Sandbox.create({
 
 const info = await sandbox.getInfo();
 console.log(info.metadata);
+```
+
+Python example:
+
+```python
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    metadata={
+        "task_id": "task-001",
+        "agent": "code-reviewer",
+    },
+)
+
+info = sandbox.get_info()
+print(info.metadata)
 ```
 
 ## Metadata vs. environment variables

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/10.Git Integration.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/10.Git Integration.md
@@ -13,12 +13,31 @@ const result = await sandbox.commands.run(
 console.log(result.stdout);
 ```
 
+Python example:
+
+```python
+result = sandbox.commands.run(
+    "git clone --depth=1 https://github.com/e2b-dev/e2b.git /tmp/repo && git -C /tmp/repo status --short",
+    timeout=120,
+)
+
+print(result.stdout)
+```
+
 ## Use the SDK Git Module
 
 ```typescript
-await sandbox.git.clone("https://github.com/e2b-dev/e2b.git", "/tmp/repo");
+await sandbox.git.clone("https://github.com/e2b-dev/e2b.git", { path: "/tmp/repo" });
 const status = await sandbox.git.status("/tmp/repo");
 console.log(status);
+```
+
+Python example:
+
+```python
+sandbox.git.clone("https://github.com/e2b-dev/e2b.git", path="/tmp/repo")
+status = sandbox.git.status("/tmp/repo")
+print(status)
 ```
 
 ## Recommendations

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/11.Metrics.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/11.Metrics.md
@@ -16,6 +16,21 @@ const metricsById = await Sandbox.getMetrics(sandbox.sandboxId, {
 console.log(metricsById);
 ```
 
+Python example:
+
+```python
+metrics = sandbox.get_metrics()
+print(metrics)
+
+metrics_by_id = Sandbox.get_metrics(
+    sandbox.sandbox_id,
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+print(metrics_by_id)
+```
+
 CLI example:
 
 ```bash

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/01.Overview.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/01.Overview.md
@@ -24,6 +24,17 @@ const sandbox = await Sandbox.create("<template-id-or-name>", {
 });
 ```
 
+Python example:
+
+```python
+sandbox = Sandbox.create(
+    template="<template-id-or-name>",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+```
+
 ## Further reading
 
 - [Built-in Templates](02.Built-in%20Templates.md)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
@@ -17,8 +17,8 @@ Use the CLI to view the templates available to the current account:
 
 ```bash
 export E2B_API_KEY="<your-api-key>"
-export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 
 e2b template list
 ```
@@ -29,6 +29,8 @@ Python example:
 
 ```python
 import os
+
+from e2b import Sandbox
 
 sandbox = Sandbox.create(
     template="code-interpreter-v1",
@@ -41,6 +43,8 @@ sandbox = Sandbox.create(
 TypeScript example:
 
 ```typescript
+import { Sandbox } from "e2b";
+
 const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Base Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Base Template.md
@@ -46,6 +46,8 @@ from e2b import Sandbox
 
 sbx = Sandbox.create(
     api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
     timeout=600,
 )
 
@@ -53,6 +55,26 @@ result = sbx.commands.run("echo hello from base template")
 print(result.stdout)
 
 sbx.kill()
+```
+
+TypeScript example:
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sbx = await Sandbox.create({
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+  timeoutMs: 600_000,
+});
+
+try {
+  const result = await sbx.commands.run("echo hello from base template");
+  console.log(result.stdout);
+} finally {
+  await sbx.kill();
+}
 ```
 
 ## Related documents

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Code Interpreter v1 Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/Code Interpreter v1 Template.md
@@ -62,10 +62,33 @@ Whether you need to explicitly specify a `template` for the code-interpreter-v1 
 import os
 from e2b_code_interpreter import Sandbox
 
-sbx = Sandbox.create(api_key=os.environ["E2B_API_KEY"])
+sbx = Sandbox.create(
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
 execution = sbx.run_code("print('hello from code interpreter')")
 print(execution.logs.stdout)
 sbx.kill()
+```
+
+TypeScript example:
+
+```typescript
+import { Sandbox } from "@e2b/code-interpreter";
+
+const sbx = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
+
+try {
+  const execution = await sbx.runCode("print('hello from code interpreter')");
+  console.log(execution.logs.stdout);
+} finally {
+  await sbx.kill();
+}
 ```
 
 **Using the `e2b` SDK:**
@@ -77,6 +100,8 @@ from e2b import Sandbox
 sbx = Sandbox.create(
     template="code-interpreter-v1",
     api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
 )
 result = sbx.commands.run("python --version")
 print(result.stdout)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -34,8 +34,8 @@ Create a `.env` file:
 E2B_API_KEY="<your-api-key>"
 FROM_IMAGE="<acr-ee-vpc-domain>/<namespace>/<image>:<tag>"
 
-E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 ```
 
 ## Build the template and verify it
@@ -93,6 +93,58 @@ finally:
     sandbox.kill()
 ```
 
+TypeScript example:
+
+```typescript
+import { Sandbox, Template, defaultBuildLogger } from "@e2b/code-interpreter";
+
+const API_URL = process.env.E2B_API_URL || "https://api.cn-beijing.e2b.fc.aliyuncs.com";
+const DOMAIN = process.env.E2B_DOMAIN || "cn-beijing.e2b.fc.aliyuncs.com";
+const OPTS = {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: API_URL,
+  domain: DOMAIN,
+};
+
+const build = await Template.build(
+  Template().fromImage(process.env.FROM_IMAGE),
+  `template-${Date.now()}`,
+  {
+    cpuCount: 2,
+    memoryMB: 2048,
+    skipCache: false,
+    onBuildLogs: defaultBuildLogger(),
+    ...OPTS,
+  },
+);
+
+const sandbox = await Sandbox.create(build.templateId, {
+  timeoutMs: 900_000,
+  ...OPTS,
+});
+
+try {
+  console.log(`template_id: ${build.templateId}`);
+  console.log(`build_id: ${build.buildId}`);
+  console.log(`sandbox_id: ${sandbox.sandboxId}`);
+
+  const execution = await sandbox.runCode("print('hello')", {
+    timeoutMs: 60_000,
+    requestTimeoutMs: 120_000,
+  });
+
+  console.log(`run_code stdout: ${execution.logs.stdout.join("").trim()}`);
+  console.log(`run_code stderr: ${execution.logs.stderr.join("").trim()}`);
+  console.log("run_code error:", execution.error);
+
+  if (execution.error) {
+    throw new Error(`run_code failed: ${execution.error.value}`);
+  }
+} finally {
+  await sandbox.kill();
+}
+```
+
 ## ACR EE network requirements
 
 - The ACR EE instance is attached to at least one VPC.
@@ -101,6 +153,17 @@ finally:
 - The ACR EE access control and VPC configuration allow traffic from the corresponding network.
 - The VPC CIDR block uses private address ranges defined by RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16`.
 - The VPC has at least one security group that is not managed by a cloud service, and its rules allow access to the corresponding ACR EE instance.
+
+## Advanced registry configuration headers
+
+Use the following alpha headers only when a self-managed image registry requires explicit certificate or VPC network settings during template build.
+
+| Header | Value | Description |
+| --- | --- | --- |
+| `X-E2B-Template-Alpha-RegistryConfig-CertConfig-Insecure` | `true`, `false` | Ignore image registry certificate errors. |
+| `X-E2B-Template-Alpha-RegistryConfig-NetworkConfig-VpcId` | VPC ID | VPC ID of the self-managed image registry. |
+| `X-E2B-Template-Alpha-RegistryConfig-NetworkConfig-VSwitchId` | vSwitch ID | vSwitch ID of the self-managed image registry. |
+| `X-E2B-Template-Alpha-RegistryConfig-NetworkConfig-SecurityGroupId` | Security group ID | Security group ID of the self-managed image registry. |
 
 ## Troubleshoot the registry path
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/04.Define a Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/04.Define a Template.md
@@ -10,6 +10,14 @@ from e2b import Template
 template = Template().from_image("<acr-ee-vpc-domain>/<namespace>/<image>:<tag>")
 ```
 
+TypeScript example:
+
+```typescript
+import { Template } from "e2b";
+
+const template = Template().fromImage("<acr-ee-vpc-domain>/<namespace>/<image>:<tag>");
+```
+
 ## Submit the build
 
 ```python
@@ -26,6 +34,18 @@ build = Template.build(
     api_url=os.environ["E2B_API_URL"],
     domain=os.environ["E2B_DOMAIN"],
 )
+```
+
+TypeScript example:
+
+```typescript
+const build = await Template.build(template, "agent-runtime", {
+  cpuCount: 2,
+  memoryMB: 2048,
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
 ```
 
 ## Recommendations

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/05.Start and Ready Commands.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/05.Start and Ready Commands.md
@@ -13,6 +13,18 @@ const host = sandbox.getHost(8000);
 console.log(`https://${host}`);
 ```
 
+Python example:
+
+```python
+server = sandbox.commands.run(
+    "python3 -m http.server 8000",
+    background=True,
+)
+
+host = sandbox.get_host(8000)
+print(f"https://{host}")
+```
+
 ## Recommendations
 
 If the service startup step is required every time a sandbox is created, install the dependencies in the template first, then start the service with a background command after sandbox creation. Validate template-level startup and readiness commands against the actual SDK behavior and build results before relying on them.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/06.Base Images.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/06.Base Images.md
@@ -31,6 +31,24 @@ build = Template.build(
 print(build.template_id)
 ```
 
+TypeScript example:
+
+```typescript
+import { Template } from "e2b";
+
+const build = await Template.build(
+  Template().fromImage(process.env.FROM_IMAGE),
+  `agent-runtime-${Date.now()}`,
+  {
+    apiKey: process.env.E2B_API_KEY,
+    apiUrl: process.env.E2B_API_URL,
+    domain: process.env.E2B_DOMAIN,
+  },
+);
+
+console.log(build.templateId);
+```
+
 ## Recommendations
 
 Keep the base image stable and traceable. In production, use an explicit version or digest instead of a drifting `latest`.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Template Names.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Template Names.md
@@ -22,6 +22,17 @@ const sandbox = await Sandbox.create("agent-python313-20260704", {
 });
 ```
 
+Python example:
+
+```python
+sandbox = Sandbox.create(
+    template="agent-python313-20260704",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+```
+
 ## Recommendations
 
 Do not overwrite templates that are already in production use. Create a new template, validate it, and then switch application references.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Tags and Versioning.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Tags and Versioning.md
@@ -26,6 +26,31 @@ const tags = await Template.getTags("agent-python313-20260704", {
 console.log(tags);
 ```
 
+Python example:
+
+```python
+import os
+
+from e2b import Template
+
+Template.assign_tags(
+    "agent-python313-20260704",
+    ["staging", "v1"],
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+tags = Template.get_tags(
+    "agent-python313-20260704",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+print(tags)
+```
+
 ## Remove tags
 
 ```typescript
@@ -34,6 +59,18 @@ await Template.removeTags("agent-python313-20260704", "staging", {
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
 });
+```
+
+Python example:
+
+```python
+Template.remove_tags(
+    "agent-python313-20260704",
+    "staging",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
 ```
 
 ## Recommendations

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/09.User and Workdir.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/09.User and Workdir.md
@@ -9,6 +9,13 @@ const result = await sandbox.commands.run("whoami && pwd");
 console.log(result.stdout);
 ```
 
+Python example:
+
+```python
+result = sandbox.commands.run("whoami && pwd")
+print(result.stdout)
+```
+
 ## Set the command working directory
 
 ```typescript
@@ -20,6 +27,20 @@ const result = await sandbox.commands.run("python3 main.py", {
 });
 
 console.log(result.stdout.trim());
+```
+
+Python example:
+
+```python
+sandbox.files.make_dir("/tmp/project")
+sandbox.files.write("/tmp/project/main.py", "print('hello')\n")
+
+result = sandbox.commands.run(
+    "python3 main.py",
+    cwd="/tmp/project",
+)
+
+print(result.stdout.strip())
 ```
 
 ## Recommendations

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/12.Error Handling.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/12.Error Handling.md
@@ -22,6 +22,29 @@ except TemplateError as error:
     raise
 ```
 
+TypeScript example:
+
+```typescript
+import { Template, TemplateError } from "e2b";
+
+try {
+  const build = await Template.build(
+    Template().fromImage(process.env.FROM_IMAGE),
+    "agent-runtime",
+    {
+      apiKey: process.env.E2B_API_KEY,
+      apiUrl: process.env.E2B_API_URL,
+      domain: process.env.E2B_DOMAIN,
+    },
+  );
+} catch (error) {
+  if (error instanceof TemplateError) {
+    console.error("template build failed:", error);
+  }
+  throw error;
+}
+```
+
 ## Troubleshooting order
 
 - Check whether the image address uses the VPC internal domain.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/02.Run Code.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/02.Run Code.md
@@ -19,6 +19,18 @@ sandbox = Sandbox.create(
 )
 ```
 
+TypeScript example:
+
+```typescript
+import { Sandbox } from "@e2b/code-interpreter";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
+```
+
 ## Execute Python code
 
 ```python
@@ -35,6 +47,22 @@ print(stdout.strip())
 print(execution.text)
 ```
 
+TypeScript example:
+
+```typescript
+const execution = await sandbox.runCode(`
+import pandas as pd
+
+df = pd.DataFrame({"value": [1, 2, 3]})
+print(df)
+df["value"].sum()
+`);
+
+const stdout = execution.logs.stdout.join("");
+console.log(stdout.trim());
+console.log(execution.text);
+```
+
 `print()` writes to stdout. The final bare expression is written to `execution.text` and may also generate a structured entry in `execution.results`.
 
 ## Set timeouts
@@ -49,6 +77,18 @@ execution = sandbox.run_code(
 )
 ```
 
+TypeScript example:
+
+```typescript
+const execution = await sandbox.runCode(
+  "import time; time.sleep(5); 42",
+  {
+    timeoutMs: 30_000,
+    requestTimeoutMs: 60_000,
+  },
+);
+```
+
 `timeout` limits code execution time inside the sandbox. `request_timeout` limits how long the SDK waits for the request. Follow the parameter names exposed by your current language SDK.
 
 ## Execute other languages
@@ -60,6 +100,14 @@ execution = sandbox.run_code(
     'console.log("hello from js")',
     language="javascript",
 )
+```
+
+TypeScript example:
+
+```typescript
+const execution = await sandbox.runCode('console.log("hello from js")', {
+  language: "javascript",
+});
 ```
 
 For more language examples, see [Supported Languages](07.Supported%20Languages.md).

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/04.Outputs.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/04.Outputs.md
@@ -30,11 +30,35 @@ print(stdout.strip())
 print(stderr.strip())
 ```
 
+TypeScript example:
+
+```typescript
+const execution = await sandbox.runCode(`
+import sys
+
+print("hello")
+print("warning", file=sys.stderr)
+`);
+
+const stdout = execution.logs.stdout.join("");
+const stderr = execution.logs.stderr.join("");
+
+console.log(stdout.trim());
+console.log(stderr.trim());
+```
+
 ## Read expression results
 
 ```python
 execution = sandbox.run_code("1 + 1")
 print(execution.text)
+```
+
+TypeScript example:
+
+```typescript
+const execution = await sandbox.runCode("1 + 1");
+console.log(execution.text);
 ```
 
 `execution.text` is suitable for simple text results. For tables, read from `execution.results`. For charts, save them as files and retrieve them through Filesystem.
@@ -54,6 +78,23 @@ for result in execution.results:
         print(result.text)
 ```
 
+TypeScript example:
+
+```typescript
+const execution = await sandbox.runCode(`
+import pandas as pd
+
+df = pd.DataFrame({"month": ["2026-01", "2026-02"], "revenue": [120, 180]})
+df
+`);
+
+for (const result of execution.results) {
+  if (result.text) {
+    console.log(result.text);
+  }
+}
+```
+
 Different SDK versions may expose `Result` fields differently. Print `execution.results` once during integration to confirm the field names returned by your current SDK.
 
 ## Handle errors
@@ -65,6 +106,18 @@ if execution.error:
     print(execution.error.name)
     print(execution.error.value)
     print(execution.error.traceback)
+```
+
+TypeScript example:
+
+```typescript
+const execution = await sandbox.runCode("raise ValueError('bad input')");
+
+if (execution.error) {
+  console.log(execution.error.name);
+  console.log(execution.error.value);
+  console.log(execution.error.traceback);
+}
 ```
 
 ## Recommendations

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/05.Data Analysis.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/05.Data Analysis.md
@@ -55,12 +55,63 @@ finally:
     sandbox.kill()
 ```
 
+TypeScript example:
+
+```typescript
+import { Sandbox } from "@e2b/code-interpreter";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
+
+try {
+  await sandbox.files.write(
+    "/tmp/sales.csv",
+    "month,revenue\n2026-01,120\n2026-02,180\n2026-03,160\n",
+  );
+
+  const execution = await sandbox.runCode(`
+import pandas as pd
+
+df = pd.read_csv("/tmp/sales.csv")
+print(df)
+df["revenue"].sum()
+`, {
+    timeoutMs: 30_000,
+    requestTimeoutMs: 60_000,
+  });
+
+  if (execution.error) {
+    throw new Error(`${execution.error.name}: ${execution.error.value}`);
+  }
+
+  console.log("stdout:");
+  console.log(execution.logs.stdout.join("").trim());
+  console.log("stderr:");
+  console.log(execution.logs.stderr.join("").trim());
+  console.log("text:");
+  console.log(execution.text);
+} finally {
+  await sandbox.kill();
+}
+```
+
 ## Generate a chart file
 
 ```python
 sandbox.run_code("""import matplotlib.pyplot as plt; plt.plot([1, 2, 3], [120, 180, 160]); plt.title("Revenue"); plt.savefig("/tmp/revenue.png")""")
 
 content = sandbox.files.read("/tmp/revenue.png", format="bytes")
+```
+
+TypeScript example:
+
+```typescript
+await sandbox.runCode(`import matplotlib.pyplot as plt; plt.plot([1, 2, 3], [120, 180, 160]); plt.title("Revenue"); plt.savefig("/tmp/revenue.png")`);
+
+const content = await sandbox.files.read("/tmp/revenue.png", { format: "bytes" });
 ```
 
 FC Agent Sandbox currently supports only the file-based fallback path for charts. For details, see [Charts and Visualizations](08.Charts%20and%20Visualizations.md).

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/06.Streaming Output.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/06.Streaming Output.md
@@ -28,6 +28,24 @@ print("done")
 
 The Python SDK uses `on_stdout` and `on_stderr`. Callback parameters are output chunks and usually include content, whether the chunk is stderr, and a timestamp. Do not assume a single callback corresponds to one complete business log line.
 
+```python
+sandbox.run_code(
+    """
+import sys
+import time
+
+print("start")
+time.sleep(3)
+print("warning", file=sys.stderr)
+time.sleep(3)
+print("done")
+""",
+    on_stdout=lambda data: print("stdout:", data),
+    on_stderr=lambda data: print("stderr:", data),
+    on_error=lambda error: print("error:", error),
+)
+```
+
 ## Rich results
 
 Rich results such as tables and text can also be received through callbacks before the final result is returned. For charts, write files and retrieve them through Filesystem.
@@ -47,6 +65,18 @@ df
 ```
 
 The Python SDK uses the corresponding snake_case callback parameters. Follow the parameter names exposed by your current SDK version.
+
+```python
+sandbox.run_code(
+    """
+import pandas as pd
+
+df = pd.DataFrame({"value": [1, 2, 3]})
+df
+""",
+    on_result=lambda result: print("result:", result),
+)
+```
 
 ## Recommendations
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/07.Supported Languages.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/07.Supported Languages.md
@@ -11,6 +11,13 @@ execution = sandbox.run_code('print("Hello, world!")')
 print("".join(execution.logs.stdout or []).strip())
 ```
 
+TypeScript example:
+
+```typescript
+const execution = await sandbox.runCode('print("Hello, world!")');
+console.log(execution.logs.stdout.join("").trim());
+```
+
 ## JavaScript and TypeScript
 
 Use `javascript` or `js` for JavaScript, and `typescript` or `ts` for TypeScript:
@@ -25,6 +32,18 @@ console.log(value)
 )
 ```
 
+In the TypeScript SDK, use the same `language` option:
+
+```typescript
+const execution = await sandbox.runCode(
+  `
+const value = await Promise.resolve(42)
+console.log(value)
+`,
+  { language: "typescript" },
+);
+```
+
 The official E2B documentation states that TypeScript supports top-level await, ESM-style imports, and automatic Promise resolution. When you integrate with FC Agent Sandbox, verify the Node.js version and dependency installation path inside the template first.
 
 ## Bash
@@ -33,6 +52,12 @@ Use the corresponding `language` value for other languages:
 
 ```python
 sandbox.run_code('echo "Hello from Bash"', language="bash")
+```
+
+TypeScript example:
+
+```typescript
+await sandbox.runCode('echo "Hello from Bash"', { language: "bash" });
 ```
 
 ## Selection guidance

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/08.Charts and Visualizations.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/05.Code Interpreter/08.Charts and Visualizations.md
@@ -10,10 +10,22 @@ When you use Matplotlib to generate a chart, save the image to a fixed path insi
 sandbox.run_code("""import matplotlib.pyplot as plt; plt.plot([1, 2, 3], [1, 4, 9]);plt.savefig("/tmp/chart.png")""")
 ```
 
+TypeScript example:
+
+```typescript
+await sandbox.runCode(`import matplotlib.pyplot as plt; plt.plot([1, 2, 3], [1, 4, 9]); plt.savefig("/tmp/chart.png")`);
+```
+
 Then read the file contents:
 
 ```python
 content = sandbox.files.read("/tmp/chart.png", format="bytes")
+```
+
+TypeScript example:
+
+```typescript
+const content = await sandbox.files.read("/tmp/chart.png", { format: "bytes" });
 ```
 
 You can also hand the image to a browser or downstream system through an upload or download URL:
@@ -22,12 +34,24 @@ You can also hand the image to a browser or downstream system through an upload 
 download_url = sandbox.download_url("/tmp/chart.png")
 ```
 
+TypeScript example:
+
+```typescript
+const downloadUrl = await sandbox.downloadUrl("/tmp/chart.png");
+```
+
 ## Generate multiple charts
 
 Use stable filenames for multiple charts so they do not overwrite each other:
 
 ```python
 sandbox.run_code("""import matplotlib.pyplot as plt; plt.figure(); plt.plot([1, 2, 3]); plt.savefig("/tmp/chart-1.png"); plt.figure(); plt.bar(["A", "B"], [10, 20]); plt.savefig("/tmp/chart-2.png")""")
+```
+
+TypeScript example:
+
+```typescript
+await sandbox.runCode(`import matplotlib.pyplot as plt; plt.figure(); plt.plot([1, 2, 3]); plt.savefig("/tmp/chart-1.png"); plt.figure(); plt.bar(["A", "B"], [10, 20]); plt.savefig("/tmp/chart-2.png")`);
 ```
 
 Then read or download `/tmp/chart-1.png` and `/tmp/chart-2.png` separately.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/01.Overview.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/01.Overview.md
@@ -19,6 +19,20 @@ console.log(`https://${host}`);
 await sandbox.commands.kill(server.pid);
 ```
 
+Python example:
+
+```python
+server = sandbox.commands.run(
+    "python3 -m http.server 8000",
+    background=True,
+)
+
+host = sandbox.get_host(8000)
+print(f"https://{host}")
+
+sandbox.commands.kill(server.pid)
+```
+
 ## Capability boundaries
 
 The current feature documentation only treats public access URLs as part of the formal compatibility surface. E2B network access control and proxy tunneling should not be copied directly into the FC Agent Sandbox integration path. Custom domains belong to the FC Extensions capability set. See [Custom Domains](../07.FC%20Extensions/03.Custom%20Domains.md).

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/02.Access URLs.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/02.Access URLs.md
@@ -12,6 +12,13 @@ print(f"sandbox_domain: {sandbox.sandbox_domain}")
 print(f"envd_api_url: {sandbox.envd_api_url}")
 ```
 
+TypeScript example:
+
+```typescript
+console.log(`sandbox_id: ${sandbox.sandboxId}`);
+console.log(`sandbox_domain: ${sandbox.sandboxDomain}`);
+```
+
 ## Recommendations
 
 - When your application needs to access a sandbox port, prefer `sandbox.getHost(port)`.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/03.Public Access.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/03.Public Access.md
@@ -33,6 +33,39 @@ try {
 }
 ```
 
+Python example:
+
+```python
+import os
+import urllib.request
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    process = sandbox.commands.run(
+        "python3 -m http.server 8000",
+        background=True,
+    )
+
+    host = sandbox.get_host(8000)
+    url = f"https://{host}"
+    print(url)
+
+    with urllib.request.urlopen(url, timeout=10) as response:
+        print(response.read().decode())
+
+    process.kill()
+finally:
+    sandbox.kill()
+```
+
 ## Notes
 
 - Before calling `getHost(port)`, make sure a service inside the sandbox is already listening on that port.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/04.Sandbox Public URL.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/04.Sandbox Public URL.md
@@ -17,6 +17,22 @@ console.log(url);
 await sandbox.commands.kill(handle.pid);
 ```
 
+Python example:
+
+```python
+handle = sandbox.commands.run(
+    "python3 -m http.server 8000",
+    background=True,
+)
+
+host = sandbox.get_host(8000)
+url = f"https://{host}"
+
+print(url)
+
+sandbox.commands.kill(handle.pid)
+```
+
 ## Recommendations
 
 - The service must listen on the target port, or the access URL will not respond correctly.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/02.VPC Network Configuration.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/02.VPC Network Configuration.md
@@ -54,6 +54,44 @@ PY`,
 }
 ```
 
+Python example:
+
+```python
+import os
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    endpoint = os.environ["INTERNAL_API_ENDPOINT"]
+    result = sandbox.commands.run(
+        """
+python3 - <<'PY'
+import os
+import urllib.request
+
+url = os.environ["INTERNAL_API_ENDPOINT"]
+with urllib.request.urlopen(url, timeout=5) as response:
+    print(response.status)
+PY
+""",
+        envs={
+            "INTERNAL_API_ENDPOINT": endpoint,
+        },
+        timeout=10,
+    )
+
+    print(result.stdout.strip())
+finally:
+    sandbox.kill()
+```
+
 ## Common configuration items
 
 - VPC: The private network that the sandbox needs to access.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/03.Custom Domains.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/03.Custom Domains.md
@@ -105,6 +105,22 @@ const host = sandbox.getHost(8000);
 console.log(`https://${host}`);
 ```
 
+Python example:
+
+```python
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url="https://api.example.com",
+    domain="example.com",
+)
+
+host = sandbox.get_host(8000)
+print(f"https://{host}")
+```
+
 If the sandbox ID is `sandbox-id` and the exposed port is `8000`, the SDK returns an address in the following format:
 
 ```text

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/05.Monitoring and Logs.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/05.Monitoring and Logs.md
@@ -60,6 +60,48 @@ try {
 }
 ```
 
+Python example:
+
+```python
+import json
+import os
+import uuid
+
+from e2b import Sandbox
+
+task_id = str(uuid.uuid4())
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    metadata={
+        "taskId": task_id,
+    },
+)
+
+try:
+    print(json.dumps({
+        "event": "sandbox_created",
+        "taskId": task_id,
+        "sandboxId": sandbox.sandbox_id,
+    }))
+
+    result = sandbox.commands.run("python3 -V", timeout=30)
+
+    print(json.dumps({
+        "event": "command_finished",
+        "taskId": task_id,
+        "sandboxId": sandbox.sandbox_id,
+        "exitCode": result.exit_code,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }))
+finally:
+    sandbox.kill()
+```
+
 ## Output structured logs
 
 After log collection is configured, output structured logs so you can search by field in Simple Log Service.
@@ -92,6 +134,38 @@ PY`,
 );
 
 console.log(result.stdout);
+```
+
+Python example:
+
+```python
+result = sandbox.commands.run(
+    """
+python3 - <<'PY'
+import json
+import os
+import time
+
+task_id = os.environ["TASK_ID"]
+print(json.dumps({
+    "event": "task_started",
+    "taskId": task_id,
+    "ts": int(time.time()),
+}), flush=True)
+print(json.dumps({
+    "event": "task_finished",
+    "taskId": task_id,
+    "ts": int(time.time()),
+}), flush=True)
+PY
+""",
+    envs={
+        "TASK_ID": task_id,
+    },
+    timeout=30,
+)
+
+print(result.stdout)
 ```
 
 ## Common observability targets

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/01.Installation.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/01.Installation.md
@@ -28,8 +28,8 @@ The E2B CLI authenticates with `E2B_API_KEY`. Create and manage the API key as d
 
 ```bash
 export E2B_API_KEY="<your-api-key>"
-export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 ```
 
 `E2B_ACCESS_TOKEN` is a deprecated legacy E2B authentication variable. New CLI flows should use `E2B_API_KEY` instead of depending on `E2B_ACCESS_TOKEN`.
@@ -46,7 +46,7 @@ If authentication fails, check the following:
 
 - The API key was created as described in [Create an API Key](../../01.Getting%20Started/02.Create%20an%20API%20Key.md).
 - The API key is enabled and not expired.
-- `E2B_API_URL` is `https://api.<region>.e2b.fc.aliyuncs.com`.
-- `E2B_DOMAIN` is `<region>.e2b.fc.aliyuncs.com`.
+- `E2B_API_URL` is `https://api.cn-beijing.e2b.fc.aliyuncs.com`.
+- `E2B_DOMAIN` is `cn-beijing.e2b.fc.aliyuncs.com`.
 - The installed E2B CLI version supports `E2B_API_KEY` authentication.
 - The current account has the required Function Compute permissions.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/02.Authentication.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/02.Authentication.md
@@ -6,8 +6,8 @@ By default, the E2B CLI reads environment variables for authentication. When con
 
 ```bash
 export E2B_API_KEY="<your-api-key>"
-export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 ```
 
 `E2B_ACCESS_TOKEN` is a deprecated legacy E2B authentication variable. New E2B CLI flows should use `E2B_API_KEY` instead of depending on `E2B_ACCESS_TOKEN`.
@@ -21,6 +21,6 @@ e2b sandbox list
 If authentication fails, check the following items:
 
 - The API key was created as described in [Create an API Key](../../01.Getting%20Started/02.Create%20an%20API%20Key.md).
-- `E2B_API_URL` includes `https://api.<region>.e2b.fc.aliyuncs.com`.
-- `E2B_DOMAIN` is set to `<region>.e2b.fc.aliyuncs.com`.
+- `E2B_API_URL` includes `https://api.cn-beijing.e2b.fc.aliyuncs.com`.
+- `E2B_DOMAIN` is set to `cn-beijing.e2b.fc.aliyuncs.com`.
 - The current account has the required permissions for Function Compute operations.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/04.Connect to a Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/04.Connect to a Sandbox.md
@@ -25,3 +25,14 @@ const sandbox = await Sandbox.connect("<sandbox-id>", {
   domain: process.env.E2B_DOMAIN,
 });
 ```
+
+Python example:
+
+```python
+sandbox = Sandbox.connect(
+    "<sandbox-id>",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+```

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/08.Execute Commands.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/08.Execute Commands.md
@@ -28,3 +28,10 @@ If you need to execute commands in server-side code, use the SDK Commands API:
 const result = await sandbox.commands.run("echo hello");
 console.log(result.stdout.trim());
 ```
+
+Python example:
+
+```python
+result = sandbox.commands.run("echo hello")
+print(result.stdout.strip())
+```

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/14.Migration/01.Migrate from E2B.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/14.Migration/01.Migrate from E2B.md
@@ -6,8 +6,8 @@ The primary integration goal of FC Agent Sandbox is native compatibility with th
 
 ```bash
 export E2B_API_KEY="<your-api-key>"
-export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 ```
 
 ## Capabilities to verify first

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/02.创建沙箱.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/02.创建沙箱.md
@@ -7,7 +7,7 @@
 ```typescript
 import { Sandbox } from "e2b";
 
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
@@ -21,6 +21,27 @@ try {
 }
 ```
 
+Python 示例：
+
+```python
+import os
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    result = sandbox.commands.run("echo hello")
+    print(result.stdout.strip())
+finally:
+    sandbox.kill()
+```
+
 ## 指定模板
 
 当需要预装依赖或固定运行环境时，可以通过模板创建沙箱：
@@ -32,6 +53,18 @@ const sandbox = await Sandbox.create("code-interpreter-v1", {
   domain: process.env.E2B_DOMAIN,
   timeoutMs: 10 * 60 * 1000,
 });
+```
+
+Python SDK 中，模板名称或模板 ID 通过 `template` 参数传入：
+
+```python
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    timeout=10 * 60,
+)
 ```
 
 TypeScript SDK 中，模板名称或模板 ID 通过 `Sandbox.create(template, options)` 的第一个参数传入。`options` 常用参数包括：

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/03.连接沙箱.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/03.连接沙箱.md
@@ -7,13 +7,30 @@
 ```typescript
 import { Sandbox } from "e2b";
 
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
 });
 
 console.log(sandbox.sandboxId);
+```
+
+Python 示例：
+
+```python
+import os
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+print(sandbox.sandbox_id)
 ```
 
 ## 连接已有沙箱
@@ -27,6 +44,20 @@ const sandbox = await Sandbox.connect(process.env.SANDBOX_ID, {
 
 const result = await sandbox.commands.run("pwd");
 console.log(result.stdout.trim());
+```
+
+Python 示例：
+
+```python
+sandbox = Sandbox.connect(
+    os.environ["SANDBOX_ID"],
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+result = sandbox.commands.run("pwd")
+print(result.stdout.strip())
 ```
 
 如果目标沙箱处于暂停状态，`Sandbox.connect()` 会自动恢复后再返回可用的沙箱对象。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/04.列出沙箱.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/04.列出沙箱.md
@@ -21,6 +21,24 @@ while (paginator.hasNext) {
 }
 ```
 
+Python 示例：
+
+```python
+import os
+
+from e2b import Sandbox
+
+paginator = Sandbox.list(
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+while paginator.has_next:
+    for sandbox in paginator.next_items():
+        print(sandbox.sandbox_id, sandbox.state)
+```
+
 不同 SDK 版本的分页对象形态可能不同。编写业务代码时，建议优先使用 SDK 提供的迭代方式，而不是假设返回值一定是数组。
 
 ## 查询当前沙箱信息
@@ -30,6 +48,15 @@ const info = await sandbox.getInfo();
 console.log(info.sandboxId);
 console.log(info.templateId);
 console.log(info.metadata);
+```
+
+Python 示例：
+
+```python
+info = sandbox.get_info()
+print(info.sandbox_id)
+print(info.template_id)
+print(info.metadata)
 ```
 
 ## 使用建议

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/05.终止沙箱.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/05.终止沙箱.md
@@ -8,10 +8,16 @@
 await sandbox.kill();
 ```
 
+Python 示例：
+
+```python
+sandbox.kill()
+```
+
 推荐在 `finally` 中释放资源：
 
 ```typescript
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
@@ -24,9 +30,24 @@ try {
 }
 ```
 
+Python 示例：
+
+```python
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    sandbox.commands.run("python3 -m pytest")
+finally:
+    sandbox.kill()
+```
+
 ## 和暂停的区别
 
 `kill()` 用于结束沙箱生命周期；`pause()` 用于暂停并等待后续恢复。终止后不能再通过 `Sandbox.connect()` 回到同一个运行现场。
 
 如果任务需要短时间等待用户继续操作，使用[暂停与恢复](06.暂停与恢复.md)。如果任务已经完成，使用终止。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/06.暂停与恢复.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/06.暂停与恢复.md
@@ -10,6 +10,12 @@
 sandbox.pause()
 ```
 
+TypeScript 示例：
+
+```typescript
+await sandbox.pause();
+```
+
 暂停后，Sandbox 不再处于活跃运行状态。后续可以通过连接已有 Sandbox 的方式恢复使用。
 
 ## 连接时自动恢复
@@ -27,6 +33,16 @@ sandbox = Sandbox.connect(
     api_url=os.environ["E2B_API_URL"],
     domain=os.environ["E2B_DOMAIN"],
 )
+```
+
+TypeScript 示例：
+
+```typescript
+const sandbox = await Sandbox.connect(sandboxId, {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
 ```
 
 ## 使用建议

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/08.环境变量.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/08.环境变量.md
@@ -5,7 +5,7 @@
 ## 创建沙箱时注入环境变量
 
 ```typescript
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
@@ -17,6 +17,24 @@ const sandbox = await Sandbox.create({
 
 const result = await sandbox.commands.run("echo $TASK_ID");
 console.log(result.stdout.trim());
+```
+
+Python 示例：
+
+```python
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    envs={
+        "NODE_ENV": "production",
+        "TASK_ID": "task-001",
+    },
+)
+
+result = sandbox.commands.run("echo $TASK_ID")
+print(result.stdout.strip())
 ```
 
 ## 执行命令时覆盖环境变量
@@ -31,9 +49,21 @@ const result = await sandbox.commands.run("echo $TASK_ID", {
 console.log(result.stdout.trim());
 ```
 
+Python 示例：
+
+```python
+result = sandbox.commands.run(
+    "echo $TASK_ID",
+    envs={
+        "TASK_ID": "task-002",
+    },
+)
+
+print(result.stdout.strip())
+```
+
 ## 使用建议
 
 - 沙箱级 `envs` 适合放多次命令都会使用的配置。
 - 命令级 `envs` 适合放单次执行参数。
 - 不要依赖环境变量保存业务状态，跨沙箱持久状态应写入外部存储。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/09.元数据.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/09.元数据.md
@@ -5,7 +5,7 @@
 ## 创建沙箱时写入元数据
 
 ```typescript
-const sandbox = await Sandbox.create({
+const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,
   domain: process.env.E2B_DOMAIN,
@@ -19,6 +19,24 @@ const info = await sandbox.getInfo();
 console.log(info.metadata);
 ```
 
+Python 示例：
+
+```python
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    metadata={
+        "task_id": "task-001",
+        "agent": "code-reviewer",
+    },
+)
+
+info = sandbox.get_info()
+print(info.metadata)
+```
+
 ## 元数据和环境变量的区别
 
 - 元数据用于管理面查询、审计和业务关联。
@@ -28,4 +46,3 @@ console.log(info.metadata);
 ## 使用建议
 
 元数据值建议使用短字符串，避免写入大段上下文、用户隐私或凭证。复杂业务状态应保存在业务数据库中，元数据只保存可索引的关联 ID。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/10.Git 集成.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/10.Git 集成.md
@@ -13,12 +13,31 @@ const result = await sandbox.commands.run(
 console.log(result.stdout);
 ```
 
+Python 示例：
+
+```python
+result = sandbox.commands.run(
+    "git clone --depth=1 https://github.com/e2b-dev/e2b.git /tmp/repo && git -C /tmp/repo status --short",
+    timeout=120,
+)
+
+print(result.stdout)
+```
+
 ## 使用 SDK Git 模块
 
 ```typescript
 await sandbox.git.clone("https://github.com/e2b-dev/e2b.git", { path: "/tmp/repo" });
 const status = await sandbox.git.status("/tmp/repo");
 console.log(status);
+```
+
+Python 示例：
+
+```python
+sandbox.git.clone("https://github.com/e2b-dev/e2b.git", path="/tmp/repo")
+status = sandbox.git.status("/tmp/repo")
+print(status)
 ```
 
 ## 使用建议

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/11.指标.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.Sandbox/11.指标.md
@@ -16,6 +16,21 @@ const metricsById = await Sandbox.getMetrics(sandbox.sandboxId, {
 console.log(metricsById);
 ```
 
+Python 示例：
+
+```python
+metrics = sandbox.get_metrics()
+print(metrics)
+
+metrics_by_id = Sandbox.get_metrics(
+    sandbox.sandbox_id,
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+print(metrics_by_id)
+```
+
 CLI 示例：
 
 ```bash

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/01.概览.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/01.概览.md
@@ -24,6 +24,17 @@ const sandbox = await Sandbox.create("<template-id-or-name>", {
 });
 ```
 
+Python 示例：
+
+```python
+sandbox = Sandbox.create(
+    template="<template-id-or-name>",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+```
+
 ## 后续阅读
 
 - [内置模板](02.内置模板.md)

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板.md
@@ -19,8 +19,8 @@
 
 ```bash
 export E2B_API_KEY="<your-api-key>"
-export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 
 e2b template list
 ```
@@ -34,6 +34,8 @@ e2b template list
 ```python
 import os
 
+from e2b import Sandbox
+
 sandbox = Sandbox.create(
     template="code-interpreter-v1",
     api_key=os.environ["E2B_API_KEY"],
@@ -45,6 +47,8 @@ sandbox = Sandbox.create(
 TypeScript 示例：
 
 ```typescript
+import { Sandbox } from "e2b";
+
 const sandbox = await Sandbox.create("code-interpreter-v1", {
   apiKey: process.env.E2B_API_KEY,
   apiUrl: process.env.E2B_API_URL,

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/base-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/base-模板.md
@@ -46,6 +46,8 @@ from e2b import Sandbox
 
 sbx = Sandbox.create(
     api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
     timeout=600,
 )
 
@@ -53,6 +55,26 @@ result = sbx.commands.run("echo hello from base template")
 print(result.stdout)
 
 sbx.kill()
+```
+
+TypeScript 示例：
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sbx = await Sandbox.create({
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+  timeoutMs: 600_000,
+});
+
+try {
+  const result = await sbx.commands.run("echo hello from base template");
+  console.log(result.stdout);
+} finally {
+  await sbx.kill();
+}
 ```
 
 ## 相关文档

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/code-interpreter-v1-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/02.内置模板/code-interpreter-v1-模板.md
@@ -62,10 +62,33 @@ Code Interpreter API 分为控制面和数据面两个层面：
 import os
 from e2b_code_interpreter import Sandbox
 
-sbx = Sandbox.create(api_key=os.environ["E2B_API_KEY"])
+sbx = Sandbox.create(
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
 execution = sbx.run_code("print('hello from code interpreter')")
 print(execution.logs.stdout)
 sbx.kill()
+```
+
+TypeScript 示例：
+
+```typescript
+import { Sandbox } from "@e2b/code-interpreter";
+
+const sbx = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
+
+try {
+  const execution = await sbx.runCode("print('hello from code interpreter')");
+  console.log(execution.logs.stdout);
+} finally {
+  await sbx.kill();
+}
 ```
 
 **使用 `e2b` SDK：**
@@ -77,6 +100,8 @@ from e2b import Sandbox
 sbx = Sandbox.create(
     template="code-interpreter-v1",
     api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
 )
 result = sbx.commands.run("python --version")
 print(result.stdout)

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/03.构建自定义镜像模板.md
@@ -98,6 +98,58 @@ finally:
     print("sandbox killed")
 ```
 
+TypeScript 示例：
+
+```typescript
+import { Sandbox, Template, defaultBuildLogger } from "@e2b/code-interpreter";
+
+const API_URL = process.env.E2B_API_URL || "https://api.cn-beijing.e2b.fc.aliyuncs.com";
+const DOMAIN = process.env.E2B_DOMAIN || "cn-beijing.e2b.fc.aliyuncs.com";
+const OPTS = {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: API_URL,
+  domain: DOMAIN,
+};
+
+const build = await Template.build(
+  Template().fromImage(process.env.FROM_IMAGE),
+  `template-${Date.now()}`,
+  {
+    cpuCount: 2,
+    memoryMB: 2048,
+    skipCache: false,
+    onBuildLogs: defaultBuildLogger(),
+    ...OPTS,
+  },
+);
+
+const sandbox = await Sandbox.create(build.templateId, {
+  timeoutMs: 900_000,
+  ...OPTS,
+});
+
+try {
+  console.log(`template_id: ${build.templateId}`);
+  console.log(`build_id: ${build.buildId}`);
+  console.log(`sandbox_id: ${sandbox.sandboxId}`);
+
+  const execution = await sandbox.runCode("print('hello')", {
+    timeoutMs: 60_000,
+    requestTimeoutMs: 120_000,
+  });
+
+  console.log(`run_code stdout: ${execution.logs.stdout.join("").trim()}`);
+  console.log(`run_code stderr: ${execution.logs.stderr.join("").trim()}`);
+  console.log("run_code error:", execution.error);
+
+  if (execution.error) {
+    throw new Error(`run_code failed: ${execution.error.value}`);
+  }
+} finally {
+  await sandbox.kill();
+}
+```
+
 ## 注意事项
 
 ### 使用 FC E2B 官方镜像
@@ -216,6 +268,10 @@ build = Template.build(
 | `X-E2B-Template-Source-VPC-ID` | VPC ID | 访问源镜像仓库使用的 VPC。 |
 | `X-E2B-Template-Source-VSwitch-IDs` | vSwitch ID 列表，逗号分隔 | 访问源镜像仓库使用的交换机。 |
 | `X-E2B-Template-Source-Security-Group-ID` | 安全组 ID | 访问源镜像仓库使用的安全组。 |
+| `X-E2B-Template-Alpha-RegistryConfig-CertConfig-Insecure` | `true`、`false` | 忽略镜像仓库证书错误 |
+| `X-E2B-Template-Alpha-RegistryConfig-NetworkConfig-VpcId` | VPC ID | 自建镜像仓库专有网络 ID |
+| `X-E2B-Template-Alpha-RegistryConfig-NetworkConfig-VSwitchId` | 交换机 ID | 自建镜像仓库交换机 ID |
+| `X-E2B-Template-Alpha-RegistryConfig-NetworkConfig-SecurityGroupId` | 安全组 ID | 自建镜像仓库安全组 ID |
 
 构建模式说明：
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/04.定义模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/04.定义模板.md
@@ -10,6 +10,14 @@ from e2b import Template
 template = Template().from_image("<acr-ee-vpc-domain>/<namespace>/<image>:<tag>")
 ```
 
+TypeScript 示例：
+
+```typescript
+import { Template } from "e2b";
+
+const template = Template().fromImage("<acr-ee-vpc-domain>/<namespace>/<image>:<tag>");
+```
+
 ## 提交构建
 
 ```python
@@ -26,6 +34,18 @@ build = Template.build(
     api_url=os.environ["E2B_API_URL"],
     domain=os.environ["E2B_DOMAIN"],
 )
+```
+
+TypeScript 示例：
+
+```typescript
+const build = await Template.build(template, "agent-runtime", {
+  cpuCount: 2,
+  memoryMB: 2048,
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
 ```
 
 ## 使用建议

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/05.启动与就绪命令.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/05.启动与就绪命令.md
@@ -13,7 +13,18 @@ const host = sandbox.getHost(8000);
 console.log(`https://${host}`);
 ```
 
+Python 示例：
+
+```python
+server = sandbox.commands.run(
+    "python3 -m http.server 8000",
+    background=True,
+)
+
+host = sandbox.get_host(8000)
+print(f"https://{host}")
+```
+
 ## 使用建议
 
 如果服务启动步骤属于每次沙箱都必须执行的初始化逻辑，可以先把依赖安装前置到模板，再在创建沙箱后用后台命令启动服务。模板级启动与就绪命令是否完全兼容，需要以实际 SDK 与构建结果验证为准。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/06.基础镜像.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/06.基础镜像.md
@@ -31,7 +31,24 @@ build = Template.build(
 print(build.template_id)
 ```
 
+TypeScript 示例：
+
+```typescript
+import { Template } from "e2b";
+
+const build = await Template.build(
+  Template().fromImage(process.env.FROM_IMAGE),
+  `agent-runtime-${Date.now()}`,
+  {
+    apiKey: process.env.E2B_API_KEY,
+    apiUrl: process.env.E2B_API_URL,
+    domain: process.env.E2B_DOMAIN,
+  },
+);
+
+console.log(build.templateId);
+```
+
 ## 使用建议
 
 基础镜像应尽量稳定、可追溯。生产环境建议使用明确版本号或 digest，避免使用会漂移的 `latest`。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/07.模板名称.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/07.模板名称.md
@@ -22,7 +22,17 @@ const sandbox = await Sandbox.create("agent-python313-20260704", {
 });
 ```
 
+Python 示例：
+
+```python
+sandbox = Sandbox.create(
+    template="agent-python313-20260704",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+```
+
 ## 使用建议
 
 生产环境不要覆盖正在使用的模板。推荐创建新模板、完成验证、再切换业务引用。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/08.标签与版本.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/08.标签与版本.md
@@ -26,6 +26,31 @@ const tags = await Template.getTags("agent-python313-20260704", {
 console.log(tags);
 ```
 
+Python 示例：
+
+```python
+import os
+
+from e2b import Template
+
+Template.assign_tags(
+    "agent-python313-20260704",
+    ["staging", "v1"],
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+tags = Template.get_tags(
+    "agent-python313-20260704",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+print(tags)
+```
+
 ## 移除标签
 
 ```typescript
@@ -36,7 +61,18 @@ await Template.removeTags("agent-python313-20260704", "staging", {
 });
 ```
 
+Python 示例：
+
+```python
+Template.remove_tags(
+    "agent-python313-20260704",
+    "staging",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+```
+
 ## 使用建议
 
 标签适合表达“阶段”和“版本”，模板名称适合表达“运行环境”。不要把复杂发布规则完全塞进标签，生产切换仍应由业务系统或发布系统控制。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/09.用户与工作目录.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/09.用户与工作目录.md
@@ -9,6 +9,13 @@ const result = await sandbox.commands.run("whoami && pwd");
 console.log(result.stdout);
 ```
 
+Python 示例：
+
+```python
+result = sandbox.commands.run("whoami && pwd")
+print(result.stdout)
+```
+
 ## 指定命令工作目录
 
 ```typescript
@@ -22,9 +29,22 @@ const result = await sandbox.commands.run("python3 main.py", {
 console.log(result.stdout.trim());
 ```
 
+Python 示例：
+
+```python
+sandbox.files.make_dir("/tmp/project")
+sandbox.files.write("/tmp/project/main.py", "print('hello')\n")
+
+result = sandbox.commands.run(
+    "python3 main.py",
+    cwd="/tmp/project",
+)
+
+print(result.stdout.strip())
+```
+
 ## 使用建议
 
 - 模板构建时固定常用工具和依赖。
 - 任务运行时使用明确的 `cwd`。
 - 不要假设所有镜像都有相同默认用户、HOME 目录和权限。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/12.错误处理.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/12.错误处理.md
@@ -22,6 +22,29 @@ except TemplateError as error:
     raise
 ```
 
+TypeScript 示例：
+
+```typescript
+import { Template, TemplateError } from "e2b";
+
+try {
+  const build = await Template.build(
+    Template().fromImage(process.env.FROM_IMAGE),
+    "agent-runtime",
+    {
+      apiKey: process.env.E2B_API_KEY,
+      apiUrl: process.env.E2B_API_URL,
+      domain: process.env.E2B_DOMAIN,
+    },
+  );
+} catch (error) {
+  if (error instanceof TemplateError) {
+    console.error("template build failed:", error);
+  }
+  throw error;
+}
+```
+
 ## 排查顺序
 
 - 镜像地址是否使用 VPC 内网域名。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/02.运行代码.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/02.运行代码.md
@@ -19,6 +19,18 @@ sandbox = Sandbox.create(
 )
 ```
 
+TypeScript 示例：
+
+```typescript
+import { Sandbox } from "@e2b/code-interpreter";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
+```
+
 ## 执行 Python 代码
 
 ```python
@@ -35,6 +47,22 @@ print(stdout.strip())
 print(execution.text)
 ```
 
+TypeScript 示例：
+
+```typescript
+const execution = await sandbox.runCode(`
+import pandas as pd
+
+df = pd.DataFrame({"value": [1, 2, 3]})
+print(df)
+df["value"].sum()
+`);
+
+const stdout = execution.logs.stdout.join("");
+console.log(stdout.trim());
+console.log(execution.text);
+```
+
 `print()` 写入 stdout；最后一个裸表达式写入 `execution.text`，并可能在 `execution.results` 中生成结构化结果。
 
 ## 设置超时
@@ -49,6 +77,18 @@ execution = sandbox.run_code(
 )
 ```
 
+TypeScript 示例：
+
+```typescript
+const execution = await sandbox.runCode(
+  "import time; time.sleep(5); 42",
+  {
+    timeoutMs: 30_000,
+    requestTimeoutMs: 60_000,
+  },
+);
+```
+
 `timeout` 限制 Sandbox 内代码执行时长；`request_timeout` 限制 SDK 请求等待时长。具体参数名以当前语言 SDK 为准。
 
 ## 执行其他语言
@@ -60,6 +100,14 @@ execution = sandbox.run_code(
     'console.log("hello from js")',
     language="javascript",
 )
+```
+
+TypeScript 示例：
+
+```typescript
+const execution = await sandbox.runCode('console.log("hello from js")', {
+  language: "javascript",
+});
 ```
 
 更多语言示例参见[支持语言](07.支持语言.md)。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/04.输出结果.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/04.输出结果.md
@@ -30,11 +30,35 @@ print(stdout.strip())
 print(stderr.strip())
 ```
 
+TypeScript 示例：
+
+```typescript
+const execution = await sandbox.runCode(`
+import sys
+
+print("hello")
+print("warning", file=sys.stderr)
+`);
+
+const stdout = execution.logs.stdout.join("");
+const stderr = execution.logs.stderr.join("");
+
+console.log(stdout.trim());
+console.log(stderr.trim());
+```
+
 ## 读取表达式结果
 
 ```python
 execution = sandbox.run_code("1 + 1")
 print(execution.text)
+```
+
+TypeScript 示例：
+
+```typescript
+const execution = await sandbox.runCode("1 + 1");
+console.log(execution.text);
 ```
 
 `execution.text` 适合展示简单文本结果。表格可从 `execution.results` 中读取；图表应保存为文件后通过 Filesystem 取回。
@@ -54,6 +78,23 @@ for result in execution.results:
         print(result.text)
 ```
 
+TypeScript 示例：
+
+```typescript
+const execution = await sandbox.runCode(`
+import pandas as pd
+
+df = pd.DataFrame({"month": ["2026-01", "2026-02"], "revenue": [120, 180]})
+df
+`);
+
+for (const result of execution.results) {
+  if (result.text) {
+    console.log(result.text);
+  }
+}
+```
+
 不同 SDK 版本对 `Result` 对象的字段暴露方式可能不同。接入时应先打印一次 `execution.results`，确认当前 SDK 返回的字段名。
 
 ## 处理错误
@@ -65,6 +106,18 @@ if execution.error:
     print(execution.error.name)
     print(execution.error.value)
     print(execution.error.traceback)
+```
+
+TypeScript 示例：
+
+```typescript
+const execution = await sandbox.runCode("raise ValueError('bad input')");
+
+if (execution.error) {
+  console.log(execution.error.name);
+  console.log(execution.error.value);
+  console.log(execution.error.traceback);
+}
 ```
 
 ## 使用建议

--- a/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/05.数据分析.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/05.数据分析.md
@@ -53,12 +53,63 @@ finally:
     sandbox.kill()
 ```
 
+TypeScript 示例：
+
+```typescript
+import { Sandbox } from "@e2b/code-interpreter";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
+
+try {
+  await sandbox.files.write(
+    "/tmp/sales.csv",
+    "month,revenue\n2026-01,120\n2026-02,180\n2026-03,160\n",
+  );
+
+  const execution = await sandbox.runCode(`
+import pandas as pd
+
+df = pd.read_csv("/tmp/sales.csv")
+print(df)
+df["revenue"].sum()
+`, {
+    timeoutMs: 30_000,
+    requestTimeoutMs: 60_000,
+  });
+
+  if (execution.error) {
+    throw new Error(`${execution.error.name}: ${execution.error.value}`);
+  }
+
+  console.log("stdout:");
+  console.log(execution.logs.stdout.join("").trim());
+  console.log("stderr:");
+  console.log(execution.logs.stderr.join("").trim());
+  console.log("text:");
+  console.log(execution.text);
+} finally {
+  await sandbox.kill();
+}
+```
+
 ## 生成图表文件
 
 ```python
 sandbox.run_code("""import matplotlib.pyplot as plt; plt.plot([1, 2, 3], [120, 180, 160]); plt.title("Revenue"); plt.savefig("/tmp/revenue.png")""")
 
 content = sandbox.files.read("/tmp/revenue.png", format="bytes")
+```
+
+TypeScript 示例：
+
+```typescript
+await sandbox.runCode(`import matplotlib.pyplot as plt; plt.plot([1, 2, 3], [120, 180, 160]); plt.title("Revenue"); plt.savefig("/tmp/revenue.png")`);
+
+const content = await sandbox.files.read("/tmp/revenue.png", { format: "bytes" });
 ```
 
 云沙箱当前只支持文件降级方案。图表细节参见[图表与可视化](08.图表与可视化.md)。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/06.流式输出.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/06.流式输出.md
@@ -28,6 +28,24 @@ print("done")
 
 Python SDK 使用 `on_stdout` 和 `on_stderr`。回调参数是输出片段，通常包含内容、是否为错误输出和时间戳。不要假设一次回调对应一整行业务日志。
 
+```python
+sandbox.run_code(
+    """
+import sys
+import time
+
+print("start")
+time.sleep(3)
+print("warning", file=sys.stderr)
+time.sleep(3)
+print("done")
+""",
+    on_stdout=lambda data: print("stdout:", data),
+    on_stderr=lambda data: print("stderr:", data),
+    on_error=lambda error: print("error:", error),
+)
+```
+
 ## 富结果
 
 表格、文本等富结果也可以通过回调提前接收。图表请写入文件后通过 Filesystem 取回。
@@ -47,6 +65,18 @@ df
 ```
 
 Python SDK 使用对应的 snake_case 回调参数，具体参数名以当前 SDK 版本为准。
+
+```python
+sandbox.run_code(
+    """
+import pandas as pd
+
+df = pd.DataFrame({"value": [1, 2, 3]})
+df
+""",
+    on_result=lambda result: print("result:", result),
+)
+```
 
 ## 使用建议
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/07.支持语言.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/07.支持语言.md
@@ -11,6 +11,13 @@ execution = sandbox.run_code('print("Hello, world!")')
 print("".join(execution.logs.stdout or []).strip())
 ```
 
+TypeScript 示例：
+
+```typescript
+const execution = await sandbox.runCode('print("Hello, world!")');
+console.log(execution.logs.stdout.join("").trim());
+```
+
 ## JavaScript 和 TypeScript
 
 JavaScript 使用 `javascript` 或 `js`，TypeScript 使用 `typescript` 或 `ts`：
@@ -25,6 +32,18 @@ console.log(value)
 )
 ```
 
+TypeScript SDK 中使用同名 `language` 选项：
+
+```typescript
+const execution = await sandbox.runCode(
+  `
+const value = await Promise.resolve(42)
+console.log(value)
+`,
+  { language: "typescript" },
+);
+```
+
 E2B 官方文档说明 TypeScript 支持 top-level await、ESM-style import 和 Promise 自动解析。云沙箱接入时应先验证模板内 Node.js 版本和依赖安装能力。
 
 ## Bash
@@ -33,6 +52,12 @@ E2B 官方文档说明 TypeScript 支持 top-level await、ESM-style import 和 
 
 ```python
 sandbox.run_code('echo "Hello from Bash"', language="bash")
+```
+
+TypeScript 示例：
+
+```typescript
+await sandbox.runCode('echo "Hello from Bash"', { language: "bash" });
 ```
 
 ## 选择建议

--- a/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/08.图表与可视化.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/05.Code Interpreter/08.图表与可视化.md
@@ -10,10 +10,22 @@
 sandbox.run_code("""import matplotlib.pyplot as plt; plt.plot([1, 2, 3], [1, 4, 9]);plt.savefig("/tmp/chart.png")""")
 ```
 
+TypeScript 示例：
+
+```typescript
+await sandbox.runCode(`import matplotlib.pyplot as plt; plt.plot([1, 2, 3], [1, 4, 9]); plt.savefig("/tmp/chart.png")`);
+```
+
 随后读取文件内容：
 
 ```python
 content = sandbox.files.read("/tmp/chart.png", format="bytes")
+```
+
+TypeScript 示例：
+
+```typescript
+const content = await sandbox.files.read("/tmp/chart.png", { format: "bytes" });
 ```
 
 也可以用上传下载地址把图片交给浏览器或下游系统：
@@ -22,12 +34,24 @@ content = sandbox.files.read("/tmp/chart.png", format="bytes")
 download_url = sandbox.download_url("/tmp/chart.png")
 ```
 
+TypeScript 示例：
+
+```typescript
+const downloadUrl = await sandbox.downloadUrl("/tmp/chart.png");
+```
+
 ## 生成多张图
 
 多张图应使用稳定文件名，避免覆盖：
 
 ```python
 sandbox.run_code("""import matplotlib.pyplot as plt; plt.figure(); plt.plot([1, 2, 3]); plt.savefig("/tmp/chart-1.png"); plt.figure(); plt.bar(["A", "B"], [10, 20]); plt.savefig("/tmp/chart-2.png")""")
+```
+
+TypeScript 示例：
+
+```typescript
+await sandbox.runCode(`import matplotlib.pyplot as plt; plt.figure(); plt.plot([1, 2, 3]); plt.savefig("/tmp/chart-1.png"); plt.figure(); plt.bar(["A", "B"], [10, 20]); plt.savefig("/tmp/chart-2.png")`);
 ```
 
 然后分别读取或下载 `/tmp/chart-1.png` 和 `/tmp/chart-2.png`。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.Network/01.概览.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.Network/01.概览.md
@@ -19,6 +19,20 @@ console.log(`https://${host}`);
 await sandbox.commands.kill(server.pid);
 ```
 
+Python 示例：
+
+```python
+server = sandbox.commands.run(
+    "python3 -m http.server 8000",
+    background=True,
+)
+
+host = sandbox.get_host(8000)
+print(f"https://{host}")
+
+sandbox.commands.kill(server.pid)
+```
+
 ## 能力边界
 
 当前功能说明只把公网访问地址作为正式兼容能力展开。E2B 的网络访问控制和代理隧道能力，不应直接照搬到云沙箱接入路径。自定义域名属于 FC Extensions 能力，参见[自定义域名](../07.FC%20Extensions/03.自定义域名.md)。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.Network/02.访问地址.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.Network/02.访问地址.md
@@ -12,6 +12,13 @@ print(f"sandbox_domain: {sandbox.sandbox_domain}")
 print(f"envd_api_url: {sandbox.envd_api_url}")
 ```
 
+TypeScript 示例：
+
+```typescript
+console.log(`sandbox_id: ${sandbox.sandboxId}`);
+console.log(`sandbox_domain: ${sandbox.sandboxDomain}`);
+```
+
 ## 使用建议
 
 - 业务访问 Sandbox 端口时，优先使用 `sandbox.getHost(port)`。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.Network/03.公网访问.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.Network/03.公网访问.md
@@ -33,6 +33,39 @@ try {
 }
 ```
 
+Python 示例：
+
+```python
+import os
+import urllib.request
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    process = sandbox.commands.run(
+        "python3 -m http.server 8000",
+        background=True,
+    )
+
+    host = sandbox.get_host(8000)
+    url = f"https://{host}"
+    print(url)
+
+    with urllib.request.urlopen(url, timeout=10) as response:
+        print(response.read().decode())
+
+    process.kill()
+finally:
+    sandbox.kill()
+```
+
 ## 注意事项
 
 - 调用 `getHost(port)` 前，需要确保 Sandbox 内已有服务监听对应端口。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.Network/04.Sandbox 公网 URL.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.Network/04.Sandbox 公网 URL.md
@@ -17,9 +17,24 @@ console.log(url);
 await sandbox.commands.kill(handle.pid);
 ```
 
+Python 示例：
+
+```python
+handle = sandbox.commands.run(
+    "python3 -m http.server 8000",
+    background=True,
+)
+
+host = sandbox.get_host(8000)
+url = f"https://{host}"
+
+print(url)
+
+sandbox.commands.kill(handle.pid)
+```
+
 ## 使用建议
 
 - 服务必须监听对应端口，否则访问地址无法正常响应。
 - 长时间运行的服务应使用后台命令，并保存进程 `pid`。
 - 访问地址适合临时服务预览，不建议作为长期生产域名。
-

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC Extensions/02.VPC 网络配置.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC Extensions/02.VPC 网络配置.md
@@ -54,6 +54,44 @@ PY`,
 }
 ```
 
+Python 示例：
+
+```python
+import os
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    endpoint = os.environ["INTERNAL_API_ENDPOINT"]
+    result = sandbox.commands.run(
+        """
+python3 - <<'PY'
+import os
+import urllib.request
+
+url = os.environ["INTERNAL_API_ENDPOINT"]
+with urllib.request.urlopen(url, timeout=5) as response:
+    print(response.status)
+PY
+""",
+        envs={
+            "INTERNAL_API_ENDPOINT": endpoint,
+        },
+        timeout=10,
+    )
+
+    print(result.stdout.strip())
+finally:
+    sandbox.kill()
+```
+
 ## 常见配置项
 
 - VPC：Sandbox 需要访问的专有网络。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC Extensions/03.自定义域名.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC Extensions/03.自定义域名.md
@@ -105,6 +105,22 @@ const host = sandbox.getHost(8000);
 console.log(`https://${host}`);
 ```
 
+Python 示例：
+
+```python
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url="https://api.example.com",
+    domain="example.com",
+)
+
+host = sandbox.get_host(8000)
+print(f"https://{host}")
+```
+
 如果沙箱 ID 为 `sandbox-id`，访问端口为 `8000`，SDK 返回的访问地址形如：
 
 ```text

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC Extensions/05.监控与日志.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC Extensions/05.监控与日志.md
@@ -60,6 +60,48 @@ try {
 }
 ```
 
+Python 示例：
+
+```python
+import json
+import os
+import uuid
+
+from e2b import Sandbox
+
+task_id = str(uuid.uuid4())
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    metadata={
+        "taskId": task_id,
+    },
+)
+
+try:
+    print(json.dumps({
+        "event": "sandbox_created",
+        "taskId": task_id,
+        "sandboxId": sandbox.sandbox_id,
+    }))
+
+    result = sandbox.commands.run("python3 -V", timeout=30)
+
+    print(json.dumps({
+        "event": "command_finished",
+        "taskId": task_id,
+        "sandboxId": sandbox.sandbox_id,
+        "exitCode": result.exit_code,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }))
+finally:
+    sandbox.kill()
+```
+
 ## 输出结构化日志
 
 配置日志采集后，建议输出结构化日志，便于在日志服务中按字段检索。
@@ -92,6 +134,38 @@ PY`,
 );
 
 console.log(result.stdout);
+```
+
+Python 示例：
+
+```python
+result = sandbox.commands.run(
+    """
+python3 - <<'PY'
+import json
+import os
+import time
+
+task_id = os.environ["TASK_ID"]
+print(json.dumps({
+    "event": "task_started",
+    "taskId": task_id,
+    "ts": int(time.time()),
+}), flush=True)
+print(json.dumps({
+    "event": "task_finished",
+    "taskId": task_id,
+    "ts": int(time.time()),
+}), flush=True)
+PY
+""",
+    envs={
+        "TASK_ID": task_id,
+    },
+    timeout=30,
+)
+
+print(result.stdout)
 ```
 
 ## 常见观测对象

--- a/docs/zh-CN/01.云沙箱/04.功能说明/08.CLI/01.安装.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/08.CLI/01.安装.md
@@ -28,8 +28,8 @@ E2B CLI 使用 `E2B_API_KEY` 完成认证。接入云沙箱时，还需要配置
 
 ```bash
 export E2B_API_KEY="<your-api-key>"
-export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 ```
 
 `E2B_ACCESS_TOKEN` 是 E2B 已废弃的旧认证变量。新版本 CLI 应使用 `E2B_API_KEY`，不要在新接入流程中依赖 `E2B_ACCESS_TOKEN`。
@@ -46,7 +46,7 @@ e2b sandbox list
 
 - API Key 是否按[创建 API Key](../../01.开始使用/02.创建%20API%20Key.md)创建。
 - API Key 是否处于启用状态且未过期。
-- `E2B_API_URL` 是否为 `https://api.<region>.e2b.fc.aliyuncs.com`。
-- `E2B_DOMAIN` 是否为 `<region>.e2b.fc.aliyuncs.com`。
+- `E2B_API_URL` 是否为 `https://api.cn-beijing.e2b.fc.aliyuncs.com`。
+- `E2B_DOMAIN` 是否为 `cn-beijing.e2b.fc.aliyuncs.com`。
 - E2B CLI 版本是否支持 `E2B_API_KEY` 认证。
 - 当前账号是否具备函数计算相关操作权限。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/08.CLI/02.认证.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/08.CLI/02.认证.md
@@ -8,8 +8,8 @@ API Key 的创建和管理方式参见[创建 API Key](../../01.开始使用/02.
 
 ```bash
 export E2B_API_KEY="<your-api-key>"
-export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 ```
 
 `E2B_ACCESS_TOKEN` 是 E2B 已废弃的旧认证变量。新版本 E2B CLI 应使用 `E2B_API_KEY`，不要在新接入流程中依赖 `E2B_ACCESS_TOKEN`。
@@ -23,6 +23,6 @@ e2b sandbox list
 如果认证失败，请检查：
 
 - API Key 是否按[创建 API Key](../../01.开始使用/02.创建%20API%20Key.md)创建。
-- `E2B_API_URL` 是否包含 `https://api.<region>.e2b.fc.aliyuncs.com`。
-- `E2B_DOMAIN` 是否为 `<region>.e2b.fc.aliyuncs.com`。
+- `E2B_API_URL` 是否包含 `https://api.cn-beijing.e2b.fc.aliyuncs.com`。
+- `E2B_DOMAIN` 是否为 `cn-beijing.e2b.fc.aliyuncs.com`。
 - 当前账号是否具备函数计算相关操作权限。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/08.CLI/04.连接沙箱.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/08.CLI/04.连接沙箱.md
@@ -25,3 +25,14 @@ const sandbox = await Sandbox.connect("<sandbox-id>", {
   domain: process.env.E2B_DOMAIN,
 });
 ```
+
+Python 示例：
+
+```python
+sandbox = Sandbox.connect(
+    "<sandbox-id>",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+```

--- a/docs/zh-CN/01.云沙箱/04.功能说明/08.CLI/08.执行命令.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/08.CLI/08.执行命令.md
@@ -28,3 +28,10 @@ e2b sandbox exec --env NODE_ENV=production --env DEBUG=true <sandbox-id> node ap
 const result = await sandbox.commands.run("echo hello");
 console.log(result.stdout.trim());
 ```
+
+Python 示例：
+
+```python
+result = sandbox.commands.run("echo hello")
+print(result.stdout.strip())
+```

--- a/docs/zh-CN/01.云沙箱/04.功能说明/14.Migration/01.从 E2B 迁移.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/14.Migration/01.从 E2B 迁移.md
@@ -6,8 +6,8 @@
 
 ```bash
 export E2B_API_KEY="<your-api-key>"
-export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
-export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.cn-beijing.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="cn-beijing.e2b.fc.aliyuncs.com"
 ```
 
 ## 优先验证的能力


### PR DESCRIPTION
## Summary
- Add paired Python and TypeScript examples across zh-CN and en-US FC Agent Sandbox feature docs
- Standardize examples on the Beijing E2B endpoint configuration
- Sync advanced template registry configuration header guidance to English docs

## Validation
- Ran live Python and JavaScript smoke tests from /Users/xl/Downloads/helloworld against the Beijing endpoint
- Checked Markdown code fences in zh-CN and en-US feature docs
- Checked SDK example coverage so docs with SDK examples include both Python and TypeScript
- Checked staged diff whitespace and verified no provided API key was written into docs