### PR TITLE
docs(sandbox): fix custom template troubleshooting links

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
@@ -310,6 +310,6 @@ Sandboxes are billed based on CPU and memory specifications and runtime duration
 | Agent not responding | Verify that `envs` includes the model Key; for China, use the Bailian `envs` configuration |
 | Build failure | Verify that `FROM_IMAGE` matches the region |
 | name 'TEMPLATE_NAME' is not defined | Obtain the template name from the console and replace `TEMPLATE_NAME` |
-| Other SDK / build issues | See [Custom Templates — Troubleshooting](https://help.aliyun.com/zh/functioncompute/custom-template#d21d3cbd8b8xo) |
+| Other SDK / build issues | See [Custom Templates — Troubleshooting](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
 
 ---

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
@@ -421,7 +421,7 @@ Sandboxes are billed based on CPU and memory specifications and runtime duration
 | `sandbox account mismatch` | The API Key and custom domain must belong to the same account; see [Cloud Sandbox Custom Domains](../04.Features/07.FC%20Extensions/03.Custom%20Domains.md) |
 | Origin not allowed | Ensure `allowedOrigins` exactly matches the address bar URL, then restart the Gateway |
 | Build failure | Verify that `FROM_IMAGE` matches the region; do not use the `openclaw-v*` prefix for `name` |
-| Other SDK / build issues | See [Custom Templates — Troubleshooting](https://help.aliyun.com/zh/functioncompute/custom-template#d21d3cbd8b8xo) |
+| Other SDK / build issues | See [Custom Templates — Troubleshooting](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
 
 ---
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
@@ -310,6 +310,6 @@ Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由
 | Agent 无响应 | 确认 `envs` 已注入模型 Key；国内用百炼 `envs` 配置                                                       |
 | 构建失败 | 确认 `FROM_IMAGE` 与地域匹配                                                                     |
 | name 'TEMPLATE_NAME' is not defined | 控制台获取模版名称并替换 `TEMPLATE_NAME`                                                                              |
-| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](https://help.aliyun.com/zh/functioncompute/custom-template#d21d3cbd8b8xo) |
+| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
 
 ---

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
@@ -421,7 +421,7 @@ Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由
 | `sandbox account mismatch` | API Key 与自定义域名须为同一账号，见 [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md) |
 | 来源不被允许 | `allowedOrigins` 与地址栏 URL 完全一致，重启 Gateway |
 | 构建失败 | 确认 `FROM_IMAGE` 与地域匹配；`name` 勿用 `openclaw-v*` 前缀 |
-| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](https://help.aliyun.com/zh/functioncompute/custom-template#d21d3cbd8b8xo) |
+| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
 
 ---
 


### PR DESCRIPTION
Fix the stale custom-template troubleshooting URL in the Claude Code and OpenClaw custom-image guides. Keep the Chinese and English pages aligned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

更新云沙箱产品“最佳实践”章节下的 Claude Code 和 OpenClaw 自定义镜像中英文指南，将 FAQ 的构建问题排查链接替换为当前的 Custom Templates Troubleshooting 页面。

本次未新增或删除页面，也未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->