### PR TITLE
docs: 补充自定义镜像运行要求

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -11,7 +11,17 @@ Built-in sandbox templates provide a baseline runtime environment. When you need
 
 ### Image requirements
 
-Use a Linux system based on the AMD64 architecture. Recommended base images: Ubuntu 20.04, Debian 12 (bookworm) or later.
+Recommended base images: Ubuntu 20.04, Debian 12 (bookworm) or later (recommended only, not a hard distro requirement). Custom images must meet the requirements below, grouped by Required / Conditional / Recommended:
+
+| Level | Requirement | Impact if not met |
+| --- | --- | --- |
+| Required | Architecture is `linux/amd64`; for multi-arch images, the manifest list must include the `linux/amd64` variant | Template conversion fails immediately |
+| Conditional | Fixed path `/bin/bash` exists in the image (not merely resolvable through PATH) | `commands.run` and PTY fail |
+| Required | `/etc/passwd` and `/etc/group` are standard files and writable | gatewayd cannot initialize the default user; container startup fails |
+| Conditional | `python3` or `python` is available in PATH | Python `run_code` is unavailable |
+| Conditional | `node` is available in PATH | JavaScript `run_code` is unavailable |
+| Conditional | Provide as needed: `git`, `openssh-client`, CA certificates, build toolchain | The corresponding Git, SSH, HTTPS, and build-from-source operations are unavailable |
+| Recommended | The system PATH includes at least `/usr/local/bin`, `/usr/bin`, `/bin` | Common commands may be missing in the login shell |
 
 ### Push the image
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
@@ -11,7 +11,17 @@
 
 ### 镜像要求
 
-基于 AMD64 架构的 Linux 系统，推荐基础镜像：ubuntu 20.04，Debian 12 (bookworm) 及以上
+推荐基础镜像：Ubuntu 20.04、Debian 12 (bookworm) 及以上（仅作推荐，不强制发行版）。自定义镜像需满足下表要求，按“硬性 / 条件 / 推荐”分级：
+
+| 级别 | 要求 | 不满足时影响 |
+| --- | --- | --- |
+| 硬性 | 架构为 `linux/amd64`；若为多架构镜像，其 manifest 列表必须包含 `linux/amd64` 变体 | Template 转换直接失败 |
+| 条件 | 镜像内存在固定路径 `/bin/bash`（不仅是 PATH 中可找到 Bash） | `commands.run`、PTY 失败 |
+| 硬性 | `/etc/passwd`、`/etc/group` 为标准文件且可写 | gatewayd 无法初始化默认用户，容器启动失败 |
+| 条件 | PATH 中存在 `python3` 或 `python` | Python `run_code` 不可用 |
+| 条件 | PATH 中存在 `node` | JavaScript `run_code` 不可用 |
+| 条件 | 按需提供：`git`、`openssh-client`、CA 证书、编译工具链 | 对应的 Git、SSH、HTTPS、编译安装操作不可用 |
+| 推荐 | 系统 PATH 至少包含 `/usr/local/bin`、`/usr/bin`、`/bin` | 登录 Shell 常用命令可能找不到 |
 
 ### 镜像推送
 


### PR DESCRIPTION
## 变更内容

- 中英文同步补充自定义镜像的硬性、条件和推荐要求
- 明确 linux/amd64、账户文件、运行时依赖及 PATH 约束
- 将 Bash 定义为 commands.run 和 PTY 的条件要求
- 保留 Ubuntu 20.04、Debian 12 及以上为推荐基础镜像，不设为发行版硬限制

## 检查

- git diff --check 通过
- 仅修改中英文构建自定义镜像模板文档

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 仅更新 FC Agent Sandbox（云沙箱）自定义镜像构建模板文档，涉及中英文版本的“构建自定义镜像模板”章节，补充镜像运行要求及其影响说明。

未新增或删除页面，未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->