### PR TITLE
docs(sandbox): add Skill extension capabilities for Claude Code and O…

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
@@ -294,6 +294,66 @@ result = sandbox.commands.run(
 | SDK `mcp` creation parameter | **Not supported** |
 | `getMcpUrl()` / `getMcpToken()` | **Not supported** |
 
+### Extend Capabilities with Skills
+
+The image does not preload custom Skills. A Skill is a Claude Code filesystem convention: place a directory that contains `SKILL.md`. For details, see [Extend Claude with skills](https://code.claude.com/docs/en/skills).
+
+| Scope | Path |
+|--------|------|
+| Personal (global within this sandbox) | `/home/user/.claude/skills/<name>/SKILL.md` |
+| Project | `<project>/.claude/skills/<name>/SKILL.md` |
+
+How to trigger: explicitly call `/skill-name` in the `-p` prompt, or describe a matching task so the model loads it automatically. Claude Code also ships bundled skills such as `/debug` and `/code-review` that require no extra installation.
+
+**Write a personal Skill at runtime:**
+
+```python
+sandbox.files.write(
+    "/home/user/.claude/skills/summarize-changes/SKILL.md",
+    """---
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+""",
+)
+
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null '
+    '-p "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**Project Skill (takes effect with the repository / working directory):**
+
+```python
+sandbox.files.write(
+    "/home/user/repo/.claude/skills/api-conventions/SKILL.md",
+    """---
+description: API design conventions for this codebase. Use when adding or changing HTTP endpoints.
+---
+
+When writing API endpoints:
+- Use RESTful naming
+- Return consistent error formats
+- Include request validation
+""",
+)
+
+sandbox.commands.run(
+    'cd /home/user/repo && claude --dangerously-skip-permissions < /dev/null '
+    '-p "/api-conventions Add a /healthz endpoint"',
+    timeout=0,
+)
+```
+
+You can also preload Skills when building a Template (useful for team reuse), for example by writing the skill directory into the image on the `Template.build` path; or clone a repository that already contains `.claude/skills/` and use it directly.
+
 ---
 
 ## Billing

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
@@ -168,6 +168,95 @@ print(f"Access Token: {sandbox._envd_access_token}")
 
 `X-Access-Token` is **not manually requested** and is **not the Gateway Token**. After `Sandbox.create(...)` succeeds, the SDK exposes `_envd_access_token` (i.e., the Sandbox Access Token) on the sandbox object. Each sandbox has its own token, valid only while the sandbox is alive; it becomes invalid after the sandbox is destroyed, and a new sandbox must be created to obtain a new value.
 
+### Extend Capabilities with Skills
+
+OpenClaw extends Agent capabilities through Skills (a directory plus `SKILL.md`). For details, see [OpenClaw Skills](https://docs.openclaw.ai/tools/skills).
+
+The image does not preload custom Skills; use `openclaw skills list` to view loaded Skills (including bundled ones).
+
+| Scope | Path (verified on this image) | Source |
+|--------|-------------------|-------------|
+| Workspace (preferred) | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
+| Managed / shared on this host | `/home/user/.openclaw/skills/<name>/SKILL.md` | managed |
+| Bundled | Shipped with the OpenClaw installation | `openclaw-bundled` |
+
+How to trigger:
+
+1. Explicit: `openclaw agent ... --message "/skill-name"`
+2. Automatic: the model loads the Skill when natural language matches the `description`
+
+> **Note**: Place the file at `<workspace>/skills/<name>/SKILL.md`. Putting `SKILL.md` directly under the workspace root (for example `/home/user/.openclaw/workspace/SKILL.md`) will **not** be recognized as a Skill.
+
+**Write a Managed Skill:**
+
+```python
+sandbox.files.write(
+    "/home/user/.openclaw/skills/summarize-changes/SKILL.md",
+    """---
+name: summarize-changes
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+user-invocable: true
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+""",
+)
+
+# Confirm it appears in the list
+print(sandbox.commands.run("openclaw skills list").stdout)
+
+result = sandbox.commands.run(
+    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
+    '--message "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**Write a Workspace Skill:**
+
+```python
+sandbox.files.write(
+    "/home/user/.openclaw/workspace/skills/api-conventions/SKILL.md",
+    """---
+name: api-conventions
+description: API design conventions. Use when adding or changing HTTP endpoints or /healthz.
+user-invocable: true
+---
+
+When writing API endpoints:
+- Use RESTful naming
+- Return consistent error formats
+- Include request validation
+""",
+)
+
+result = sandbox.commands.run(
+    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
+    '--message "/api-conventions Add a /healthz endpoint"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**Install from ClawHub (optional):**
+
+The sandbox has public outbound access by default, so you can search for and install community Skills directly (browse [clawhub.ai](https://clawhub.ai)):
+
+```python
+# Search
+result = sandbox.commands.run("openclaw skills search calendar", timeout=120)
+print(result.stdout)
+
+# Install
+sandbox.commands.run("openclaw skills install weather", timeout=180)
+```
+
+You can also preload Skills when building a Template (useful for team reuse) by writing the skill directory into `~/.openclaw/skills/` or the workspace `skills/` directory.
+
 ### Browser Access (FC E2B)
 
 To open the Gateway Control UI in a browser on FC E2B, **a custom domain must be bound first**. The default platform domain (`*.e2b.fc.aliyuncs.com`) will **trigger a download instead of opening the page**; after binding a custom domain, the page loads normally. For the complete steps on adding a domain in the console, DNS resolution, HTTPS certificates, and SDK configuration, see [Cloud Sandbox Custom Domains](../04.Features/07.FC%20Extensions/03.Custom%20Domains.md).

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
@@ -294,6 +294,66 @@ result = sandbox.commands.run(
 | SDK `mcp` 创建参数 | **不支持** |
 | `getMcpUrl()` / `getMcpToken()` | **不支持** |
 
+### 使用 Skill 扩展能力
+
+镜像不预装自定义 Skill。Skill 是 Claude Code 的文件系统约定：放入带 `SKILL.md` 的目录即可。详情见 [Extend Claude with skills](https://code.claude.com/docs/en/skills)。
+
+| 作用域 | 路径 |
+|--------|------|
+| 个人（本沙箱内全局） | `/home/user/.claude/skills/<name>/SKILL.md` |
+| 项目 | `<项目>/.claude/skills/<name>/SKILL.md` |
+
+触发方式：在 `-p` 提示词中写 `/skill-name` 显式调用，或描述匹配任务由模型自动加载。Claude Code 还自带 `/debug`、`/code-review` 等 bundled skill，无需额外安装。
+
+**运行时写入个人 Skill：**
+
+```python
+sandbox.files.write(
+    "/home/user/.claude/skills/summarize-changes/SKILL.md",
+    """---
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+""",
+)
+
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null '
+    '-p "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**项目内 Skill（随仓库 / 工作目录生效）：**
+
+```python
+sandbox.files.write(
+    "/home/user/repo/.claude/skills/api-conventions/SKILL.md",
+    """---
+description: API design conventions for this codebase. Use when adding or changing HTTP endpoints.
+---
+
+When writing API endpoints:
+- Use RESTful naming
+- Return consistent error formats
+- Include request validation
+""",
+)
+
+sandbox.commands.run(
+    'cd /home/user/repo && claude --dangerously-skip-permissions < /dev/null '
+    '-p "/api-conventions Add a /healthz endpoint"',
+    timeout=0,
+)
+```
+
+也可在构建 Template 时预置 Skill（适合团队复用），例如在 `Template.build` 链路中把 skill 目录写入镜像；或克隆已含 `.claude/skills/` 的仓库后直接使用。
+
 ---
 
 ## 计费说明

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
@@ -296,7 +296,7 @@ result = sandbox.commands.run(
 
 ### 使用 Skill 扩展能力
 
-镜像不预装自定义 Skill。Skill 是 Claude Code 的文件系统约定：放入带 `SKILL.md` 的目录即可。详情见 [Extend Claude with skills](https://code.claude.com/docs/en/skills)。
+镜像不预装自定义 Skill。Skill 是 Claude Code 的文件系统约定：放入带 `SKILL.md` 的目录即可。详情见 [Extend Claude with skills](https://code.claude.com/docs/zh-CN/skills)。
 
 | 作用域 | 路径 |
 |--------|------|

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
@@ -168,6 +168,95 @@ print(f"Access Token: {sandbox._envd_access_token}")
 
 `X-Access-Token` **不是手动申请的**，也**不是 Gateway Token**。`Sandbox.create(...)` 成功后，SDK 在 sandbox 对象上暴露 `_envd_access_token`（即 Sandbox Access Token）。每个 Sandbox 各有一份，仅在该 Sandbox 存活期间有效；销毁后失效，需重新创建 Sandbox 获取新值。
 
+### 使用 Skill 扩展能力
+
+OpenClaw 通过 Skill（目录 + `SKILL.md`）扩展 Agent 能力。详见 [OpenClaw Skills](https://docs.openclaw.ai/tools/skills)。
+
+镜像不预装自定义 Skill；可用 `openclaw skills list` 查看已加载 Skill（含 bundled）。
+
+| 作用域 | 路径（本镜像实测） | Source 标识 |
+|--------|-------------------|-------------|
+| Workspace（优先） | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
+| Managed / 本机共享 | `/home/user/.openclaw/skills/<name>/SKILL.md` | managed |
+| Bundled | 随 OpenClaw 安装自带 | `openclaw-bundled` |
+
+触发方式：
+
+1. 显式：`openclaw agent ... --message "/skill-name"`
+2. 自动：自然语言匹配 `description` 时由模型加载
+
+> **注意**：请写成 `<workspace>/skills/<name>/SKILL.md`。把 `SKILL.md` 直接放在 workspace 根目录（例如 `/home/user/.openclaw/workspace/SKILL.md`）**不会**被识别为 Skill。
+
+**写入 Managed Skill：**
+
+```python
+sandbox.files.write(
+    "/home/user/.openclaw/skills/summarize-changes/SKILL.md",
+    """---
+name: summarize-changes
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+user-invocable: true
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+""",
+)
+
+# 确认已出现在列表中
+print(sandbox.commands.run("openclaw skills list").stdout)
+
+result = sandbox.commands.run(
+    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
+    '--message "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**写入 Workspace Skill：**
+
+```python
+sandbox.files.write(
+    "/home/user/.openclaw/workspace/skills/api-conventions/SKILL.md",
+    """---
+name: api-conventions
+description: API design conventions. Use when adding or changing HTTP endpoints or /healthz.
+user-invocable: true
+---
+
+When writing API endpoints:
+- Use RESTful naming
+- Return consistent error formats
+- Include request validation
+""",
+)
+
+result = sandbox.commands.run(
+    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
+    '--message "/api-conventions Add a /healthz endpoint"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**从 ClawHub 安装（可选）：**
+
+沙箱默认具备公网出站，可直接搜索 / 安装社区 Skill（浏览 [clawhub.ai](https://clawhub.ai)）：
+
+```python
+# 搜索
+result = sandbox.commands.run("openclaw skills search calendar", timeout=120)
+print(result.stdout)
+
+# 安装
+sandbox.commands.run("openclaw skills install weather", timeout=180)
+```
+
+也可在构建 Template 时预置 Skill（适合团队复用），把 skill 目录写入 `~/.openclaw/skills/` 或 workspace `skills/`。
+
 ### 浏览器访问（FC E2B）
 
 FC E2B 要在浏览器中打开 Gateway Control UI，**须先绑定自定义域名**。默认平台域名（`*.e2b.fc.aliyuncs.com`）会**触发下载而非打开页面**；绑定自定义域名后可正常访问。控制台添加域名、DNS 解析、HTTPS 证书及 SDK 配置的完整步骤，见 [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md)。
@@ -199,6 +288,7 @@ OPTS = {
 **第三步：全流程传入 `OPTS`。** `Template.build(..., **OPTS)`、`Sandbox.create(..., **OPTS)` 及文档中其他 SDK 调用均使用上述 `OPTS`，无需额外参数。
 
 完成后 `sandbox.get_host(PORT)` 将返回 `{PORT}-sbx-{sandbox_id}.<你的自定义域名>`；Gateway 的 `allowedOrigins`、浏览器地址栏与下文 `curl` 中的 `<host>` 均使用该地址。
+
 
 #### 打开 Control UI
 


### PR DESCRIPTION
…penClaw

Enhance documentation by introducing the Skill extension feature for both Claude Code and OpenClaw. Include instructions on creating and using Skills, along with examples for personal and project-specific Skills. Ensure alignment between Chinese and English documentation.

Change-Id: Ife2022baa823232b84e821c37351af135352b696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
本次 PR 涉及两个产品及其最佳实践文档章节（均为“自定义镜像”相关页面）：

- **Claude Code**：在中文与英文文档中、于“连接 MCP 工具”之后新增/补充“使用 Skill 扩展能力 / Extend Capabilities with Skills”章节，覆盖个人与项目 Skill、预置 Skill 等内容；同时**修正了中文 Claude Code Skill 扩展链接**。
- **OpenClaw**：在中文与英文文档中新增“使用 Skill 扩展能力 / Extend Capabilities with Skills”章节，覆盖 Managed Skill / Workspace Skill、Skill 加载与触发方式、SKILL.md 识别规则、可选的社区 Skill 安装与模板预置方式。

未新增或删除页面；未改动图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->