### PR TITLE
docs(sandbox): replace broken help center links

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/01.Overview.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/01.Overview.md
@@ -29,8 +29,8 @@ FC Extensions do not change the basic usage of the E2B SDK or CLI. Applications 
 
 For more configuration details, see the official documentation:
 
-- [Monitoring and Logs](https://help.aliyun.com/zh/functioncompute/monitoring-and-logs)
-- [Log Collection Configuration](https://help.aliyun.com/zh/functioncompute/log-collection-configuration)
-- [VPC Network Configuration](https://help.aliyun.com/zh/functioncompute/vpc-network-configuration)
-- [Custom Domains](https://help.aliyun.com/zh/functioncompute/custom-domain-name)
-- [Dynamic OSS Mounts](https://help.aliyun.com/zh/functioncompute/mount-oss-dynamically)
+- [Monitoring and Logs](./05.Monitoring%20and%20Logs.md)
+- [VPC Network Configuration](./02.VPC%20Network%20Configuration.md)
+- [Custom Domains](./03.Custom%20Domains.md)
+- [Dynamic OSS Mounts](./04.Dynamic%20OSS%20Mounts.md)
+- [Quota Management](./06.Quota%20Management.md)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/02.VPC Network Configuration.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/02.VPC Network Configuration.md
@@ -186,5 +186,3 @@ To prove that the VPC configuration is the reason access works, first create a s
 - The VPC, vSwitch, security group, FC Agent Sandbox, and target resources should be in the same region or in a reachable network scope.
 - Open only the ports and address ranges that the sandbox needs.
 - Do not expose long-lived credentials in code, templates, metadata, environment variables, or logs.
-
-For more network configuration background, see the official documentation: [VPC Network Configuration](https://help.aliyun.com/zh/functioncompute/vpc-network-configuration).

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/05.Monitoring and Logs.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/05.Monitoring and Logs.md
@@ -182,5 +182,3 @@ print(result.stdout)
 - Do not write full API keys, AccessKeys, database passwords, or OAuth tokens to logs.
 - For long-running tasks, set both command timeouts and sandbox timeouts.
 - For tasks that produce large volumes of logs, control output size to avoid excessive logging costs.
-
-For configuration details, see the official documentation: [Monitoring and Logs](https://help.aliyun.com/zh/functioncompute/monitoring-and-logs) and [Log Collection Configuration](https://help.aliyun.com/zh/functioncompute/log-collection-configuration).

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
@@ -310,6 +310,6 @@ Sandboxes are billed based on CPU and memory specifications and runtime duration
 | Agent not responding | Verify that `envs` includes the model Key; for China, use the Bailian `envs` configuration |
 | Build failure | Verify that `FROM_IMAGE` matches the region |
 | name 'TEMPLATE_NAME' is not defined | Obtain the template name from the console and replace `TEMPLATE_NAME` |
-| Other SDK / build issues | See [Custom Templates — Troubleshooting](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
+| Other SDK / build issues | See [Custom Templates — Troubleshooting](../08.FAQ/05.Template%20Builds.md) |
 
 ---

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
@@ -421,7 +421,7 @@ Sandboxes are billed based on CPU and memory specifications and runtime duration
 | `sandbox account mismatch` | The API Key and custom domain must belong to the same account; see [Cloud Sandbox Custom Domains](../04.Features/07.FC%20Extensions/03.Custom%20Domains.md) |
 | Origin not allowed | Ensure `allowedOrigins` exactly matches the address bar URL, then restart the Gateway |
 | Build failure | Verify that `FROM_IMAGE` matches the region; do not use the `openclaw-v*` prefix for `name` |
-| Other SDK / build issues | See [Custom Templates — Troubleshooting](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
+| Other SDK / build issues | See [Custom Templates — Troubleshooting](../08.FAQ/05.Template%20Builds.md) |
 
 ---
 

--- a/docs/zh-CN/01.云沙箱/02.产品动态/01.2026年功能发布记录.md
+++ b/docs/zh-CN/01.云沙箱/02.产品动态/01.2026年功能发布记录.md
@@ -12,4 +12,4 @@
 
 | **功能名称** | **变更类型** | **功能描述** | **相关文档** |
 | --- | --- | --- | --- |
-| 云沙箱（FC Agent Sandbox） | 正式发布 | 云沙箱在华北 2（北京）地域正式发布，面向 AI Agent、代码执行、命令执行、文件处理和临时服务预览等场景，提供按需创建、运行、连接和释放的云端隔离执行环境。开发者可通过 E2B SDK / CLI 接入云沙箱，使用 Sandbox、Commands、Filesystem、Code Interpreter、Template 等核心能力。 | [云沙箱（FC Agent Sandbox）](https://help.aliyun.com/zh/functioncompute/what-is-a-fc-sandbox)|
+| 云沙箱（FC Agent Sandbox） | 正式发布 | 云沙箱在华北 2（北京）地域正式发布，面向 AI Agent、代码执行、命令执行、文件处理和临时服务预览等场景，提供按需创建、运行、连接和释放的云端隔离执行环境。开发者可通过 E2B SDK / CLI 接入云沙箱，使用 Sandbox、Commands、Filesystem、Code Interpreter、Template 等核心能力。 | 云沙箱（FC Agent Sandbox）|

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/01.概览.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/01.概览.md
@@ -29,8 +29,8 @@ FC Extensions 不改变 E2B SDK / CLI 的基本使用方式。应用仍然使用
 
 更多配置方式以官方文档为准：
 
-- [监控与日志](https://help.aliyun.com/zh/functioncompute/monitoring-and-logs)
-- [日志采集配置](https://help.aliyun.com/zh/functioncompute/log-collection-configuration)
-- [VPC 网络配置](https://help.aliyun.com/zh/functioncompute/vpc-network-configuration)
-- [自定义域名](https://help.aliyun.com/zh/functioncompute/custom-domain-name)
-- [动态挂载 OSS](https://help.aliyun.com/zh/functioncompute/mount-oss-dynamically)
+- [监控与日志](./05.监控与日志.md)
+- [VPC 网络配置](./02.VPC%20网络配置.md)
+- [自定义域名](./03.自定义域名.md)
+- [动态挂载 OSS](./04.动态挂载%20OSS.md)
+- [配额管理](./06.配额管理.md)

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/02.VPC 网络配置.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/02.VPC 网络配置.md
@@ -186,5 +186,3 @@ print(result.stdout.strip())
 - VPC、vSwitch、安全组、云沙箱和目标资源应位于同一地域或可连通的网络范围内。
 - 只开放 Sandbox 访问目标资源所需的端口和地址范围。
 - 不要在代码、模板、metadata、环境变量或日志中暴露长期凭证。
-
-更多网络配置背景参见官方文档：[VPC 网络配置](https://help.aliyun.com/zh/functioncompute/vpc-network-configuration)。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/05.监控与日志.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/05.监控与日志.md
@@ -182,5 +182,3 @@ print(result.stdout)
 - 不要把完整 API Key、AccessKey、数据库密码、OAuth Token 写入日志。
 - 长任务建议设置命令超时和 Sandbox 超时。
 - 对日志量大的任务，应控制输出大小，避免日志费用过高。
-
-配置方式参见官方文档：[监控与日志](https://help.aliyun.com/zh/functioncompute/monitoring-and-logs)、[日志采集配置](https://help.aliyun.com/zh/functioncompute/log-collection-configuration)。

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
@@ -310,6 +310,6 @@ Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由
 | Agent 无响应 | 确认 `envs` 已注入模型 Key；国内用百炼 `envs` 配置                                                       |
 | 构建失败 | 确认 `FROM_IMAGE` 与地域匹配                                                                     |
 | name 'TEMPLATE_NAME' is not defined | 控制台获取模版名称并替换 `TEMPLATE_NAME`                                                                              |
-| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
+| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](../08.常见问题/05.模板构建.md) |
 
 ---

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
@@ -421,7 +421,7 @@ Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由
 | `sandbox account mismatch` | API Key 与自定义域名须为同一账号，见 [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md) |
 | 来源不被允许 | `allowedOrigins` 与地址栏 URL 完全一致，重启 Gateway |
 | 构建失败 | 确认 `FROM_IMAGE` 与地域匹配；`name` 勿用 `openclaw-v*` 前缀 |
-| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
+| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](../08.常见问题/05.模板构建.md) |
 
 ---
 


### PR DESCRIPTION
Use local cloud-sandbox references for FC Extensions and template troubleshooting, and remove retired external links from the release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 涉及云沙箱（FC Agent Sandbox）文档，覆盖：

- FC 扩展：概览、VPC 网络配置、监控与日志
- 最佳实践：Claude Code 自定义镜像、OpenClaw 自定义镜像
- 常见问题：模板构建相关引用
- 中文版 2026 年功能发布记录

主要将失效的帮助中心外链替换为站内相对链接，删除已退休的外部配置说明及发布记录中的外部链接。

未新增或删除页面，未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->