### PR TITLE
fix: templates、netWork、内置模版 and migration

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
@@ -33,7 +33,7 @@ from e2b import Sandbox
 sandbox = Sandbox.create(template="code-interpreter-v1")
 ```
 
-TypeScript example:
+**TypeScript**:
 
 ```typescript
 import { Sandbox } from "e2b";

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/01.Base Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates/01.Base Template.md
@@ -39,6 +39,8 @@ If you need code interpreter, browser automation, or a combination of both, plea
 
 When `template` is not explicitly specified, a base sandbox is created by default.
 
+**Python**:
+
 ```python
 from e2b import Sandbox
 
@@ -50,7 +52,7 @@ print(result.stdout)
 sbx.kill()
 ```
 
-TypeScript example:
+**Node.js**:
 
 ```typescript
 import { Sandbox } from "e2b";

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -47,6 +47,8 @@ E2B_DOMAIN=cn-beijing.e2b.fc.aliyuncs.com
 
 Run the script to build the image into a template and create a sandbox to verify:
 
+**Python**:
+
 ```python
 #!/usr/bin/env python3
 
@@ -100,7 +102,7 @@ finally:
     print("sandbox killed")
 ```
 
-TypeScript example:
+**TypeScript**:
 
 ```typescript
 import { Sandbox, Template, defaultBuildLogger } from "@e2b/code-interpreter";

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/04.User and Workdir.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/04.User and Workdir.md
@@ -2,14 +2,46 @@
 
 The user and working directory inside a template affect command execution, file permissions, and dependency installation paths. In agent scenarios, keep the working directory stable so commands do not rely on implicit paths.
 
+## Prerequisites
+
+**TypeScript**:
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+  timeoutMs: 300_000,
+});
+```
+
+**Python**:
+
+```python
+import os
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    timeout=300,
+)
+```
+
 ## Check the current user and directory
+
+**TypeScript**:
 
 ```typescript
 const result = await sandbox.commands.run("whoami && pwd");
 console.log(result.stdout);
 ```
 
-Python example:
+**Python**:
 
 ```python
 result = sandbox.commands.run("whoami && pwd")
@@ -17,6 +49,8 @@ print(result.stdout)
 ```
 
 ## Set the command working directory
+
+**TypeScript**:
 
 ```typescript
 await sandbox.files.makeDir("/tmp/project");
@@ -29,7 +63,7 @@ const result = await sandbox.commands.run("python3 main.py", {
 console.log(result.stdout.trim());
 ```
 
-Python example:
+**Python**:
 
 ```python
 sandbox.files.make_dir("/tmp/project")

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/05.Start and Ready Commands.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/05.Start and Ready Commands.md
@@ -2,7 +2,7 @@
 
 To run a long-lived process such as a web service in a sandbox, start it with a background command after creating the sandbox.
 
-Python example:
+**Python**:
 
 ```python
 server = sandbox.commands.run(
@@ -14,7 +14,7 @@ host = sandbox.get_host(8000)
 print(f"https://{host}")
 ```
 
-TypeScript example:
+**TypeScript**:
 
 ```typescript
 const server = await sandbox.commands.run("python3 -m http.server 8000", {

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/01.Overview.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/01.Overview.md
@@ -2,11 +2,43 @@
 
 Network is used to access services running inside the sandbox. The common pattern is to start an HTTP service in the sandbox and then call `sandbox.getHost(port)` to get a publicly accessible URL.
 
+## Prerequisites
+
+**TypeScript**:
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+  timeoutMs: 300_000,
+});
+```
+
+**Python**:
+
+```python
+import os
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    timeout=300,
+)
+```
+
 ## Basic workflow
 
 1. Start a service inside the sandbox and make it listen on a specific port.
 2. Call `sandbox.getHost(port)` to get the access host.
 3. Access that port over HTTPS or WebSocket.
+
+**TypeScript**:
 
 ```typescript
 const server = await sandbox.commands.run("python3 -m http.server 8000", {
@@ -19,7 +51,7 @@ console.log(`https://${host}`);
 await sandbox.commands.kill(server.pid);
 ```
 
-Python example:
+**Python**:
 
 ```python
 server = sandbox.commands.run(

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/02.Access URLs.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/02.Access URLs.md
@@ -6,13 +6,15 @@ Some examples print sandbox-related addresses such as `sandbox_domain` and `envd
 
 Custom template validation scripts include output like this:
 
+**Python**:
+
 ```python
 print(f"sandbox_id: {sandbox.sandbox_id}")
 print(f"sandbox_domain: {sandbox.sandbox_domain}")
 print(f"envd_api_url: {sandbox.envd_api_url}")
 ```
 
-TypeScript example:
+**TypeScript**:
 
 ```typescript
 console.log(`sandbox_id: ${sandbox.sandboxId}`);

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/03.Public Access.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/03.Public Access.md
@@ -4,7 +4,7 @@ Use `sandbox.getHost(port)` to get a public access URL for a specific port in th
 
 ## Start and access a service
 
-TypeScript example:
+**TypeScript**:
 
 ```typescript
 import { Sandbox } from "e2b";
@@ -33,7 +33,7 @@ try {
 }
 ```
 
-Python example:
+**Python**:
 
 ```python
 import os

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/04.Sandbox Public URL.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/04.Sandbox Public URL.md
@@ -2,7 +2,39 @@
 
 `sandbox.getHost(port)` gets the public host for a specific port in the sandbox. It is useful for previewing web applications, exposing temporary APIs, or connecting to debugging services in the sandbox.
 
+## Prerequisites
+
+**TypeScript**:
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+  timeoutMs: 300_000,
+});
+```
+
+**Python**:
+
+```python
+import os
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    timeout=300,
+)
+```
+
 ## Start a service and get its access URL
+
+**TypeScript**:
 
 ```typescript
 const handle = await sandbox.commands.run("python3 -m http.server 8000", {
@@ -17,7 +49,7 @@ console.log(url);
 await sandbox.commands.kill(handle.pid);
 ```
 
-Python example:
+**Python**:
 
 ```python
 handle = sandbox.commands.run(

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/01.Installation.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/01.Installation.md
@@ -24,7 +24,7 @@ e2b --version
 
 ## Configure connection parameters
 
-The E2B CLI authenticates with `E2B_API_KEY`. Create and manage the API key as described in [Create an API Key](../../01.Getting%20Started/02.Create%20an%20API%20Key.md).
+The E2B CLI authenticates with `E2B_API_KEY`. When connecting to FC Agent Sandbox, you also need to configure the API URL and Domain. Create and manage the API key as described in [Create an API Key](../../01.Getting%20Started/02.Create%20an%20API%20Key.md).
 
 ```bash
 export E2B_API_KEY="<your-api-key>"

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/02.Authentication.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/02.Authentication.md
@@ -2,6 +2,8 @@
 
 By default, the E2B CLI reads environment variables for authentication. When connecting to FC Agent Sandbox, configure the API key, API URL, and domain together.
 
+Create and manage the API key as described in [Create an API Key](../../01.Getting%20Started/02.Create%20an%20API%20Key.md).
+
 ## Environment Variables
 
 ```bash

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/08.Execute Commands.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/08.CLI/08.Execute Commands.md
@@ -24,12 +24,14 @@ e2b sandbox exec --env NODE_ENV=production --env DEBUG=true <sandbox-id> node ap
 
 If you need to execute commands in server-side code, use the SDK Commands API:
 
+**TypeScript**:
+
 ```typescript
 const result = await sandbox.commands.run("echo hello");
 console.log(result.stdout.trim());
 ```
 
-Python example:
+**Python**:
 
 ```python
 result = sandbox.commands.run("echo hello")

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/02.内置模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/02.内置模板.md
@@ -33,13 +33,15 @@ e2b template list
 
 使用通用 `e2b` SDK 时，可通过 `template` 参数显式选择模板。SDK 会自动读取 `E2B_API_KEY`、`E2B_API_URL`、`E2B_DOMAIN` 环境变量。Python 示例：
 
+**Python 示例**：
+
 ```python
 from e2b import Sandbox
 
 sandbox = Sandbox.create(template="code-interpreter-v1")
 ```
 
-TypeScript 示例：
+**TypeScript 示例**：
 
 ```typescript
 import { Sandbox } from "e2b";

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/02.内置模板/01.base-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/02.内置模板/01.base-模板.md
@@ -39,6 +39,8 @@ base 模板的默认配置如下：
 
 未显式指定 `template` 时，默认创建 base 沙箱。
 
+**Python 示例**：
+
 ```python
 from e2b import Sandbox
 
@@ -50,7 +52,7 @@ print(result.stdout)
 sbx.kill()
 ```
 
-TypeScript 示例：
+**TypeScript 示例**：
 
 ```typescript
 import { Sandbox } from "e2b";

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
@@ -43,6 +43,8 @@ E2B_DOMAIN=cn-beijing.e2b.fc.aliyuncs.com
 
 运行脚本，将 image 构建为 template，并创建 sandbox 验证：
 
+**Python 示例**：
+
 ```python
 #!/usr/bin/env python3
 
@@ -96,7 +98,7 @@ finally:
     print("sandbox killed")
 ```
 
-TypeScript 示例：
+**TypeScript 示例**：
 
 ```typescript
 import { Sandbox, Template, defaultBuildLogger } from "@e2b/code-interpreter";

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/04.用户与工作目录.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/04.用户与工作目录.md
@@ -2,14 +2,46 @@
 
 模板中的用户和工作目录会影响命令执行、文件权限和依赖安装位置。Agent 场景中，建议保持工作目录稳定，避免每次执行命令都依赖隐式路径。
 
+## 前置条件
+
+**TypeScript 示例**：
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+  timeoutMs: 300_000,
+});
+```
+
+**Python 示例**：
+
+```python
+import os
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    timeout=300,
+)
+```
+
 ## 查看当前用户和目录
+
+**TypeScript 示例**：
 
 ```typescript
 const result = await sandbox.commands.run("whoami && pwd");
 console.log(result.stdout);
 ```
 
-Python 示例：
+**Python 示例**：
 
 ```python
 result = sandbox.commands.run("whoami && pwd")
@@ -17,6 +49,8 @@ print(result.stdout)
 ```
 
 ## 指定命令工作目录
+
+**TypeScript 示例**：
 
 ```typescript
 await sandbox.files.makeDir("/tmp/project");
@@ -29,7 +63,7 @@ const result = await sandbox.commands.run("python3 main.py", {
 console.log(result.stdout.trim());
 ```
 
-Python 示例：
+**Python 示例**：
 
 ```python
 sandbox.files.make_dir("/tmp/project")

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/05.启动与就绪命令.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/05.启动与就绪命令.md
@@ -2,7 +2,7 @@
 
 如需在沙箱中运行 Web 服务等常驻进程，可以在创建沙箱后通过后台命令启动。
 
-Python 示例：
+**Python 示例**：
 
 ```python
 server = sandbox.commands.run(
@@ -14,7 +14,7 @@ host = sandbox.get_host(8000)
 print(f"https://{host}")
 ```
 
-TypeScript 示例：
+**Typescript 示例**：
 
 ```typescript
 const server = await sandbox.commands.run("python3 -m http.server 8000", {

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/01.概览.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/01.概览.md
@@ -2,11 +2,43 @@
 
 Network 用于访问沙箱中运行的服务。常见做法是在沙箱内启动 HTTP 服务，再通过 `sandbox.getHost(port)` 获取公网可访问地址。
 
+## 前置条件
+
+**TypeScript 示例**：
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+  timeoutMs: 300_000,
+});
+```
+
+**Python 示例**：
+
+```python
+import os
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    timeout=300,
+)
+```
+
 ## 基本流程
 
 1. 在沙箱内启动服务，并监听指定端口。
 2. 调用 `sandbox.getHost(port)` 获取访问域名。
 3. 通过 HTTPS 或 WebSocket 访问该端口。
+
+**TypeScript 示例**：
 
 ```typescript
 const server = await sandbox.commands.run("python3 -m http.server 8000", {
@@ -19,7 +51,7 @@ console.log(`https://${host}`);
 await sandbox.commands.kill(server.pid);
 ```
 
-Python 示例：
+**Python 示例**：
 
 ```python
 server = sandbox.commands.run(

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/02.访问地址.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/02.访问地址.md
@@ -6,13 +6,15 @@
 
 自定义模板验证脚本中包含以下输出：
 
+**Python 示例**：
+
 ```python
 print(f"sandbox_id: {sandbox.sandbox_id}")
 print(f"sandbox_domain: {sandbox.sandbox_domain}")
 print(f"envd_api_url: {sandbox.envd_api_url}")
 ```
 
-TypeScript 示例：
+**TypeScript 示例**：
 
 ```typescript
 console.log(`sandbox_id: ${sandbox.sandboxId}`);

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/03.公网访问.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/03.公网访问.md
@@ -4,7 +4,7 @@
 
 ## 启动服务并访问
 
-TypeScript 示例：
+**TypeScript 示例**：
 
 ```typescript
 import { Sandbox } from "e2b";
@@ -33,7 +33,7 @@ try {
 }
 ```
 
-Python 示例：
+**Python 示例**：
 
 ```python
 import os

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/04.Sandbox 公网 URL.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/04.Sandbox 公网 URL.md
@@ -2,7 +2,39 @@
 
 `sandbox.getHost(port)` 用于获取沙箱内指定端口的公网访问域名。它适合预览 Web 应用、暴露临时 API 或连接沙箱中的调试服务。
 
+## 前置条件
+
+**TypeScript 示例**：
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+  timeoutMs: 300_000,
+});
+```
+
+**Python 示例**：
+
+```python
+import os
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+    timeout=300,
+)
+```
+
 ## 启动服务并获取访问地址
+
+**TypeScript 示例**：
 
 ```typescript
 const handle = await sandbox.commands.run("python3 -m http.server 8000", {
@@ -17,7 +49,7 @@ console.log(url);
 await sandbox.commands.kill(handle.pid);
 ```
 
-Python 示例：
+**Python 示例**：
 
 ```python
 handle = sandbox.commands.run(

--- a/docs/zh-CN/01.云沙箱/04.功能说明/08.命令行工具/08.执行命令.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/08.命令行工具/08.执行命令.md
@@ -24,12 +24,14 @@ e2b sandbox exec --env NODE_ENV=production --env DEBUG=true <sandbox-id> node ap
 
 如果需要在服务端代码中执行命令，请使用 SDK 的 Commands：
 
+**TypeScript 示例**：
+
 ```typescript
 const result = await sandbox.commands.run("echo hello");
 console.log(result.stdout.trim());
 ```
 
-Python 示例：
+**Python 示例**：
 
 ```python
 result = sandbox.commands.run("echo hello")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
本 PR 涉及 **云沙箱（FC Agent Sandbox）** 文档，主要覆盖：

- **模板（02.模板）**：模板概览、内置模板、定义模板、构建自定义镜像模板、基础镜像、启动与就绪命令、模板名称、用户与工作目录、错误处理、标签与版本等章节。调整/补全并统一 Python 与 TypeScript 示例的标题与代码结构（含部分模板快速入门示例从 Node.js 切换为 Python/TypeScript），并更新 All-in-One 模板默认地域与对应示例配置（由 `ap-southeast-1` 调整为 `cn-beijing`）。
- **网络（06.网络）**：网络概览、访问地址、公网访问、公网 URL 等章节，新增前置条件示例并补齐/统一示例代码展示（主要是 Python/TypeScript 示例完整性与标题规范化），同时调整示例展示内容的排版。
- **命令行工具（08.命令行工具/08.执行命令）**：对 Python/TypeScript 示例的标题与代码块边界进行版式对齐。
- **迁移（14.迁移）**：新增/补充对 E2B SDK v2 迁移指南与不兼容 V1 build 废弃的归属说明，避免云沙箱文档误复制迁移内容，并新增页面说明《「不兼容」V1 build 废弃》。
- **英文文档同步更新**：All-in-One Template 与 Base Template 两处模板文档的示例标题与默认地域配置等内容。

**新增/删除页面**：新增页面《「不兼容」V1 build 废弃》。其余为文档内容调整与示例/排版更新，未删除页面。  
**图片资源**：未改动图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->