### PR TITLE
docs: update SDK/CLI version requirements and install guides

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/01.Getting Started/03.Quickstarts/01.Use FC Agent Sandbox with the SDK.md
+++ b/docs/en-US/01.FC Agent Sandbox/01.Getting Started/03.Quickstarts/01.Use FC Agent Sandbox with the SDK.md
@@ -8,7 +8,7 @@ This guide walks you through creating your first FC Agent Sandbox with the E2B S
 - You have [created an API key](../02.Create%20an%20API%20Key.md) in the Function Compute console.
 - You have confirmed that FC Agent Sandbox is available in the target region and that your local network can access the service endpoint in that region.
 - For the Python example, Python 3.10 or later is installed.
-- For the TypeScript example, Node.js 18 or later is installed.
+- For the TypeScript example, Node.js 20.18.1 or later is installed.
 
 For SDK version requirements, supported regions, and endpoint rules, see [Usage Constraints](../04.Usage%20Constraints.md).
 
@@ -28,6 +28,12 @@ Replace `<region>` with the region where FC Agent Sandbox is deployed.
 
 Python:
 
+First, confirm that Python is version 3.10 or later:
+
+```bash
+python3 --version
+```
+
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
@@ -36,9 +42,15 @@ pip install e2b==2.31.0 e2b-code-interpreter==2.8.1
 
 TypeScript:
 
+First, confirm that Node.js is version 20.18.1 or later:
+
+```bash
+node --version
+```
+
 ```bash
 npm init -y
-npm install e2b@^2.31.0 @e2b/code-interpreter@^2.8.1 dotenv
+npm install e2b@^2.31.0 @e2b/code-interpreter@^2.6.1 dotenv
 npm install -D tsx typescript @types/node
 ```
 

--- a/docs/en-US/01.FC Agent Sandbox/01.Getting Started/03.Quickstarts/02.Use FC Agent Sandbox with the CLI.md
+++ b/docs/en-US/01.FC Agent Sandbox/01.Getting Started/03.Quickstarts/02.Use FC Agent Sandbox with the CLI.md
@@ -23,6 +23,12 @@ You can also install it with npm:
 npm i -g @e2b/cli
 ```
 
+After installation, check the version:
+
+```bash
+e2b --version
+```
+
 ## 2. Configure environment variables
 
 Configure the API key, API URL, and domain. For API key creation and management, see [Create an API Key](../02.Create%20an%20API%20Key.md).

--- a/docs/en-US/01.FC Agent Sandbox/01.Getting Started/04.Usage Constraints.md
+++ b/docs/en-US/01.FC Agent Sandbox/01.Getting Started/04.Usage Constraints.md
@@ -23,12 +23,20 @@ FC Agent Sandbox requires compatible E2B SDK and E2B CLI versions.
 
 The installation commands in this documentation reflect the versions validated for the corresponding examples. Different examples may be verified in different batches, so when you integrate the service, check both the installation commands and the capability boundaries documented in [E2B Compatibility](05.E2B%20Compatibility.md).
 
-Use the following SDK versions unless a specific example says otherwise:
+The Python quickstart is validated with these pinned versions:
 
 - `e2b==2.31.0`
 - `e2b-code-interpreter==2.8.1`
 
-To check your local CLI version, run:
+The Python SDK requires Python 3.10 or later. Before installation, check your local version:
+
+```bash
+python3 --version
+```
+
+The TypeScript quickstart uses `e2b@^2.31.0` and `@e2b/code-interpreter@^2.6.1` and requires Node.js 20.18.1 or later. `npm install` creates or updates a lockfile. Commit the lockfile in production projects and validate again after dependency upgrades.
+
+The CLI does not require a single pinned version. Use the latest compatible version, and check it after installation or an upgrade:
 
 ```bash
 e2b --version

--- a/docs/zh-CN/01.云沙箱/01.开始使用/03.快速入门/01.通过 SDK 使用云沙箱.md
+++ b/docs/zh-CN/01.云沙箱/01.开始使用/03.快速入门/01.通过 SDK 使用云沙箱.md
@@ -8,7 +8,7 @@
 - 已在函数计算控制台[创建 API Key](../02.创建%20API%20Key.md)。
 - 已确认目标地域支持云沙箱，并且本机网络可访问该地域的云沙箱服务。
 - 使用 Python 示例时，已安装 Python 3.10 或更高版本。
-- 使用 TypeScript 示例时，已安装 Node.js 18 或更高版本。
+- 使用 TypeScript 示例时，已安装 Node.js 20.18.1 或更高版本。
 
 SDK 版本要求、支持地域和 Endpoint 规则参见[使用约束](../04.使用约束.md)。
 
@@ -28,6 +28,11 @@ export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
 
 Python：
 
+先确认 Python 版本为 3.10 或更高版本：
+
+```bash
+python3 --version
+```
 
 ```bash
 python3 -m venv .venv
@@ -37,9 +42,15 @@ pip install e2b==2.31.0 e2b-code-interpreter==2.8.1
 
 TypeScript：
 
+先确认 Node.js 版本为 20.18.1 或更高版本：
+
+```bash
+node --version
+```
+
 ```bash
 npm init -y
-npm install e2b@^2.31.0 @e2b/code-interpreter@^2.8.1 dotenv
+npm install e2b@^2.31.0 @e2b/code-interpreter@^2.6.1 dotenv
 npm install -D tsx typescript @types/node
 ```
 

--- a/docs/zh-CN/01.云沙箱/01.开始使用/03.快速入门/02.通过 CLI 使用云沙箱.md
+++ b/docs/zh-CN/01.云沙箱/01.开始使用/03.快速入门/02.通过 CLI 使用云沙箱.md
@@ -23,6 +23,12 @@ brew install e2b
 npm i -g @e2b/cli
 ```
 
+安装后检查版本：
+
+```bash
+e2b --version
+```
+
 ## 2. 配置环境变量
 
 配置 API Key、API URL 和域名。API Key 的创建和管理方式参见[创建 API Key](../02.创建%20API%20Key.md)。

--- a/docs/zh-CN/01.云沙箱/01.开始使用/04.使用约束.md
+++ b/docs/zh-CN/01.云沙箱/01.开始使用/04.使用约束.md
@@ -23,12 +23,20 @@ export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
 
 本文档示例中的安装命令代表对应示例的验证版本。不同示例可能来自不同验证批次，接入时需要同时关注安装命令和[E2B 兼容说明](05.E2B%20兼容说明.md)中的能力边界。
 
-建议使用以下 SDK 版本：
+Python 快速入门已通过以下固定版本验证：
 
 - `e2b==2.31.0`
 - `e2b-code-interpreter==2.8.1`
 
-使用 CLI 时，可通过以下命令查看本机版本：
+Python SDK 要求 Python 3.10 或更高版本。安装前运行以下命令确认本机版本：
+
+```bash
+python3 --version
+```
+
+TypeScript 快速入门使用 `e2b@^2.31.0` 和 `@e2b/code-interpreter@^2.6.1`，要求 Node.js 20.18.1 或更高版本。`npm install` 会生成或更新 lockfile；生产项目应提交 lockfile，并在升级依赖后重新验证。
+
+CLI 不固定单一版本。使用最新兼容版本，并在安装或升级后运行以下命令确认版本：
 
 ```bash
 e2b --version

--- a/docs/zh-CN/01.云沙箱/09.服务支持/04.服务条款.md
+++ b/docs/zh-CN/01.云沙箱/09.服务支持/04.服务条款.md
@@ -1,3 +1,3 @@
 # 服务条款
 
-云沙箱当前沿用阿里云产品服务协议。服务条款请参见[阿里云产品服务协议](http://terms.aliyun.com/legal-agreement/terms/suit_bu1_ali_cloud/suit_bu1_ali_cloud201802281451_77479.html)。
+云沙箱当前沿用阿里云产品服务协议。服务条款请参见[阿里云产品服务协议](https://terms.aliyun.com/legal-agreement/terms/suit_bu1_ali_cloud/suit_bu1_ali_cloud201802281451_77479.html)。


### PR DESCRIPTION
## Summary

Update FC Agent Sandbox documentation to clarify runtime version requirements and improve the first-run install experience across SDK quickstart, CLI quickstart, and Usage Constraints pages.

## Changes

- **Node.js minimum raised**: 18 → 20.18.1 for TypeScript quickstart
- **TypeScript SDK pin**: `@e2b/code-interpreter` changed from `^2.8.1` to `^2.6.1`
- **Runtime version checks added**: `python3 --version` and `node --version` commands placed before install steps so users verify their environment early
- **CLI version check added**: `e2b --version` after installation
- **Usage Constraints restructured**: Python (pinned versions) vs TypeScript (semver range) strategies documented separately; CLI versioning clarified as not pinned
- **Service terms link**: HTTP → HTTPS
- All changes applied to both English and Chinese documentation

## Test Plan

- [ ] Verify SDK Python quickstart renders correctly with new version check block
- [ ] Verify SDK TypeScript quickstart renders correctly with updated install command
- [ ] Verify CLI quickstart renders correctly with new version check block
- [ ] Verify Usage Constraints page renders the Python/TypeScript split correctly
- [ ] Confirm service terms link resolves over HTTPS
- [ ] Cross-check EN and ZH versions for content parity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 更新 FC Agent Sandbox（云沙箱）文档，涵盖：

- 英文与中文的 SDK 快速入门章节：补充 Python、Node.js 运行时版本检查，调整 Node.js 最低版本及 TypeScript 依赖版本。
- 英文与中文的 CLI 快速入门章节：新增 `e2b --version` 安装后版本检查。
- 英文与中文的使用约束章节：明确 Python 固定版本、TypeScript 版本范围、Node.js 要求、lockfile 提交建议及 CLI 版本策略。
- 中文服务条款章节：将阿里云产品服务协议链接由 HTTP 更新为 HTTPS。

本次未新增或删除页面；未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->