### PR TITLE
docs(sandbox): update template name prefix examples

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/06.Base Images.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/06.Base Images.md
@@ -24,7 +24,7 @@ connection = {
 
 build = Template.build(
     Template().from_image(os.environ["FROM_IMAGE"]),
-    name=f"agent-runtime-{int(time.time())}",
+    name=f"my-template-{int(time.time())}",
     **connection,
 )
 
@@ -38,7 +38,7 @@ import { Template } from "e2b";
 
 const build = await Template.build(
   Template().fromImage(process.env.FROM_IMAGE),
-  `agent-runtime-${Date.now()}`,
+  `my-template-${Date.now()}`,
   {
     apiKey: process.env.E2B_API_KEY,
     apiUrl: process.env.E2B_API_URL,

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/06.基础镜像.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.Templates/06.基础镜像.md
@@ -24,7 +24,7 @@ connection = {
 
 build = Template.build(
     Template().from_image(os.environ["FROM_IMAGE"]),
-    name=f"agent-runtime-{int(time.time())}",
+    name=f"my-template-{int(time.time())}",
     **connection,
 )
 
@@ -38,7 +38,7 @@ import { Template } from "e2b";
 
 const build = await Template.build(
   Template().fromImage(process.env.FROM_IMAGE),
-  `agent-runtime-${Date.now()}`,
+  `my-template-${Date.now()}`,
   {
     apiKey: process.env.E2B_API_KEY,
     apiUrl: process.env.E2B_API_URL,


### PR DESCRIPTION
## Summary
- Replace `agent-runtime-` with `my-template-` in FC Agent Sandbox base image examples
- Keep English and Chinese docs consistent

## Verification
- `rg -n --hidden --glob '!.git/**' "agent-runtime-" .` returns no matches
- `rg -n --hidden --glob '!.git/**' "my-template-" docs/en-US docs/zh-CN` shows the expected four example lines