### PR TITLE
精简模板构建 FAQ 并明确镜像 tag 使用规范

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -18,8 +18,10 @@ Use a Linux system based on the AMD64 architecture. Recommended base images: Ubu
 Push the image to that ACR EE repository and use the VPC-accessible internal image address, for example:
 
 ```text
-test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12
+test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
 ```
+
+Do not push different image contents to the same tag. Every distinct image must use a new, unique tag, such as a version, date, or commit ID, and templates should keep referencing that specific tag.
 
 ### Build the template
 
@@ -36,7 +38,7 @@ Create a `.env` file:
 ```bash
 # Replace with your own API_KEY and image address
 E2B_API_KEY=e2b_xxx
-FROM_IMAGE="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12"
+FROM_IMAGE="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"
 
 # Beijing production environment example
 E2B_API_URL=https://api.cn-beijing.e2b.fc.aliyuncs.com

--- a/docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md
+++ b/docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md
@@ -1,61 +1,39 @@
 # Template Builds
 
-## When do I need a custom template?
-
-Use a custom template when the task requires pinned system packages, language runtimes, Python or Node dependencies, testing tools, browser dependencies, or foundational business code.
-
-Do not install large dependency sets after every sandbox creation. Dependency installation should be moved into the template build phase whenever possible.
-
-## What should go into a template?
-
-Put stable, reusable, versioned runtime content into the template: base images, system packages, language runtimes, common dependencies, CLI tools, and base directories.
-
-Do not put user data, temporary task files, long-lived secrets, tokens, or frequently changing business state into the template.
-
-## How can I optimize slow template builds?
-
-Start by checking the base image size, dependency download volume, build cache usage, image registry network quality, and dependency source stability.
-
-Production templates should pin base image versions and dependency versions. During development, frequent builds are acceptable. In production, template builds should be part of the release process, not triggered in real time on the user request path.
-
 ## How should I handle dependency installation failures or insufficient space?
 
-Large packages, compiled dependencies, browser dependencies, and GPU or CUDA dependencies are the most likely to fail. Prefer CPU-only or minimal dependency variants, pin versions, and reduce temporary cache usage.
+The Template Build API currently does not support declaring `steps` (installation steps) in the build request. Passing `steps` returns `400 steps are not supported`, so do not try to install dependencies online through build steps.
 
-For Python dependencies, you can first try:
+Dependencies should be installed during the Dockerfile or external image build phase, and then the finished image should be pushed to an image registry so the template only builds from that image. This avoids downloading dependencies during the template build or after every Sandbox creation and reduces installation caches and temporary files; the dependencies themselves still contribute to the image size.
 
-```bash
-pip install --no-cache-dir <package>
+Minimal Dockerfile example:
+
+```dockerfile
+FROM python:3.12-slim
+
+# Python dependencies: disable caching so the pip cache is not written into image layers
+RUN pip install --no-cache-dir pandas numpy
+
+# System dependencies: clean the apt cache right after install to keep the image small
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 ```
 
-If the failure occurs during the build, keep the full build log instead of looking only at the last error line.
+Start with the error summary. If it is not sufficient to locate the failure, inspect the full build log for the failing phase, the `RequestId`, the image address, and the build configuration.
 
-## What should I check first when pulling a private image fails?
+For the full custom image and template build flow, see [Build Custom Image Templates](../04.Features/02.Templates/03.Build%20Custom%20Image%20Templates.md).
 
-Check the image address, region, namespace, repository permissions, VPC binding, security groups, and ACR EE access path.
+## How do I troubleshoot private image pull or build failures?
 
-When private image pulls fail, network and permission problems are more common than SDK parameter issues. It is recommended to verify the path with a minimum image first and then add business dependencies.
+A template build goes through four phases: pull the source image, convert or build it, push the destination image, and create the template function and optimize its image through CreateFunction. Identify the failing phase in the full build log, then use the following table.
 
-## Does a successful build mean the template is ready to use?
+| Failing phase | Typical error | Action |
+| --- | --- | --- |
+| Pulling the source image | `unauthorized`, `denied`, `manifest unknown`, or `not found` | Verify that the image address, tag, or digest exists. For ACR EE, confirm that the instance and FC Agent Sandbox use the same UID and region, that a VPC reachable by the build path is bound, and that the username, password, or token is valid. |
+| Conversion or build | `invalid image, platform of image is unknown/unknown`, or manifest/provenance errors | Inspect the image manifest. Build a single `linux/amd64` platform image, disable provenance and SBOM, push a new tag, and retry. Do not reuse an old tag whose content may have changed. |
+| Pushing the destination image | `Unable to upload into a virtual repository without default local deployment configured` | The Artifactory virtual repository has no writable destination. Configure a writable Default Deployment Repository, or set `X-E2B-Template-Dest-Image-Ref` to a local repository where the account has push permission. Configure source and destination credentials separately when they differ. |
+| CreateFunction or asynchronous image optimization | `400 InvalidArgument: resolved image does not exist` | Verify that the final destination image was pushed and that the repository address and tag referenced by the function exist and match exactly. |
+| CreateFunction or asynchronous image optimization | `ImageOptimizingFailed` with `403 Forbidden` while downloading a Blob in the inner log | If the manifest and other layers download successfully, registry authentication and basic connectivity already work. Ask the registry administrator to check the backend object storage permission, signature, or origin path for the failed Blob, then push the repaired image under a unique new tag. |
 
-No. A successful build only means the template artifact was generated successfully. It does not guarantee that runtime commands, the filesystem, Code Interpreter, or port services work correctly.
-
-Create a sandbox immediately after the build and run smoke checks:
-
-```bash
-python3 --version
-node --version
-pwd
-```
-
-## Can `run_code` port or service readiness errors be related to the template?
-
-Usually yes. The E2B FAQ also attributes unopened Code Interpreter ports to templates that do not include the correct Code Interpreter base environment or startup command.
-
-If you see similar issues in FC Agent Sandbox, switch back to the built-in `code-interpreter-v1` first for comparison. If the built-in template works, then fix the custom template's dependencies, startup commands, and readiness checks.
-
-## Are there limits on template count or build concurrency?
-
-Template builds are constrained by account, region, build resources, and platform quotas. Do not design template builds as high-frequency online actions.
-
-The correct approach is to keep a small number of stable templates, manage multiple versions, validate them before release, and let online requests only create sandboxes and run tasks.
+For the full custom image template build flow, see [Build Custom Image Templates](../04.Features/02.Templates/03.Build%20Custom%20Image%20Templates.md); for an end-to-end example of pulling from a private registry, see [Build a Sandbox Template from a GHCR Custom Image](../05.Best%20Practices/07.Build%20a%20Sandbox%20Template%20from%20a%20GHCR%20Custom%20Image.md).

--- a/docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md
+++ b/docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md
@@ -4,17 +4,17 @@
 
 The Template Build API currently does not support declaring `steps` (installation steps) in the build request. Passing `steps` returns `400 steps are not supported`, so do not try to install dependencies online through build steps.
 
-Dependencies should be installed during the Dockerfile or external image build phase, and then the finished image should be pushed to an image registry so the template only builds from that image. This avoids downloading dependencies during the template build or after every Sandbox creation and reduces installation caches and temporary files; the dependencies themselves still contribute to the image size.
+Dependencies should be installed during the Dockerfile or external image build phase, and then the finished image should be pushed to an image registry so the template only builds from that image. This avoids downloading and installing dependencies during the template build or after every Sandbox creation.
 
 Minimal Dockerfile example:
 
 ```dockerfile
 FROM python:3.12-slim
 
-# Python dependencies: disable caching so the pip cache is not written into image layers
+# Install Python dependencies
 RUN pip install --no-cache-dir pandas numpy
 
-# System dependencies: clean the apt cache right after install to keep the image small
+# Install system dependencies and clean the apt index
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
@@ -26,14 +26,11 @@ For the full custom image and template build flow, see [Build Custom Image Templ
 
 ## How do I troubleshoot private image pull or build failures?
 
-A template build goes through four phases: pull the source image, convert or build it, push the destination image, and create the template function and optimize its image through CreateFunction. Identify the failing phase in the full build log, then use the following table.
+Identify the failing phase in the full build log, then use the following table for common source image pull and image format issues.
 
 | Failing phase | Typical error | Action |
 | --- | --- | --- |
 | Pulling the source image | `unauthorized`, `denied`, `manifest unknown`, or `not found` | Verify that the image address, tag, or digest exists. For ACR EE, confirm that the instance and FC Agent Sandbox use the same UID and region, that a VPC reachable by the build path is bound, and that the username, password, or token is valid. |
 | Conversion or build | `invalid image, platform of image is unknown/unknown`, or manifest/provenance errors | Inspect the image manifest. Build a single `linux/amd64` platform image, disable provenance and SBOM, push a new tag, and retry. Do not reuse an old tag whose content may have changed. |
-| Pushing the destination image | `Unable to upload into a virtual repository without default local deployment configured` | The Artifactory virtual repository has no writable destination. Configure a writable Default Deployment Repository, or set `X-E2B-Template-Dest-Image-Ref` to a local repository where the account has push permission. Configure source and destination credentials separately when they differ. |
-| CreateFunction or asynchronous image optimization | `400 InvalidArgument: resolved image does not exist` | Verify that the final destination image was pushed and that the repository address and tag referenced by the function exist and match exactly. |
-| CreateFunction or asynchronous image optimization | `ImageOptimizingFailed` with `403 Forbidden` while downloading a Blob in the inner log | If the manifest and other layers download successfully, registry authentication and basic connectivity already work. Ask the registry administrator to check the backend object storage permission, signature, or origin path for the failed Blob, then push the repaired image under a unique new tag. |
 
 For the full custom image template build flow, see [Build Custom Image Templates](../04.Features/02.Templates/03.Build%20Custom%20Image%20Templates.md); for an end-to-end example of pulling from a private registry, see [Build a Sandbox Template from a GHCR Custom Image](../05.Best%20Practices/07.Build%20a%20Sandbox%20Template%20from%20a%20GHCR%20Custom%20Image.md).

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
@@ -15,7 +15,9 @@
 
 ### 镜像推送
 
-将镜像推送到该 ACR EE 仓库，得到支持 VPC 访问的内网镜像地址，例如 `test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12`。
+将镜像推送到该 ACR EE 仓库，得到支持 VPC 访问的内网镜像地址，例如 `test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1`。
+
+不要向同一个 tag 推送内容不同的镜像。每个不同的镜像都必须使用新的唯一 tag，例如使用版本号、日期或提交 ID，并让模板固定引用对应 tag。
 
 ### 构建 template
 
@@ -32,7 +34,7 @@ pip install e2b==2.31.0 e2b-code-interpreter==2.8.1 python-dotenv
 ```bash
 # 使用前请替换为自己的 API_KEY 和镜像地址
 E2B_API_KEY=e2b_xxx
-FROM_IMAGE="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12"
+FROM_IMAGE="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"
 
 # 北京生产环境地址示例值
 E2B_API_URL=https://api.cn-beijing.e2b.fc.aliyuncs.com

--- a/docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建.md
+++ b/docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建.md
@@ -1,61 +1,39 @@
 # 模板构建
 
-## 什么时候需要自定义模板？
-
-当任务需要固定系统包、语言运行时、Python/Node 依赖、测试工具、浏览器依赖或业务基础代码时，应使用自定义模板。
-
-不要在每次创建 Sandbox 后安装大量依赖。依赖安装应尽量前置到模板构建阶段。
-
-## 模板里应该放什么？
-
-放稳定、可复用、可版本化的运行环境：基础镜像、系统包、语言运行时、常用依赖、CLI 工具和基础目录。
-
-不要放用户数据、任务临时文件、长期密钥、Token 或频繁变化的业务状态。
-
-## 模板构建慢，怎么优化？
-
-先看基础镜像大小、依赖下载量、构建缓存、镜像仓库网络和依赖源稳定性。
-
-生产模板应固定基础镜像版本和依赖版本。开发阶段可以频繁构建，生产阶段应把模板构建放在发布流程中，不要在用户请求链路里实时构建。
-
 ## 依赖安装失败或空间不足，怎么处理？
 
-大包、编译型依赖、浏览器依赖、GPU/CUDA 依赖最容易失败。优先使用 CPU-only 或最小依赖版本，固定版本，并减少临时缓存。
+当前 Template Build API 不支持在构建请求里声明 `steps`（安装步骤）。传入 `steps` 会返回 `400 steps are not supported`，因此不要试图用构建步骤在线安装依赖。
 
-Python 依赖可优先尝试：
+依赖应在 Dockerfile 或外部镜像构建阶段装好，再把成品镜像推送到镜像仓库，模板只负责从该镜像构建。这样可以避免在模板构建或每次创建 Sandbox 后重复下载依赖，并减少安装缓存和临时文件；依赖本身仍会计入镜像体积。
 
-```bash
-pip install --no-cache-dir <package>
+精简的 Dockerfile 示例：
+
+```dockerfile
+FROM python:3.12-slim
+
+# Python 依赖：关闭缓存，避免把 pip 缓存写进镜像层
+RUN pip install --no-cache-dir pandas numpy
+
+# 系统依赖：安装后立即清理 apt 缓存，减小镜像体积
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 ```
 
-如果失败发生在构建阶段，要保留完整构建日志，不要只看最后一行错误。
+排查失败时先看错误摘要；如果摘要不足以定位，再查看完整构建日志中的失败阶段、`RequestId`、镜像地址和构建配置。
 
-## 私有镜像拉取失败，先查什么？
+模板构建与自定义镜像的完整流程，参见[构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)。
 
-检查镜像地址、地域、命名空间、仓库权限、VPC 绑定、安全组和 ACR EE 访问链路。
+## 私有镜像拉取或构建失败，怎么排查？
 
-私有镜像失败时，网络和权限问题比 SDK 参数问题更常见。建议先用最小镜像验证链路，再加入业务依赖。
+模板构建会经过「拉取源镜像 → 转换/构建 → 推送目标镜像 → CreateFunction 创建模板函数并优化镜像」四个阶段。先在完整构建日志中确认失败阶段，再按下表处理。
 
-## 构建成功就代表模板可用吗？
+| 失败阶段 | 典型错误 | 处理动作 |
+| --- | --- | --- |
+| 拉取源镜像 | `unauthorized`、`denied`、`manifest unknown` 或 `not found` | 核对镜像地址、tag 或 digest 是否真实存在。使用 ACR EE 时，确认实例与云沙箱属于同一 UID、同一地域，已绑定构建链路可访问的 VPC，并检查用户名、密码或 token。 |
+| 转换/构建 | `invalid image, platform of image is unknown/unknown`，或 manifest、provenance 相关错误 | 检查镜像 manifest。使用 `linux/amd64` 单一平台构建，关闭 provenance 和 SBOM，推送新 tag 后重试；不要复用内容可能已变化的旧 tag。 |
+| 推送目标镜像 | `Unable to upload into a virtual repository without default local deployment configured` | Artifactory virtual repository 没有可写落点。为其配置可写的 Default Deployment Repository，或通过 `X-E2B-Template-Dest-Image-Ref` 将目标地址指向有 push 权限的 local repository；源、目标凭证不同时分别配置。 |
+| CreateFunction 或异步镜像优化 | `400 InvalidArgument: resolved image does not exist` | 核对最终目标镜像是否推送成功，以及函数引用的仓库地址和 tag 是否存在且拼写一致。 |
+| CreateFunction 或异步镜像优化 | `ImageOptimizingFailed`，内层日志包含 Blob 下载 `403 Forbidden` | 如果 manifest 和其他 layer 可正常下载，说明整体鉴权和网络已通；让镜像仓库管理员检查失败 Blob 对应的后端对象存储权限、签名或回源链路，修复后用唯一新 tag 重新推送。 |
 
-不代表。构建成功只说明模板产物生成成功，不代表运行时命令、文件系统、Code Interpreter 或端口服务都正常。
-
-构建后应立刻创建 Sandbox 做冒烟验证：
-
-```bash
-python3 --version
-node --version
-pwd
-```
-
-## `run_code` 报端口或服务未就绪，和模板有关吗？
-
-通常有关。E2B FAQ 中也把代码解释器端口未打开归因到模板没有包含正确的 Code Interpreter 基础环境或启动命令。
-
-云沙箱中遇到类似问题时，先切回内置 `code-interpreter-v1` 对照；若内置模板正常，再修自定义模板的依赖、启动命令和就绪检查。
-
-## 模板数量或构建并发有限制吗？
-
-模板构建会受到账号、地域、构建资源和平台配额限制。不要把模板构建设计成高频在线动作。
-
-正确做法是少量稳定模板、多版本管理、发布前验证，在线请求只创建 Sandbox 并执行任务。
+自定义镜像模板的完整构建流程参见[构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)；从私有仓库拉取镜像的端到端示例参见[使用 GHCR 自定义镜像构建 Sandbox 模板](../05.最佳实践/07.使用%20GHCR%20自定义镜像构建%20Sandbox%20模板.md)。

--- a/docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建.md
+++ b/docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建.md
@@ -4,17 +4,17 @@
 
 当前 Template Build API 不支持在构建请求里声明 `steps`（安装步骤）。传入 `steps` 会返回 `400 steps are not supported`，因此不要试图用构建步骤在线安装依赖。
 
-依赖应在 Dockerfile 或外部镜像构建阶段装好，再把成品镜像推送到镜像仓库，模板只负责从该镜像构建。这样可以避免在模板构建或每次创建 Sandbox 后重复下载依赖，并减少安装缓存和临时文件；依赖本身仍会计入镜像体积。
+依赖应在 Dockerfile 或外部镜像构建阶段装好，再把成品镜像推送到镜像仓库，模板只负责从该镜像构建。这样可以避免在模板构建或每次创建 Sandbox 后重复下载和安装依赖。
 
 精简的 Dockerfile 示例：
 
 ```dockerfile
 FROM python:3.12-slim
 
-# Python 依赖：关闭缓存，避免把 pip 缓存写进镜像层
+# 安装 Python 依赖
 RUN pip install --no-cache-dir pandas numpy
 
-# 系统依赖：安装后立即清理 apt 缓存，减小镜像体积
+# 安装系统依赖并清理 apt 索引
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
@@ -26,14 +26,11 @@ RUN apt-get update \
 
 ## 私有镜像拉取或构建失败，怎么排查？
 
-模板构建会经过「拉取源镜像 → 转换/构建 → 推送目标镜像 → CreateFunction 创建模板函数并优化镜像」四个阶段。先在完整构建日志中确认失败阶段，再按下表处理。
+先在完整构建日志中确认失败阶段，再按下表处理常见的源镜像拉取和镜像格式问题。
 
 | 失败阶段 | 典型错误 | 处理动作 |
 | --- | --- | --- |
 | 拉取源镜像 | `unauthorized`、`denied`、`manifest unknown` 或 `not found` | 核对镜像地址、tag 或 digest 是否真实存在。使用 ACR EE 时，确认实例与云沙箱属于同一 UID、同一地域，已绑定构建链路可访问的 VPC，并检查用户名、密码或 token。 |
 | 转换/构建 | `invalid image, platform of image is unknown/unknown`，或 manifest、provenance 相关错误 | 检查镜像 manifest。使用 `linux/amd64` 单一平台构建，关闭 provenance 和 SBOM，推送新 tag 后重试；不要复用内容可能已变化的旧 tag。 |
-| 推送目标镜像 | `Unable to upload into a virtual repository without default local deployment configured` | Artifactory virtual repository 没有可写落点。为其配置可写的 Default Deployment Repository，或通过 `X-E2B-Template-Dest-Image-Ref` 将目标地址指向有 push 权限的 local repository；源、目标凭证不同时分别配置。 |
-| CreateFunction 或异步镜像优化 | `400 InvalidArgument: resolved image does not exist` | 核对最终目标镜像是否推送成功，以及函数引用的仓库地址和 tag 是否存在且拼写一致。 |
-| CreateFunction 或异步镜像优化 | `ImageOptimizingFailed`，内层日志包含 Blob 下载 `403 Forbidden` | 如果 manifest 和其他 layer 可正常下载，说明整体鉴权和网络已通；让镜像仓库管理员检查失败 Blob 对应的后端对象存储权限、签名或回源链路，修复后用唯一新 tag 重新推送。 |
 
 自定义镜像模板的完整构建流程参见[构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)；从私有仓库拉取镜像的端到端示例参见[使用 GHCR 自定义镜像构建 Sandbox 模板](../05.最佳实践/07.使用%20GHCR%20自定义镜像构建%20Sandbox%20模板.md)。


### PR DESCRIPTION
## 修改内容

- 中英文《模板构建》FAQ 均只保留两个问题。
- 明确 Template Build API 不支持内联 `steps`；依赖需在 Dockerfile 或外部镜像构建阶段安装。
- 私有镜像排障聚焦源镜像拉取和镜像格式问题，覆盖 ACR EE、tag/digest、manifest 与 provenance。
- 中英文《构建自定义镜像模板》明确：不要向同一个 tag 推送内容不同的镜像；每个不同镜像必须使用新的唯一 tag，并让模板固定引用对应 tag。

## 验证

- `git diff --check`
- `python3 scripts/prepare-mkdocs.py && mkdocs build --config-file mkdocs.generated.yml`（exit 0）
- 相关中英文页面内容与链接检查通过

## 生产验证依据

- 杭州生产验证确认：在 Template Build 请求中传入 `steps` 返回 `400 steps are not supported`。
- ACR EE 及 manifest/provenance 排障动作来自已完成的生产验证和客户问题复盘。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 涉及 **云沙箱（FC Agent Sandbox）** 产品的文档范围，包含以下页面的更新：

- **英文**  
  - `docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md`：精简并重写《模板构建》FAQ为聚焦的两段排障内容，明确 Template Build API 不支持请求内联 `steps`，并补充分阶段（如拉取源镜像/转换或构建）故障与处理对照说明。  
  - `docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md`：更新推送镜像与构建模板示例，强调同一 tag 不复用内容，ACR EE VPC 场景地址/标签示例同步调整（如 `runtime/python:3.12-v1`）。
- **中文**  
  - `docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建/05.模板构建.md`：精简并重写《模板构建》FAQ为两段更聚焦的常见问题，强调不支持内联 `steps`，并按阶段给出私有镜像拉取/构建失败的排查与处理动作（含 tag/digest、manifest/provenance 等故障模式）。  
  - `docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md`：更新内网镜像地址示例与“同一 tag 不得推送不同内容”要求，并同步 `FROM_IMAGE` 示例标签与前文建议一致（如 `runtime/python:3.12-v1`）。

**新增/删除页面**：未新增或删除页面，均为对现有 Markdown 文档的内容重写与示例调整。  
**图片资源**：未改动图片资源（仅更新文档文本与示例代码/链接）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->