### PR TITLE
docs: update Standard Input and Dynamic OSS Mounts documentation

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/03.Commands/06.Standard Input.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/03.Commands/06.Standard Input.md
@@ -27,7 +27,7 @@ handle = sandbox.commands.run(
 )
 
 sandbox.commands.send_stdin(handle.pid, "hello from stdin\n")
-sandbox.commands.closeStdin(handle.pid)
+sandbox.commands.close_stdin(handle.pid)
 
 result = handle.wait()
 print(result.stdout)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/04.Dynamic OSS Mounts.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/04.Dynamic OSS Mounts.md
@@ -169,7 +169,7 @@ mountPoints: [
 
 const sandbox = await Sandbox.create("code-interpreter-v1", {
     apiKey: apiKey,
-    timeout: 3000,
+    timeoutMs: 300_000,
     ...connOpts,
     metadata: {
         "fc.sandbox.storage.oss": JSON.stringify(ossConfig),
@@ -179,22 +179,6 @@ const sandbox = await Sandbox.create("code-interpreter-v1", {
 
 try {
 console.log(`Sandbox created: ${sandbox.sandboxId}`);
-
-// List the mount directory through the Filesystem API.
-const files = await sandbox.files.list(mountDir);
-console.log(files.map(f => f.name));
-
-// Write a file inside the Sandbox.
-const result = await sandbox.commands.run(
-    `python3 - <<'PY'\n` +
-    `from pathlib import Path\n` +
-    `path = Path('${mountDir}') / 'outputs' / 'result.txt'\n` +
-    `path.parent.mkdir(parents=True, exist_ok=True)\n` +
-    `path.write_text('sandbox task finished\\n', encoding='utf-8')\n` +
-    `print(path)\n` +
-    `PY`
-);
-console.log(result.stdout);
 
 const filesAfter = await sandbox.files.list(mountDir);
 console.log(`OSS files: ${filesAfter.map(f => f.name)}`);

--- a/docs/zh-CN/01.云沙箱/04.功能说明/03.命令/06.标准输入.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/03.命令/06.标准输入.md
@@ -29,7 +29,7 @@ handle = sandbox.commands.run(
 )
 
 sandbox.commands.send_stdin(handle.pid, "hello from stdin\n")
-sandbox.commands.closeStdin(handle.pid)
+sandbox.commands.close_stdin(handle.pid)
 
 result = handle.wait()
 print(result.stdout)

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/04.动态挂载 OSS.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/04.动态挂载 OSS.md
@@ -169,7 +169,7 @@ mountPoints: [
 
 const sandbox = await Sandbox.create("code-interpreter-v1", {
     apiKey: apiKey,
-    timeout: 3000,
+    timeoutMs: 300_000,
     ...connOpts,
     metadata: {
         "fc.sandbox.storage.oss": JSON.stringify(ossConfig),
@@ -179,22 +179,6 @@ const sandbox = await Sandbox.create("code-interpreter-v1", {
 
 try {
 console.log(`Sandbox created: ${sandbox.sandboxId}`);
-
-// 通过 Filesystem API 查看挂载目录
-const files = await sandbox.files.list(mountDir);
-console.log(files.map(f => f.name));
-
-// 在 Sandbox 内写入文件
-const result = await sandbox.commands.run(
-    `python3 - <<'PY'\n` +
-    `from pathlib import Path\n` +
-    `path = Path('${mountDir}') / 'outputs' / 'result.txt'\n` +
-    `path.parent.mkdir(parents=True, exist_ok=True)\n` +
-    `path.write_text('sandbox task finished\\n', encoding='utf-8')\n` +
-    `print(path)\n` +
-    `PY`
-);
-console.log(result.stdout);
 
 const filesAfter = await sandbox.files.list(mountDir);
 console.log(`OSS files: ${filesAfter.map(f => f.name)}`);


### PR DESCRIPTION
- Remove redundant usage examples from Dynamic OSS Mounts
- Fix formatting in Standard Input documentation (en/zh-CN)
- Clean up code examples in Dynamic OSS Mounts (en/zh-CN)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
本 PR 更新了 **FC Agent Sandbox（云沙箱）** 文档，涉及英文（en-US）与简体中文（zh-CN）两套内容，范围包括：

- **命令章节：标准输入（Standard Input／标准输入）**
  - 同步修正 TypeScript/Python 示例中关闭 stdin 的函数调用命名：`closeStdin` / `closeStdin(handle.pid)` 改为 `close_stdin(handle.pid)`，并调整对应代码排版。

- **功能扩展章节：动态 OSS 挂载（Dynamic OSS Mounts／动态挂载 OSS）**
  - 更新 `Sandbox.create` 超时配置参数：`timeout` 改为 `timeoutMs`（并在示例中调整数值）。
  - 精简 TypeScript 示例流程：删除了挂载后通过命令在挂载目录内写入 `result.txt`、输出 stdout 等冗余示例逻辑，保留对挂载目录的文件列表读取与结果输出，并在 `finally` 中销毁 Sandbox。

**页面增删**：仅修改既有文档页面，未新增或删除页面。  
**图片资源**：未改动图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->