### PR TITLE
docs(filesystem): 优化 Filesystem 文档表述

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/04.Filesystem/03.Upload and Download Files.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/04.Filesystem/03.Upload and Download Files.md
@@ -2,6 +2,23 @@
 
 Upload and download URLs are suitable for browser-direct uploads, handing result files to environments that do not hold SDK credentials, or passing files to downstream systems. For small files, binary content, streams, and agent-generated code, prefer `sandbox.files.write()` and `sandbox.files.read()`.
 
+> **Note**: If you want to upload or download files by using URLs returned by `sandbox.downloadUrl()` and `sandbox.uploadUrl()`, make sure that you explicitly set `secure=false` when creating the sandbox. Otherwise, uploading and downloading files through these URLs still requires the caller to send `X-Access-Token`.
+
+Python example:
+
+```python
+sandbox = Sandbox.create(..., secure=False)
+```
+
+TypeScript example:
+
+```typescript
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  ...,
+  secure: false,
+});
+```
+
 ## Generate a download URL
 
 When a file has already been generated inside the sandbox, call `sandbox.downloadUrl(path)` to get a download URL, and then hand the file to the user or a downstream system from your application.
@@ -26,7 +43,7 @@ console.log(downloadUrl);
 
 ## Generate an upload URL
 
-When you need to upload a file into the sandbox from a browser or another unauthenticated environment, first call `sandbox.uploadUrl(path)` to get an upload URL, and then post the file to that URL as `multipart/form-data`.
+When you need to upload a file into the sandbox from a browser or another environment without SDK credentials, first call `sandbox.uploadUrl(path)` to get an upload URL, and then post the file to that URL as `multipart/form-data`.
 
 Python example:
 
@@ -83,57 +100,10 @@ const result = await sandbox.commands.run("python3 - <<'PY'\nfrom pathlib import
 console.log(result.stdout.trim());
 ```
 
-## Secure access
-
-If an upload or download URL is exposed to a browser, end user, or third-party system, create a secure sandbox and keep the URL lifetime short.
-
-Python example:
-
-```python
-import os
-
-from e2b import Sandbox
-
-sandbox = Sandbox.create(
-    template="code-interpreter-v1",
-    api_key=os.environ["E2B_API_KEY"],
-    api_url=os.environ["E2B_API_URL"],
-    domain=os.environ["E2B_DOMAIN"],
-    secure=True,
-)
-
-download_url = sandbox.download_url(
-    "/tmp/result.txt",
-    use_signature_expiration=10_000,
-)
-
-upload_url = sandbox.upload_url(
-    "/tmp/input.csv",
-    use_signature_expiration=10_000,
-)
-```
-
-TypeScript example:
-
-```typescript
-const sandbox = await Sandbox.create("code-interpreter-v1", {
-  apiKey: process.env.E2B_API_KEY,
-  apiUrl: process.env.E2B_API_URL,
-  domain: process.env.E2B_DOMAIN,
-  secure: true,
-});
-
-const downloadUrl = await sandbox.downloadUrl("/tmp/result.txt", {
-  useSignatureExpiration: 10_000,
-});
-
-const uploadUrl = await sandbox.uploadUrl("/tmp/input.csv", {
-  useSignatureExpiration: 10_000,
-});
-```
-
 ## Notes
 
+- When handing URLs returned by `downloadUrl(path)` and `uploadUrl(path)` directly to environments without SDK credentials, use a sandbox created with `secure=false`.
+- `secure=false` reduces the access protection on sandbox endpoints. Control the sandbox lifetime, file paths, and data sensitivity accordingly.
 - `downloadUrl(path)` and `uploadUrl(path)` generate access URLs for the specified path, so confirm that the path matches your application expectations before use.
 - Do not write upload or download URLs that expose sensitive data into logs or share them with unrelated users.
 - After a large upload, use `sandbox.files.exists()` or a command check to verify that the file is readable.
@@ -142,5 +112,5 @@ const uploadUrl = await sandbox.uploadUrl("/tmp/input.csv", {
 ## Selection guidance
 
 - Small files, text files, binary content, streams, and agent-generated code: use `sandbox.files.write()` and `sandbox.files.read()`.
-- Browser-direct uploads, downloading result files, or handing files to environments without SDK credentials: use `sandbox.uploadUrl()` and `sandbox.downloadUrl()`.
+- Browser-direct uploads, downloading result files, or handing files to environments without SDK credentials: use `sandbox.uploadUrl()` and `sandbox.downloadUrl()`, and create the sandbox with `secure=false`.
 - Directory traversal, renaming, and deletion: use the Filesystem API.

--- a/docs/zh-CN/01.云沙箱/04.功能说明/04.文件系统/03.上传和下载文件.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/04.文件系统/03.上传和下载文件.md
@@ -2,6 +2,23 @@
 
 上传和下载地址适合浏览器直传、把结果文件交给未持有 SDK 鉴权信息的环境，或把文件交给后续系统处理。小文件、二进制内容、流式内容和 Agent 生成代码优先使用 `sandbox.files.write()` 和 `sandbox.files.read()`。
 
+> **注意**：如果要使用 `sandbox.downloadUrl()` 和 `sandbox.uploadUrl()` 返回的 URL 上传和下载文件，确保在创建 Sandbox 时显式设置了 `secure=false`。否则，通过 URL 上传和下载文件仍需要请求方携带 `X-Access-Token`。
+
+Python 示例：
+
+```python
+sandbox = Sandbox.create(..., secure=False)
+```
+
+TypeScript 示例：
+
+```typescript
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  ...,
+  secure: false,
+});
+```
+
 ## 生成下载地址
 
 当 Sandbox 内已经生成文件时，可以通过 `sandbox.downloadUrl(path)` 获取下载地址，再由业务侧把文件交给用户或后续系统处理。
@@ -26,7 +43,7 @@ console.log(downloadUrl);
 
 ## 生成上传地址
 
-需要从浏览器等未授权环境把文件上传到 Sandbox 时，可以先通过 `sandbox.uploadUrl(path)` 获取上传地址，再从业务侧以 `multipart/form-data` POST 到该地址。
+需要从浏览器等未持有 SDK 鉴权信息的环境把文件上传到 Sandbox 时，可以先通过 `sandbox.uploadUrl(path)` 获取上传地址，再从业务侧以 `multipart/form-data` POST 到该地址。
 
 Python 示例：
 
@@ -83,57 +100,10 @@ const result = await sandbox.commands.run("python3 - <<'PY'\nfrom pathlib import
 console.log(result.stdout.trim());
 ```
 
-## 安全访问
-
-如果上传或下载 URL 会暴露给浏览器、终端用户或第三方系统，应创建安全 Sandbox，并为 URL 设置较短有效期。
-
-Python 示例：
-
-```python
-import os
-
-from e2b import Sandbox
-
-sandbox = Sandbox.create(
-    template="code-interpreter-v1",
-    api_key=os.environ["E2B_API_KEY"],
-    api_url=os.environ["E2B_API_URL"],
-    domain=os.environ["E2B_DOMAIN"],
-    secure=True,
-)
-
-download_url = sandbox.download_url(
-    "/tmp/result.txt",
-    use_signature_expiration=10_000,
-)
-
-upload_url = sandbox.upload_url(
-    "/tmp/input.csv",
-    use_signature_expiration=10_000,
-)
-```
-
-TypeScript 示例：
-
-```typescript
-const sandbox = await Sandbox.create("code-interpreter-v1", {
-  apiKey: process.env.E2B_API_KEY,
-  apiUrl: process.env.E2B_API_URL,
-  domain: process.env.E2B_DOMAIN,
-  secure: true,
-});
-
-const downloadUrl = await sandbox.downloadUrl("/tmp/result.txt", {
-  useSignatureExpiration: 10_000,
-});
-
-const uploadUrl = await sandbox.uploadUrl("/tmp/input.csv", {
-  useSignatureExpiration: 10_000,
-});
-```
-
 ## 注意事项
 
+- 将 `downloadUrl(path)` 和 `uploadUrl(path)` 返回的地址交给未持有 SDK 鉴权信息的环境直接访问时，需要使用 `secure=false` 的 Sandbox。
+- `secure=false` 会降低 Sandbox 暴露端点的访问保护强度。请控制 Sandbox 生命周期、文件路径和数据敏感性。
 - `downloadUrl(path)` 和 `uploadUrl(path)` 生成的是指定路径的访问地址，使用前要确认路径符合业务预期。
 - 不要把包含敏感数据的上传、下载地址写入日志或暴露给无关用户。
 - 大文件上传后建议通过 `sandbox.files.exists()` 或命令检查文件是否可读。
@@ -142,5 +112,5 @@ const uploadUrl = await sandbox.uploadUrl("/tmp/input.csv", {
 ## 选择建议
 
 - 小文件、文本文件、二进制内容、流式内容和 Agent 生成代码：使用 `sandbox.files.write()` 和 `sandbox.files.read()`。
-- 浏览器直传、下载结果文件或把文件交给未持有 SDK 鉴权信息的环境：使用 `sandbox.uploadUrl()` 和 `sandbox.downloadUrl()`。
+- 浏览器直传、下载结果文件或把文件交给未持有 SDK 鉴权信息的环境：使用 `sandbox.uploadUrl()` 和 `sandbox.downloadUrl()`，并在创建 Sandbox 时设置 `secure=false`。
 - 目录遍历、重命名或删除：使用 Filesystem API。


### PR DESCRIPTION
- 明确 downloadUrl/uploadUrl 返回的 URL 需要 secure=false 的 Sandbox
- 删除误导性的 secure=true 安全访问章节
- 统一'未授权环境'为'未持有 SDK 鉴权信息的环境'
- 注意事项补充 secure=false 的安全风险提示
- 选择建议追加 secure=false 说明
- 中英文文档同步更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 更新了 Filesystem 的中英文“上传和下载文件”章节，涉及云沙箱（Cloud Sandbox）/FC Agent Sandbox 产品文档。

主要变更：
- 明确 `sandbox.uploadUrl()` 和 `sandbox.downloadUrl()` 返回的 URL 需配合 `secure=false` 的 Sandbox 使用。
- 删除原“安全访问”章节，改为“注意事项”，补充 `secure=false` 的安全风险及使用建议。
- 将“未授权环境”统一表述为“未持有 SDK 鉴权信息的环境”。
- 在“选择建议”中补充浏览器直传、下载结果及无 SDK 鉴权信息环境的适用方案。

本次未新增或删除页面，未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->