### PR TITLE
docs(sandbox): add Traefik canary traffic routing best practice

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/08.Use Traefik for Canary Traffic Routing.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/08.Use Traefik for Canary Traffic Routing.md
@@ -1,0 +1,645 @@
+# Use Traefik for Canary Traffic Routing
+
+## Background
+
+When running an online service in a cloud Sandbox, you often need to roll out a new version (v2) gradually **without interrupting the service**: first send a small portion of traffic to the new version to observe it, then expand the ratio after confirming it works, or let internal users access the new version directly for verification. This "canary / gradual release" capability can be implemented inside the Sandbox by introducing the lightweight reverse proxy **Traefik**.
+
+> **About Traefik**: [Traefik](https://traefik.io/) is an open-source, cloud-native reverse proxy and load balancer. It ships as a single, dependency-free binary that can be downloaded and run directly inside the Sandbox. Its defining feature is **dynamic configuration**—routing rules, backend services, and split weights can all be delivered in real time through a config file, and combined with file watching (`watch`) it hot-reloads within seconds without restarting the process. This makes it a great fit for canary and blue-green releases that need to adjust traffic online.
+
+This document uses two versions of an HTTP service (v1 / v2) as an example and shows how to perform two kinds of canary routing with Traefik inside a single cloud Sandbox:
+
+- **Weight-based canary**: default traffic is split between v1 / v2 by ratio (for example 70% / 30%), and the ratio can be **hot-adjusted** at runtime without a restart.
+- **Header-based pinning**: requests carrying a specific header (for example `X-Version: v2`) are forced to hit a specific version, commonly used for internal / allowlist verification.
+
+## Solution overview
+
+The Sandbox exposes only **Traefik's entry port** to the outside; Traefik forwards requests to v1 / v2 inside the Sandbox according to rules:
+
+<img src="https://img.alicdn.com/imgextra/i1/O1CN01ZXqbVq1dclAm1f1Fq_!!6000000003757-2-tps-1143-1227.png" alt="Traffic path of Traefik canary routing inside a cloud Sandbox" width="480" />
+
+- The cloud Sandbox assigns an external address to each port listening inside the Sandbox. Get it via the SDK's `sandbox.get_host(port)` and prefix `https://` to access it from outside. **The exposable port range is `[3000, 65535]`.**
+- v1 / v2 are two backend services listening only inside the Sandbox; there is no need to (and you should not) access them directly from outside—all traffic goes through the Traefik entry.
+- Traefik uses "file configuration + hot reload" (`--providers.file.watch=true`): to adjust canary rules you only rewrite one config file, and Traefik applies it within seconds—**no process restart, no traffic interruption**.
+
+## Prerequisites
+
+- FC Agent Sandbox is enabled, and you have the `E2B_API_KEY` for the target region.
+- The target region is US (Silicon Valley), with the following endpoints:
+  - `api_url`: `https://api.us-west-1.e2b.fc.aliyuncs.com`
+  - `domain`: `us-west-1.e2b.fc.aliyuncs.com`
+- The Sandbox needs public network access to download the Traefik binary (in mainland China, use a mirror; see "FAQ").
+- Install the cloud Sandbox Python SDK and an HTTP client, and set the connection parameters as environment variables:
+
+  ```bash
+  pip install e2b httpx
+
+  export E2B_API_KEY="<your-e2b-api-key>"
+  export E2B_DOMAIN="us-west-1.e2b.fc.aliyuncs.com"
+  export E2B_API_URL="https://api.us-west-1.e2b.fc.aliyuncs.com"
+  ```
+
+## Procedure
+
+### Step 1: Create a Sandbox and start two versions of the backend service
+
+Use `python3 -m http.server` to simulate two versions, each with a version-identifying homepage in its own directory, so you can verify "which version this request hit."
+
+```python
+import os
+import time
+
+from e2b import Sandbox
+
+WORKDIR = "/tmp/canary"
+V1_PORT, V2_PORT = 9000, 9001
+
+conn = {
+    "api_key": os.environ["E2B_API_KEY"],
+    "api_url": os.environ["E2B_API_URL"],
+    "domain": os.environ["E2B_DOMAIN"],
+}
+
+# secure=True (SDK default): access control enabled; attach X-Access-Token as needed when accessing dynamic ports (see Step 5)
+sbx = Sandbox.create(template="base", timeout=600, secure=True, **conn)
+
+# v1 backend: homepage content marked as v1
+sbx.files.write(f"{WORKDIR}/v1/index.html", "backend=v1\n")
+sbx.commands.run(f"python3 -m http.server {V1_PORT}", cwd=f"{WORKDIR}/v1", background=True)
+
+# v2 backend: homepage content marked as v2
+sbx.files.write(f"{WORKDIR}/v2/index.html", "backend=v2\n")
+sbx.commands.run(f"python3 -m http.server {V2_PORT}", cwd=f"{WORKDIR}/v2", background=True)
+```
+
+> **Note**: `secure=True` is the SDK default and the recommended production setting—once the Sandbox has access control enabled, accessing dynamic ports from outside requires attaching `X-Access-Token` as needed (see Step 5 and FAQ #3). For quick local verification without handling tokens, you can temporarily use `secure=False` (open access without a token, for demo/testing only).
+
+### Step 2: Deploy Traefik inside the Sandbox
+
+Download and extract Traefik inside the Sandbox (equivalent to running `curl -O` then unpacking). The snippet below uses Python for the download—compatible with templates that don't preinstall `curl` / `wget`, with a resumable-download fallback for weak networks.
+
+```python
+GET_TRAEFIK = r'''
+import os, shutil, subprocess, tarfile, time, urllib.request
+DEST, URL = "/tmp/canary", os.environ["TRAEFIK_TARBALL"]
+TAR, BIN = DEST + "/traefik.tar.gz", DEST + "/traefik"
+
+def done():
+    try:
+        with tarfile.open(TAR) as t:
+            t.getmembers()
+        return True
+    except Exception:
+        return False
+
+def via_cmd(argv):
+    for _ in range(10):
+        if subprocess.call(argv) == 0 and done():
+            return True
+        time.sleep(2)
+    return done()
+
+def via_py():
+    for _ in range(30):
+        have = os.path.getsize(TAR) if os.path.exists(TAR) else 0
+        try:
+            req = urllib.request.Request(URL, headers={"Range": f"bytes={have}-", "User-Agent": "x"})
+            with urllib.request.urlopen(req, timeout=60) as r:
+                # if the server ignores Range it returns 200 + the full file; overwrite instead of appending
+                mode = "ab" if have and r.status == 206 else "wb"
+                with open(TAR, mode) as f:
+                    shutil.copyfileobj(r, f, 1 << 20)
+        except Exception:
+            time.sleep(2)
+            continue
+        if done():
+            return True
+    return done()
+
+ok = shutil.which("wget") and via_cmd(["wget", "-c", "-q", "-T", "60", "-O", TAR, URL])
+if not ok and shutil.which("curl"):
+    ok = via_cmd(["curl", "-fsSL", "-C", "-", "--max-time", "120", "-o", TAR, URL])
+if not ok:
+    ok = via_py()
+if not ok:
+    raise SystemExit("download failed")
+with tarfile.open(TAR) as t:
+    t.extract("traefik", DEST)
+os.chmod(BIN, 0o755)
+print("traefik ready")
+'''
+
+# Official Traefik release artifact. Override with the TRAEFIK_TARBALL env var to use a mirror or internal registry;
+# in production, prefer baking the binary into a custom template (see "FAQ") so no download is needed at runtime.
+TRAEFIK_TARBALL = os.environ.get(
+    "TRAEFIK_TARBALL",
+    "https://github.com/traefik/traefik/releases/download/"
+    "v3.7.8/traefik_v3.7.8_linux_amd64.tar.gz",
+)
+
+sbx.files.write(f"{WORKDIR}/get_traefik.py", GET_TRAEFIK)
+res = sbx.commands.run(
+    f"python3 {WORKDIR}/get_traefik.py",
+    envs={"TRAEFIK_TARBALL": TRAEFIK_TARBALL},
+    timeout=600,
+)
+assert res.exit_code == 0, res.stderr
+```
+
+### Step 3: Write the two-tier forwarding rules
+
+In Traefik's dynamic configuration, write two kinds of rules and use **priority** to make the header-pinning rules take precedence over the default weighting rule:
+
+```python
+TRAEFIK_PORT = 8080
+
+def dynamic_config(w1: int, w2: int) -> str:
+    """Split by weight w1:w2 by default; requests with the X-Version header are forced to the matching version."""
+    return f"""\
+http:
+  routers:
+    pin-v1:                                  # X-Version: v1 -> force v1
+      rule: "Header(`X-Version`, `v1`)"
+      entryPoints: [web]
+      service: v1
+      priority: 100
+    pin-v2:                                  # X-Version: v2 -> force v2
+      rule: "Header(`X-Version`, `v2`)"
+      entryPoints: [web]
+      service: v2
+      priority: 100
+    default:                                 # other traffic -> weighted split
+      rule: "PathPrefix(`/`)"
+      entryPoints: [web]
+      service: weighted
+      priority: 1
+  services:
+    weighted:
+      weighted:
+        services:
+          - {{name: v1, weight: {w1}}}
+          - {{name: v2, weight: {w2}}}
+    v1:
+      loadBalancer:
+        servers: [{{url: "http://127.0.0.1:{V1_PORT}"}}]
+    v2:
+      loadBalancer:
+        servers: [{{url: "http://127.0.0.1:{V2_PORT}"}}]
+"""
+
+def set_weights(w1: int, w2: int):
+    """Write/overwrite the config file; Traefik has watch enabled and hot-reloads automatically."""
+    sbx.files.write(f"{WORKDIR}/dynamic.yml", dynamic_config(w1, w2))
+```
+
+### Step 4: Start Traefik
+
+Start Traefik with `8080` as the external entry, and enable file-config hot reload:
+
+```python
+set_weights(100, 0)   # initial: all traffic to v1
+sbx.commands.run(
+    f"{WORKDIR}/traefik"
+    f" --entrypoints.web.address=:{TRAEFIK_PORT}"
+    f" --providers.file.filename={WORKDIR}/dynamic.yml"
+    f" --providers.file.watch=true"
+    f" --api.dashboard=false --log.level=INFO --accesslog=true",
+    background=True,
+)
+time.sleep(3)   # wait for Traefik to start and load config (in production, poll for readiness—see wait_ready in "Complete example")
+```
+
+### Step 5: Verify the canary effect
+
+Access the Traefik entry from outside and count the ratio of versions hit.
+
+```python
+import httpx
+from collections import Counter
+
+BASE = f"https://{sbx.get_host(TRAEFIK_PORT)}"
+# When secure=True and traffic tokens are enabled, accessing dynamic ports requires X-Access-Token; otherwise traffic_access_token is None
+TOKEN = sbx.traffic_access_token
+
+def sample(n: int, version: str | None = None) -> Counter:
+    headers = {"X-Access-Token": TOKEN} if TOKEN else {}
+    if version:
+        headers["X-Version"] = version
+    hits = Counter()
+    with httpx.Client(timeout=5) as c:
+        for _ in range(n):
+            body = c.get(BASE + "/", headers=headers).text
+            hits["v2" if "backend=v2" in body else "v1" if "backend=v1" in body else "?"] += 1
+    return hits
+
+# 1) Default weight-based canary: hot-adjust 100/0 -> 70/30 -> 30/70
+for w1, w2 in ((100, 0), (70, 30), (30, 70)):
+    set_weights(w1, w2)
+    time.sleep(3)                       # wait for hot reload
+    print(f"weight {w1}/{w2}:", dict(sample(100)))
+
+# 2) Header pinning: the default weight is still 30/70, but header requests should hit the specified version 100%
+print("X-Version=v1:", dict(sample(100, "v1")))
+print("X-Version=v2:", dict(sample(100, "v2")))
+```
+
+Expected output (exact ratios, and header pinning hitting 100%):
+
+```text
+weight 100/0: {'v1': 100}
+weight 70/30: {'v1': 70, 'v2': 30}
+weight 30/70: {'v1': 30, 'v2': 70}
+X-Version=v1: {'v1': 100}
+X-Version=v2: {'v2': 100}
+```
+
+> **Note**: weighted round-robin is a deterministic smooth interleave; sampling 100 requests yields a near-exact ratio—do not judge the ratio from a tiny sample (the printed `dict` key order may vary by which version is hit first, which does not affect the ratio). Remember to call `sbx.kill()` when done to reclaim the Sandbox and its background processes.
+
+## Advanced usage
+
+You only need to change the rules generated by `dynamic_config()`; the overall architecture stays the same:
+
+- **Path / query-based canary**: replace `Header(...)` with ``PathPrefix(`/beta`)`` or ``Query(`canary`, `true`)`` to route requests with a specific path or query parameter to the new version.
+- **Blue-green deployment**: switch the weight from `100/0` to `0/100` in one shot for a full cutover.
+- **Session stickiness**: configure `sticky.cookie` on the service so the same user always hits the same version during the canary, avoiding a jarring experience.
+- **Traffic mirroring**: use `mirroring` to **copy** a portion of traffic to the new version (responses discarded), observing without affecting real users.
+- **Active health checks**: configure `loadBalancer.healthCheck` for backends so unhealthy instances are removed automatically, making the canary safer.
+
+## FAQ
+
+**1. Traefik download is slow or fails?**
+Accessing GitHub release artifacts can be slow. Suggestions:
+
+- On slow networks, use a GitHub acceleration proxy (such as `ghfast.top`) and override the default download URL via the `TRAEFIK_TARBALL` environment variable; note that third-party proxies are outside your trust boundary—verify the binary's hash after downloading.
+- Or upload Traefik to your own object storage / internal mirror in advance and point `TRAEFIK_TARBALL` to that address.
+- **Recommended**: bake the Traefik binary into a **custom Sandbox template image** so no download is needed at runtime (see [Build a Sandbox Template from a GHCR Custom Image](./07.Build%20a%20Sandbox%20Template%20from%20a%20GHCR%20Custom%20Image.md)).
+
+**2. Port access returns 5xx?**
+Confirm the exposed port is within `[3000, 65535]` and the corresponding service inside the Sandbox is already listening and ready.
+
+**3. How do I ensure secure access in production?**
+Enable Sandbox access control (`secure=True`). When traffic tokens are enabled, accessing dynamic ports requires the `X-Access-Token` header, obtained via the public property `sbx.traffic_access_token` (this property is `None` when traffic tokens are not enabled, in which case no header is needed); see the cloud Sandbox "Secure Access" documentation for how to obtain and use the token. Never write access tokens into logs or front-end code.
+
+**4. How do I choose the version identification method?**
+This document distinguishes versions by "response content" for demo simplicity; in production, prefer having the backend expose the version via a **response header** (such as `X-App-Version`)—it is out-of-band metadata that does not pollute the business response body and is easier for gateways, monitoring, and tracing to collect uniformly.
+
+## Complete example
+
+Combine the steps above into a single runnable script `canary_demo.py`. Compared with the demo snippets in the procedure, this script adds production hardening: it creates the Sandbox with `secure=True` by default (automatically attaching `X-Access-Token` when traffic tokens are enabled in the environment), adds port-readiness polling, asserts the ratio for each weight tier, and cleans up processes and the Sandbox in a `finally` block. `E2B_API_KEY`, `E2B_DOMAIN`, and `E2B_API_URL` are all read from environment variables.
+
+```python
+#!/usr/bin/env python3
+"""A runnable example of Traefik-based service traffic canary routing inside a single cloud Sandbox.
+
+Hot-adjust weights in stages (100/0 -> 70/30 -> 30/70) to verify weight-based canary,
+then use the X-Version header to verify header pinning (higher priority than the weighted split).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from collections import Counter
+
+import httpx
+
+from e2b import Sandbox
+
+TEMPLATE = os.environ.get("E2B_TEMPLATE_ID", "base")
+
+TRAEFIK_PORT = 8080                 # Traefik external entry
+V1_PORT, V2_PORT = 9000, 9001       # two backends (visible only inside the Sandbox)
+N_REQUESTS = 100                    # number of sample requests per round
+SANDBOX_TIMEOUT = 600               # sandbox lifetime in seconds
+VERSION_HEADER = "X-Version"        # this header (value v1/v2) forces the matching version
+WORKDIR = "/tmp/canary"
+
+# Official Traefik release artifact. Override with the TRAEFIK_TARBALL env var to use a mirror or internal registry;
+# in production, prefer baking the binary into a custom template (see "FAQ") so no download is needed at runtime.
+TRAEFIK_TARBALL = os.environ.get(
+    "TRAEFIK_TARBALL",
+    "https://github.com/traefik/traefik/releases/download/"
+    "v3.7.8/traefik_v3.7.8_linux_amd64.tar.gz",
+)
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+def log(step: str, msg: str = "") -> None:
+    print(f"\n[{step}] {msg}", flush=True)
+
+
+def conn_opts() -> dict:
+    """Assemble SDK connection parameters from environment variables."""
+    api_key = os.environ.get("E2B_API_KEY")
+    if not api_key:
+        sys.exit("ERROR: E2B_API_KEY must be set")
+    opts = {"api_key": api_key}
+    for env, key in (("E2B_API_URL", "api_url"), ("E2B_DOMAIN", "domain")):
+        if val := os.environ.get(env):
+            opts[key] = val
+    return opts
+
+
+def auth(sbx: Sandbox) -> dict:
+    """Sandboxes with traffic tokens enabled need X-Access-Token to access dynamic ports; traffic_access_token is None when not enabled."""
+    token = sbx.traffic_access_token
+    return {"X-Access-Token": token} if token else {}
+
+
+def url(sbx: Sandbox, port: int = TRAEFIK_PORT, path: str = "/") -> str:
+    return f"https://{sbx.get_host(port)}{path}"
+
+
+def classify(resp: httpx.Response) -> str | None:
+    """Determine which version was hit from the response body (backend homepage content is backend=v1 / backend=v2)."""
+    if "backend=v2" in resp.text:
+        return "v2"
+    if "backend=v1" in resp.text:
+        return "v1"
+    return None
+
+
+def wait_ready(sbx: Sandbox, port: int, expect: str, retries: int = 30) -> bool:
+    """Poll a port until it returns 200 and the body contains expect."""
+    for _ in range(retries):
+        try:
+            r = httpx.get(url(sbx, port), headers=auth(sbx), timeout=3)
+            if r.status_code == 200 and expect in r.text:
+                return True
+        except (httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError):
+            pass
+        time.sleep(1)
+    return False
+
+
+def sample(sbx: Sandbox, n: int, version: str | None = None) -> Counter:
+    """Make n requests (if version is set, add the X-Version header to pin the version); count hit versions by response body."""
+    headers = auth(sbx)
+    if version:
+        headers[VERSION_HEADER] = version
+    hits: Counter = Counter()
+    with httpx.Client(timeout=5) as client:
+        for _ in range(n):
+            try:
+                r = client.get(url(sbx), headers=headers)
+                hits[classify(r) or f"other({r.status_code})"] += 1
+            except Exception as exc:  # count exceptions too in this demo
+                hits[f"error:{type(exc).__name__}"] += 1
+    return hits
+
+
+def show(hits: Counter, n: int) -> None:
+    for k in sorted(hits):
+        print(f"        {k:>12}: {hits[k]:>4}  ({hits[k] / n * 100:5.1f}%)", flush=True)
+
+
+# --------------------------------------------------------------------------
+# Backends & Traefik
+# --------------------------------------------------------------------------
+def start_backend(sbx: Sandbox, name: str, port: int):
+    """Write a version marker page and start a python http.server as that version's backend."""
+    sbx.files.write(f"{WORKDIR}/{name}/index.html", f"backend={name} port={port}\n")
+    return sbx.commands.run(
+        f"python3 -m http.server {port}", cwd=f"{WORKDIR}/{name}", background=True
+    )
+
+
+def dynamic_config(w1: int, w2: int) -> str:
+    """Two-tier routing: header-pinned version (high priority) takes precedence over the default weighted (w1:w2) split."""
+    return f"""\
+http:
+  routers:
+    pin-v1:                                  # X-Version: v1 -> force v1
+      rule: "Header(`{VERSION_HEADER}`, `v1`)"
+      entryPoints: [web]
+      service: v1
+      priority: 100
+    pin-v2:                                  # X-Version: v2 -> force v2
+      rule: "Header(`{VERSION_HEADER}`, `v2`)"
+      entryPoints: [web]
+      service: v2
+      priority: 100
+    default:                                 # other traffic -> weighted split
+      rule: "PathPrefix(`/`)"
+      entryPoints: [web]
+      service: weighted
+      priority: 1
+  services:
+    weighted:
+      weighted:
+        services:
+          - {{name: v1, weight: {w1}}}
+          - {{name: v2, weight: {w2}}}
+    v1:
+      loadBalancer:
+        servers: [{{url: "http://127.0.0.1:{V1_PORT}"}}]
+    v2:
+      loadBalancer:
+        servers: [{{url: "http://127.0.0.1:{V2_PORT}"}}]
+"""
+
+
+def set_weights(sbx: Sandbox, w1: int, w2: int) -> None:
+    """Write/overwrite dynamic.yml; Traefik has watch enabled and hot-reloads the new weights within seconds."""
+    sbx.files.write(f"{WORKDIR}/dynamic.yml", dynamic_config(w1, w2))
+
+
+# Download and unpack traefik inside the Sandbox, hardened with resumable download for rate-limited/broken connections.
+GET_TRAEFIK = r'''
+import os, shutil, subprocess, tarfile, time, urllib.request
+DEST, URL = "/tmp/canary", os.environ["TRAEFIK_TARBALL"]
+TAR, BIN = DEST + "/traefik.tar.gz", DEST + "/traefik"
+
+def done():
+    try:
+        with tarfile.open(TAR) as t:
+            t.getmembers()
+        return True
+    except Exception:
+        return False
+
+def via_cmd(argv):
+    for _ in range(10):
+        if subprocess.call(argv) == 0 and done():
+            return True
+        time.sleep(2)
+    return done()
+
+def via_py():
+    for _ in range(30):
+        have = os.path.getsize(TAR) if os.path.exists(TAR) else 0
+        try:
+            req = urllib.request.Request(URL, headers={"Range": f"bytes={have}-", "User-Agent": "x"})
+            with urllib.request.urlopen(req, timeout=60) as r:
+                # if the server ignores Range it returns 200 + the full file; overwrite instead of appending
+                mode = "ab" if have and r.status == 206 else "wb"
+                with open(TAR, mode) as f:
+                    shutil.copyfileobj(r, f, 1 << 20)
+        except Exception:
+            time.sleep(2)
+            continue
+        if done():
+            return True
+    return done()
+
+ok = shutil.which("wget") and via_cmd(["wget", "-c", "-q", "-T", "60", "-O", TAR, URL])
+if not ok and shutil.which("curl"):
+    ok = via_cmd(["curl", "-fsSL", "-C", "-", "--max-time", "120", "-o", TAR, URL])
+if not ok:
+    ok = via_py()
+if not ok:
+    raise SystemExit("download failed")
+with tarfile.open(TAR) as t:
+    t.extract("traefik", DEST)
+os.chmod(BIN, 0o755)
+print("traefik ready")
+'''
+
+
+def provision_traefik(sbx: Sandbox) -> None:
+    sbx.files.write(f"{WORKDIR}/get_traefik.py", GET_TRAEFIK)
+    res = sbx.commands.run(
+        f"python3 {WORKDIR}/get_traefik.py",
+        envs={"TRAEFIK_TARBALL": TRAEFIK_TARBALL},
+        timeout=600,
+    )
+    if res.exit_code != 0:
+        raise RuntimeError(f"Failed to download traefik; point TRAEFIK_TARBALL to an internal mirror:\n{res.stderr}")
+
+
+def start_traefik(sbx: Sandbox):
+    """Start the traefik process (dynamic.yml must be written first by set_weights)."""
+    cmd = (
+        f"{WORKDIR}/traefik"
+        f" --entrypoints.web.address=:{TRAEFIK_PORT}"
+        f" --providers.file.filename={WORKDIR}/dynamic.yml"
+        f" --providers.file.watch=true"
+        f" --api.dashboard=false --log.level=INFO --accesslog=true"
+    )
+    return sbx.commands.run(cmd, background=True)
+
+
+# --------------------------------------------------------------------------
+# Main flow: hot-adjust weights in stages (100/0 -> 70/30 -> 30/70), sampling each time to verify the ratio
+# --------------------------------------------------------------------------
+def check_ratio(sbx: Sandbox, w1: int, w2: int) -> None:
+    """Sample N times and verify the v1 ratio is close to w1/(w1+w2)."""
+    hits = sample(sbx, N_REQUESTS)
+    show(hits, N_REQUESTS)
+    exp_v1 = w1 / (w1 + w2) * 100
+    got_v1 = hits["v1"] / N_REQUESTS * 100
+    # weighted round-robin is a deterministic interleave; ±12 percentage points covers jitter
+    assert abs(got_v1 - exp_v1) <= 12, f"ratio deviation: v1={got_v1:.0f}% expected≈{exp_v1:.0f}%"
+
+
+def reweight(sbx: Sandbox, w1: int, w2: int) -> None:
+    """Hot-update weights and wait for the file provider to reload."""
+    set_weights(sbx, w1, w2)
+    time.sleep(3)  # file provider watch hot-reload latency is about 1~2s
+
+
+def main() -> int:
+    log("create", f"create sandbox (template={TEMPLATE})")
+    sbx = Sandbox.create(template=TEMPLATE, timeout=SANDBOX_TIMEOUT, secure=True, **conn_opts())
+    print(f"    sandbox_id = {sbx.sandbox_id}", flush=True)
+
+    procs = []
+    try:
+        # 1. start v1 service
+        log("1", f"start v1 service: http.server:{V1_PORT}")
+        procs.append(start_backend(sbx, "v1", V1_PORT))
+        if not wait_ready(sbx, V1_PORT, "v1"):
+            raise RuntimeError("v1 not ready")
+
+        # start traefik (initial weight 100/0, only v1 exists at this point)
+        log("traefik", "download and start traefik")
+        provision_traefik(sbx)
+        set_weights(sbx, 100, 0)
+        procs.append(start_traefik(sbx))
+        if not wait_ready(sbx, TRAEFIK_PORT, "backend="):
+            raise RuntimeError("traefik entry not ready")
+        print(f"    external URL: {url(sbx)}", flush=True)
+
+        # 2. test requests to v1 (through traefik, expect all v1)
+        log("2", f"test requests to v1 ({N_REQUESTS} times, expect 100% v1)")
+        check_ratio(sbx, 100, 0)
+
+        # 3. start v2 service
+        log("3", f"start v2 service: http.server:{V2_PORT}")
+        procs.append(start_backend(sbx, "v2", V2_PORT))
+        if not wait_ready(sbx, V2_PORT, "v2"):
+            raise RuntimeError("v2 not ready")
+
+        # 4. hot-adjust weights in stages, sampling each time to verify the ratio: 100/0 -> 70/30 -> 30/70
+        for w1, w2 in ((100, 0), (70, 30), (30, 70)):
+            log(f"weight {w1}/{w2}", f"hot-reload weight and sample {N_REQUESTS} times to verify the ratio")
+            reweight(sbx, w1, w2)
+            check_ratio(sbx, w1, w2)
+
+        # 5. Header pinning: force the specified version with the X-Version header (higher priority than default weighting)
+        for want in ("v1", "v2"):
+            log(f"Header {want}", f"with {VERSION_HEADER}: {want}, sample {N_REQUESTS} times, expect 100% {want}")
+            hits = sample(sbx, N_REQUESTS, version=want)
+            show(hits, N_REQUESTS)
+            assert hits[want] == N_REQUESTS, f"Header pin {want} did not all hit: {dict(hits)}"
+
+        print("\nStaged weighting + Header pinning verified ✔", flush=True)
+        return 0
+    finally:
+        log("cleanup", "clean up processes and sandbox")
+        for p in procs:
+            try:
+                sbx.commands.kill(p.pid)
+            except Exception:
+                pass
+        sbx.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Set the environment variables, then run it directly:
+
+```bash
+export E2B_API_KEY="<your-e2b-api-key>"
+export E2B_DOMAIN="us-west-1.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.us-west-1.e2b.fc.aliyuncs.com"
+python3 canary_demo.py
+```
+
+A normal run prints the split ratio for each stage, closely matching the configured weights:
+
+```text
+[create] create sandbox (template=base)
+    sandbox_id = sbx-xxxxxxxx
+    external URL: https://8080-sbx-xxxxxxxx.us-west-1.e2b.fc.aliyuncs.com/
+
+[2] test requests to v1 (100 times, expect 100% v1)
+                  v1:  100  (100.0%)
+
+[weight 70/30] hot-reload weight and sample 100 times to verify the ratio
+                  v1:   70  ( 70.0%)
+                  v2:   30  ( 30.0%)
+
+[weight 30/70] hot-reload weight and sample 100 times to verify the ratio
+                  v1:   30  ( 30.0%)
+                  v2:   70  ( 70.0%)
+
+[Header v1] with X-Version: v1, sample 100 times, expect 100% v1
+                  v1:  100  (100.0%)
+
+[Header v2] with X-Version: v2, sample 100 times, expect 100% v2
+                  v2:  100  (100.0%)
+
+Staged weighting + Header pinning verified ✔
+```
+
+## Related features
+
+- [Sandbox Public URL](../04.Features/06.Network/04.Sandbox%20Public%20URL.md)
+- [Public Access](../04.Features/06.Network/03.Public%20Access.md)
+- [Background Commands](../04.Features/03.Commands/05.Background%20Commands.md)
+- [Read and Write Files](../04.Features/04.Filesystem/02.Read%20and%20Write%20Files.md)
+- [Build a Sandbox Template from a GHCR Custom Image](./07.Build%20a%20Sandbox%20Template%20from%20a%20GHCR%20Custom%20Image.md)

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/08.使用 Traefik 做服务流量灰度转发.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/08.使用 Traefik 做服务流量灰度转发.md
@@ -1,0 +1,646 @@
+# 使用 Traefik 做服务流量灰度转发
+
+## 背景信息
+
+在云沙箱（Sandbox）中运行在线服务时，常常需要在**不中断服务**的前提下把新版本（v2）逐步放量：先让一小部分流量打到新版本观察效果，确认无误后再逐步扩大比例，或直接让内部用户定向访问新版本做验证。这一「灰度发布 / 金丝雀发布」能力，可以在沙箱内引入轻量反向代理 **Traefik** 来实现。
+
+> **关于 Traefik**：[Traefik](https://traefik.io/) 是一款开源的云原生反向代理与负载均衡器，以单文件二进制分发、无外部依赖，可直接在沙箱内下载运行。它最大的特点是**动态配置**——路由规则、后端服务、分流权重都能通过配置文件实时下发，配合文件监听（`watch`）做到秒级热更新、无需重启进程，因此特别适合灰度发布、蓝绿发布这类需要在线调整流量的场景。
+
+本文以两个版本的 HTTP 服务（v1 / v2）为例，介绍如何在一个云沙箱内用 Traefik 完成两类灰度转发：
+
+- **按权重灰度**：默认流量按比例分给 v1 / v2（如 70% / 30%），并可在运行时**热调整**比例，无需重启。
+- **按 Header 定向**：携带指定请求头（如 `X-Version: v2`）的请求强制命中某个版本，常用于内部/白名单验证。
+
+## 方案概述
+
+沙箱对外只暴露 **Traefik 的入口端口**，由 Traefik 在沙箱内部按规则把请求转发到 v1 / v2：
+
+
+<img src="https://img.alicdn.com/imgextra/i4/O1CN01ylm5EM1dFrMymAvAW_!!6000000003707-2-tps-1143-1239.png" alt="Traefik 在云沙箱内做灰度转发的流量链路示意" width="480" />
+
+- 云沙箱会为沙箱内监听的每个端口分配一个外部访问地址，通过 SDK 的 `sandbox.get_host(port)` 获取，拼接 `https://` 即可从外部访问。**可对外暴露的端口范围为 `[3000, 65535]`**。
+- v1 / v2 是两个只在沙箱内部监听的后端服务；外部无需（也不应）直接访问它们，统一走 Traefik 入口。
+- Traefik 使用「文件配置 + 热加载」（`--providers.file.watch=true`）：调整灰度规则时只需重写一个配置文件，Traefik 会在秒级内自动生效，**无需重启进程、不中断流量**。
+
+## 前置条件
+
+- 已开通云沙箱，并获取目标地域的 `E2B_API_KEY`。
+- 目标地域为美国（硅谷），对应接入点：
+  - `api_url`：`https://api.us-west-1.e2b.fc.aliyuncs.com`
+  - `domain`：`us-west-1.e2b.fc.aliyuncs.com`
+- 沙箱需要能访问公网以下载 Traefik 二进制（国内环境建议使用镜像加速，见「常见问题」）。
+- 安装云沙箱 Python SDK 及 HTTP 客户端，并将连接参数设置为环境变量：
+
+  ```bash
+  pip install e2b httpx
+
+  export E2B_API_KEY="<your-e2b-api-key>"
+  export E2B_DOMAIN="us-west-1.e2b.fc.aliyuncs.com"
+  export E2B_API_URL="https://api.us-west-1.e2b.fc.aliyuncs.com"
+  ```
+
+## 操作步骤
+
+### 步骤一：创建沙箱并启动两个版本的后端服务
+
+用 `python3 -m http.server` 模拟两个版本，各自目录下放一个可区分版本的首页，方便验证「本次请求命中了哪个版本」。
+
+```python
+import os
+import time
+
+from e2b import Sandbox
+
+WORKDIR = "/tmp/canary"
+V1_PORT, V2_PORT = 9000, 9001
+
+conn = {
+    "api_key": os.environ["E2B_API_KEY"],
+    "api_url": os.environ["E2B_API_URL"],
+    "domain": os.environ["E2B_DOMAIN"],
+}
+
+# secure=True（SDK 默认）：启用访问控制，从外部访问动态端口时按需附加 X-Access-Token（见步骤五）
+sbx = Sandbox.create(template="base", timeout=600, secure=True, **conn)
+
+# v1 后端：首页内容标识为 v1
+sbx.files.write(f"{WORKDIR}/v1/index.html", "backend=v1\n")
+sbx.commands.run(f"python3 -m http.server {V1_PORT}", cwd=f"{WORKDIR}/v1", background=True)
+
+# v2 后端：首页内容标识为 v2
+sbx.files.write(f"{WORKDIR}/v2/index.html", "backend=v2\n")
+sbx.commands.run(f"python3 -m http.server {V2_PORT}", cwd=f"{WORKDIR}/v2", background=True)
+```
+
+> **说明**：`secure=True` 是 SDK 默认值，也是生产推荐值——沙箱开启访问控制后，从外部访问动态端口需按需附加 `X-Access-Token`（见步骤五、「常见问题」第 3 条）。若只想本地快速验证、不处理令牌，可临时改用 `secure=False`（对外免令牌，仅限演示/测试）。
+
+### 步骤二：在沙箱内部署 Traefik
+
+在沙箱内下载并解压 Traefik（等价于在沙箱里执行 `curl -O` 后解包）。下面用 Python 完成下载，兼容未预装 `curl` / `wget` 的模板，并对弱网做了断点续传兜底。
+
+```python
+GET_TRAEFIK = r'''
+import os, shutil, subprocess, tarfile, time, urllib.request
+DEST, URL = "/tmp/canary", os.environ["TRAEFIK_TARBALL"]
+TAR, BIN = DEST + "/traefik.tar.gz", DEST + "/traefik"
+
+def done():
+    try:
+        with tarfile.open(TAR) as t:
+            t.getmembers()
+        return True
+    except Exception:
+        return False
+
+def via_cmd(argv):
+    for _ in range(10):
+        if subprocess.call(argv) == 0 and done():
+            return True
+        time.sleep(2)
+    return done()
+
+def via_py():
+    for _ in range(30):
+        have = os.path.getsize(TAR) if os.path.exists(TAR) else 0
+        try:
+            req = urllib.request.Request(URL, headers={"Range": f"bytes={have}-", "User-Agent": "x"})
+            with urllib.request.urlopen(req, timeout=60) as r:
+                # 服务端忽略 Range 会回 200 + 完整包，此时须覆盖写而非续写
+                mode = "ab" if have and r.status == 206 else "wb"
+                with open(TAR, mode) as f:
+                    shutil.copyfileobj(r, f, 1 << 20)
+        except Exception:
+            time.sleep(2)
+            continue
+        if done():
+            return True
+    return done()
+
+ok = shutil.which("wget") and via_cmd(["wget", "-c", "-q", "-T", "60", "-O", TAR, URL])
+if not ok and shutil.which("curl"):
+    ok = via_cmd(["curl", "-fsSL", "-C", "-", "--max-time", "120", "-o", TAR, URL])
+if not ok:
+    ok = via_py()
+if not ok:
+    raise SystemExit("download failed")
+with tarfile.open(TAR) as t:
+    t.extract("traefik", DEST)
+os.chmod(BIN, 0o755)
+print("traefik ready")
+'''
+
+# Traefik 官方发布产物。可用 TRAEFIK_TARBALL 环境变量覆盖为镜像加速地址或内网镜像；
+# 生产环境更推荐把二进制预置进自定义模板（见「常见问题」），运行时无需下载。
+TRAEFIK_TARBALL = os.environ.get(
+    "TRAEFIK_TARBALL",
+    "https://github.com/traefik/traefik/releases/download/"
+    "v3.7.8/traefik_v3.7.8_linux_amd64.tar.gz",
+)
+
+sbx.files.write(f"{WORKDIR}/get_traefik.py", GET_TRAEFIK)
+res = sbx.commands.run(
+    f"python3 {WORKDIR}/get_traefik.py",
+    envs={"TRAEFIK_TARBALL": TRAEFIK_TARBALL},
+    timeout=600,
+)
+assert res.exit_code == 0, res.stderr
+```
+
+### 步骤三：编写两级转发规则
+
+Traefik 的动态配置里写两类规则，用**优先级（priority）**让 Header 定向规则高于默认加权规则：
+
+```python
+TRAEFIK_PORT = 8080
+
+def dynamic_config(w1: int, w2: int) -> str:
+    """默认按权重 w1:w2 分流；带 X-Version 头的请求强制命中对应版本。"""
+    return f"""\
+http:
+  routers:
+    pin-v1:                                  # X-Version: v1 -> 强制 v1
+      rule: "Header(`X-Version`, `v1`)"
+      entryPoints: [web]
+      service: v1
+      priority: 100
+    pin-v2:                                  # X-Version: v2 -> 强制 v2
+      rule: "Header(`X-Version`, `v2`)"
+      entryPoints: [web]
+      service: v2
+      priority: 100
+    default:                                 # 其余流量 -> 按权重分流
+      rule: "PathPrefix(`/`)"
+      entryPoints: [web]
+      service: weighted
+      priority: 1
+  services:
+    weighted:
+      weighted:
+        services:
+          - {{name: v1, weight: {w1}}}
+          - {{name: v2, weight: {w2}}}
+    v1:
+      loadBalancer:
+        servers: [{{url: "http://127.0.0.1:{V1_PORT}"}}]
+    v2:
+      loadBalancer:
+        servers: [{{url: "http://127.0.0.1:{V2_PORT}"}}]
+"""
+
+def set_weights(w1: int, w2: int):
+    """写入/覆盖配置文件；Traefik 开启了 watch，会自动热加载。"""
+    sbx.files.write(f"{WORKDIR}/dynamic.yml", dynamic_config(w1, w2))
+```
+
+### 步骤四：启动 Traefik
+
+以 `8080` 作为对外入口启动 Traefik，并开启文件配置热加载：
+
+```python
+set_weights(100, 0)   # 初始：全部流量走 v1
+sbx.commands.run(
+    f"{WORKDIR}/traefik"
+    f" --entrypoints.web.address=:{TRAEFIK_PORT}"
+    f" --providers.file.filename={WORKDIR}/dynamic.yml"
+    f" --providers.file.watch=true"
+    f" --api.dashboard=false --log.level=INFO --accesslog=true",
+    background=True,
+)
+time.sleep(3)   # 等待 Traefik 启动并加载配置（生产建议改为轮询就绪，见「完整示例」的 wait_ready）
+```
+
+### 步骤五：验证灰度效果
+
+从外部访问 Traefik 入口，统计命中的版本占比。
+
+```python
+import httpx
+from collections import Counter
+
+BASE = f"https://{sbx.get_host(TRAEFIK_PORT)}"
+# secure=True 且环境启用流量令牌时，访问动态端口需带 X-Access-Token；未启用则 traffic_access_token 为 None
+TOKEN = sbx.traffic_access_token
+
+def sample(n: int, version: str | None = None) -> Counter:
+    headers = {"X-Access-Token": TOKEN} if TOKEN else {}
+    if version:
+        headers["X-Version"] = version
+    hits = Counter()
+    with httpx.Client(timeout=5) as c:
+        for _ in range(n):
+            body = c.get(BASE + "/", headers=headers).text
+            hits["v2" if "backend=v2" in body else "v1" if "backend=v1" in body else "?"] += 1
+    return hits
+
+# 1) 默认按权重灰度：热调 100/0 -> 70/30 -> 30/70
+for w1, w2 in ((100, 0), (70, 30), (30, 70)):
+    set_weights(w1, w2)
+    time.sleep(3)                       # 等待热加载生效
+    print(f"权重 {w1}/{w2}:", dict(sample(100)))
+
+# 2) Header 定向：此刻默认权重仍是 30/70，但带头请求应 100% 命中指定版本
+print("X-Version=v1:", dict(sample(100, "v1")))
+print("X-Version=v2:", dict(sample(100, "v2")))
+```
+
+预期输出（占比精确、Header 定向 100% 命中）：
+
+```text
+权重 100/0: {'v1': 100}
+权重 70/30: {'v1': 70, 'v2': 30}
+权重 30/70: {'v1': 30, 'v2': 70}
+X-Version=v1: {'v1': 100}
+X-Version=v2: {'v2': 100}
+```
+
+> **说明**：加权轮询是确定性平滑交织，采样 100 次即可得到接近精确的比例；不要用极小样本判断占比（打印出的 `dict` 键顺序可能因命中先后而不同，不影响比例）。任务结束后记得调用 `sbx.kill()` 回收沙箱与其中的后台进程。
+
+## 进阶用法
+
+只需修改 `dynamic_config()` 生成的规则，无需改动整体架构：
+
+- **按路径 / 参数灰度**：把 `Header(...)` 换成 ``PathPrefix(`/beta`)`` 或 ``Query(`canary`, `true`)``，即可让特定路径或带特定查询参数的请求命中新版本。
+- **蓝绿发布**：把权重从 `100/0` 一次性切到 `0/100` 完成整体切换。
+- **会话粘性**：为服务配置 `sticky.cookie`，保证同一用户在灰度期间始终命中同一版本，避免体验跳变。
+- **流量镜像**：用 `mirroring` 把一定比例的流量**复制**到新版本（响应丢弃），只观测不影响真实用户。
+- **主动健康检查**：为后端配置 `loadBalancer.healthCheck`，不健康的实例自动摘除，灰度更安全。
+
+## 常见问题
+
+**1. Traefik 下载缓慢或失败？**
+国内环境访问 GitHub 发布产物较慢。建议：
+
+- 网络慢时可用 GitHub 加速代理（如 `ghfast.top`），通过 `TRAEFIK_TARBALL` 环境变量覆盖默认下载地址；注意第三方代理不在你的信任域内，建议下载后校验二进制哈希再使用；
+- 或将 Traefik 预先上传到自建的对象存储 / 内网镜像，把 `TRAEFIK_TARBALL` 指向该地址；
+- **推荐做法**：把 Traefik 二进制**预置进自定义沙箱模板镜像**，运行时无需再下载即可直接使用（构建方式参见 [使用 GHCR 自定义镜像构建 Sandbox 模板](./07.使用%20GHCR%20自定义镜像构建%20Sandbox%20模板.md)）。
+
+**2. 端口访问返回 5xx？**
+确认对外暴露的端口在 `[3000, 65535]` 范围内，且沙箱内对应服务已经正常监听、就绪。
+
+**3. 生产环境如何保证访问安全？**
+开启沙箱访问控制（`secure=True`）。启用流量令牌后，访问动态端口需带 `X-Access-Token` 头，令牌通过公开属性 `sbx.traffic_access_token` 获取（未启用流量令牌时该属性为 `None`，此时无需附加）；令牌的获取与使用方式参见云沙箱「安全访问」文档。切勿把访问令牌写入日志或前端代码。
+
+**4. 版本识别方式如何选择？**
+本文用「响应内容」区分版本，便于演示；生产中更推荐让后端通过**响应头**（如 `X-App-Version`）暴露版本号——它属于带外元数据，不污染业务响应体，且便于网关、监控与链路追踪统一采集。
+
+## 完整示例
+
+把上述步骤整合为一个可直接运行的脚本 `canary_demo.py`。相比操作步骤中的演示片段，该脚本做了工程化处理：默认以 `secure=True` 创建沙箱（在环境启用了流量令牌时自动附加 `X-Access-Token`）、加入端口就绪轮询、对每一档权重做占比断言校验、并在 `finally` 中清理进程与沙箱。`E2B_API_KEY`、`E2B_DOMAIN`、`E2B_API_URL` 均从环境变量读取。
+
+```python
+#!/usr/bin/env python3
+"""在一个云沙箱内用 Traefik 做服务流量灰度转发的可运行示例。
+
+分阶段热调权重（100/0 -> 70/30 -> 30/70）验证按权重灰度，
+再带 X-Version 头验证 Header 定向（优先级高于加权分流）。
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from collections import Counter
+
+import httpx
+
+from e2b import Sandbox
+
+TEMPLATE = os.environ.get("E2B_TEMPLATE_ID", "base")
+
+TRAEFIK_PORT = 8080                 # Traefik 对外入口
+V1_PORT, V2_PORT = 9000, 9001       # 两个后端（仅沙箱内部可见）
+N_REQUESTS = 100                    # 每轮采样请求数
+SANDBOX_TIMEOUT = 600               # sandbox 存活秒数
+VERSION_HEADER = "X-Version"        # 带此头（值 v1/v2）即强制命中对应版本
+WORKDIR = "/tmp/canary"
+
+# Traefik 官方发布产物。可用 TRAEFIK_TARBALL 环境变量覆盖为镜像加速地址或内网镜像；
+# 生产环境更推荐把二进制预置进自定义模板（见「常见问题」），运行时无需下载。
+TRAEFIK_TARBALL = os.environ.get(
+    "TRAEFIK_TARBALL",
+    "https://github.com/traefik/traefik/releases/download/"
+    "v3.7.8/traefik_v3.7.8_linux_amd64.tar.gz",
+)
+
+
+# --------------------------------------------------------------------------
+# 基础工具
+# --------------------------------------------------------------------------
+def log(step: str, msg: str = "") -> None:
+    print(f"\n[{step}] {msg}", flush=True)
+
+
+def conn_opts() -> dict:
+    """从环境变量拼接 SDK 连接参数。"""
+    api_key = os.environ.get("E2B_API_KEY")
+    if not api_key:
+        sys.exit("ERROR: 必须设置 E2B_API_KEY")
+    opts = {"api_key": api_key}
+    for env, key in (("E2B_API_URL", "api_url"), ("E2B_DOMAIN", "domain")):
+        if val := os.environ.get(env):
+            opts[key] = val
+    return opts
+
+
+def auth(sbx: Sandbox) -> dict:
+    """启用流量令牌的沙箱访问动态端口需带 X-Access-Token；未启用时 traffic_access_token 为 None。"""
+    token = sbx.traffic_access_token
+    return {"X-Access-Token": token} if token else {}
+
+
+def url(sbx: Sandbox, port: int = TRAEFIK_PORT, path: str = "/") -> str:
+    return f"https://{sbx.get_host(port)}{path}"
+
+
+def classify(resp: httpx.Response) -> str | None:
+    """从响应体判定命中的版本（后端首页内容为 backend=v1 / backend=v2）。"""
+    if "backend=v2" in resp.text:
+        return "v2"
+    if "backend=v1" in resp.text:
+        return "v1"
+    return None
+
+
+def wait_ready(sbx: Sandbox, port: int, expect: str, retries: int = 30) -> bool:
+    """轮询某端口直到返回 200 且响应体包含 expect。"""
+    for _ in range(retries):
+        try:
+            r = httpx.get(url(sbx, port), headers=auth(sbx), timeout=3)
+            if r.status_code == 200 and expect in r.text:
+                return True
+        except (httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError):
+            pass
+        time.sleep(1)
+    return False
+
+
+def sample(sbx: Sandbox, n: int, version: str | None = None) -> Counter:
+    """打 n 次请求（version 非空则带 X-Version 头指定版本），按响应体统计命中的版本。"""
+    headers = auth(sbx)
+    if version:
+        headers[VERSION_HEADER] = version
+    hits: Counter = Counter()
+    with httpx.Client(timeout=5) as client:
+        for _ in range(n):
+            try:
+                r = client.get(url(sbx), headers=headers)
+                hits[classify(r) or f"other({r.status_code})"] += 1
+            except Exception as exc:  # demo 里把异常也计入统计
+                hits[f"error:{type(exc).__name__}"] += 1
+    return hits
+
+
+def show(hits: Counter, n: int) -> None:
+    for k in sorted(hits):
+        print(f"        {k:>12}: {hits[k]:>4}  ({hits[k] / n * 100:5.1f}%)", flush=True)
+
+
+# --------------------------------------------------------------------------
+# 后端 & Traefik
+# --------------------------------------------------------------------------
+def start_backend(sbx: Sandbox, name: str, port: int):
+    """写入版本标识页并起一个 python http.server 作为该版本后端。"""
+    sbx.files.write(f"{WORKDIR}/{name}/index.html", f"backend={name} port={port}\n")
+    return sbx.commands.run(
+        f"python3 -m http.server {port}", cwd=f"{WORKDIR}/{name}", background=True
+    )
+
+
+def dynamic_config(w1: int, w2: int) -> str:
+    """两级路由：Header 指定版本（高优先级）优先于默认加权（w1:w2）分流。"""
+    return f"""\
+http:
+  routers:
+    pin-v1:                                  # X-Version: v1 -> 强制 v1
+      rule: "Header(`{VERSION_HEADER}`, `v1`)"
+      entryPoints: [web]
+      service: v1
+      priority: 100
+    pin-v2:                                  # X-Version: v2 -> 强制 v2
+      rule: "Header(`{VERSION_HEADER}`, `v2`)"
+      entryPoints: [web]
+      service: v2
+      priority: 100
+    default:                                 # 其余流量 -> 按权重分流
+      rule: "PathPrefix(`/`)"
+      entryPoints: [web]
+      service: weighted
+      priority: 1
+  services:
+    weighted:
+      weighted:
+        services:
+          - {{name: v1, weight: {w1}}}
+          - {{name: v2, weight: {w2}}}
+    v1:
+      loadBalancer:
+        servers: [{{url: "http://127.0.0.1:{V1_PORT}"}}]
+    v2:
+      loadBalancer:
+        servers: [{{url: "http://127.0.0.1:{V2_PORT}"}}]
+"""
+
+
+def set_weights(sbx: Sandbox, w1: int, w2: int) -> None:
+    """写入/覆盖 dynamic.yml；Traefik 开了 watch，会秒级热加载新权重。"""
+    sbx.files.write(f"{WORKDIR}/dynamic.yml", dynamic_config(w1, w2))
+
+
+# 在沙箱内下载并解包 traefik，对限速/断流做了断点续传加固。
+GET_TRAEFIK = r'''
+import os, shutil, subprocess, tarfile, time, urllib.request
+DEST, URL = "/tmp/canary", os.environ["TRAEFIK_TARBALL"]
+TAR, BIN = DEST + "/traefik.tar.gz", DEST + "/traefik"
+
+def done():
+    try:
+        with tarfile.open(TAR) as t:
+            t.getmembers()
+        return True
+    except Exception:
+        return False
+
+def via_cmd(argv):
+    for _ in range(10):
+        if subprocess.call(argv) == 0 and done():
+            return True
+        time.sleep(2)
+    return done()
+
+def via_py():
+    for _ in range(30):
+        have = os.path.getsize(TAR) if os.path.exists(TAR) else 0
+        try:
+            req = urllib.request.Request(URL, headers={"Range": f"bytes={have}-", "User-Agent": "x"})
+            with urllib.request.urlopen(req, timeout=60) as r:
+                # 服务端忽略 Range 会回 200 + 完整包，此时须覆盖写而非续写
+                mode = "ab" if have and r.status == 206 else "wb"
+                with open(TAR, mode) as f:
+                    shutil.copyfileobj(r, f, 1 << 20)
+        except Exception:
+            time.sleep(2)
+            continue
+        if done():
+            return True
+    return done()
+
+ok = shutil.which("wget") and via_cmd(["wget", "-c", "-q", "-T", "60", "-O", TAR, URL])
+if not ok and shutil.which("curl"):
+    ok = via_cmd(["curl", "-fsSL", "-C", "-", "--max-time", "120", "-o", TAR, URL])
+if not ok:
+    ok = via_py()
+if not ok:
+    raise SystemExit("download failed")
+with tarfile.open(TAR) as t:
+    t.extract("traefik", DEST)
+os.chmod(BIN, 0o755)
+print("traefik ready")
+'''
+
+
+def provision_traefik(sbx: Sandbox) -> None:
+    sbx.files.write(f"{WORKDIR}/get_traefik.py", GET_TRAEFIK)
+    res = sbx.commands.run(
+        f"python3 {WORKDIR}/get_traefik.py",
+        envs={"TRAEFIK_TARBALL": TRAEFIK_TARBALL},
+        timeout=600,
+    )
+    if res.exit_code != 0:
+        raise RuntimeError(f"下载 traefik 失败，可改 TRAEFIK_TARBALL 指向内网镜像:\n{res.stderr}")
+
+
+def start_traefik(sbx: Sandbox):
+    """启动 traefik 进程（dynamic.yml 需先由 set_weights 写好）。"""
+    cmd = (
+        f"{WORKDIR}/traefik"
+        f" --entrypoints.web.address=:{TRAEFIK_PORT}"
+        f" --providers.file.filename={WORKDIR}/dynamic.yml"
+        f" --providers.file.watch=true"
+        f" --api.dashboard=false --log.level=INFO --accesslog=true"
+    )
+    return sbx.commands.run(cmd, background=True)
+
+
+# --------------------------------------------------------------------------
+# 主流程：按权重分阶段热调（100/0 -> 70/30 -> 30/70），每次采样验证占比
+# --------------------------------------------------------------------------
+def check_ratio(sbx: Sandbox, w1: int, w2: int) -> None:
+    """采样 N 次并校验 v1 占比接近 w1/(w1+w2)。"""
+    hits = sample(sbx, N_REQUESTS)
+    show(hits, N_REQUESTS)
+    exp_v1 = w1 / (w1 + w2) * 100
+    got_v1 = hits["v1"] / N_REQUESTS * 100
+    # 加权轮询是确定性交织，±12 个百分点足够覆盖抖动
+    assert abs(got_v1 - exp_v1) <= 12, f"占比偏离: v1={got_v1:.0f}% 期望≈{exp_v1:.0f}%"
+
+
+def reweight(sbx: Sandbox, w1: int, w2: int) -> None:
+    """热更新权重并等待 file provider 重新加载。"""
+    set_weights(sbx, w1, w2)
+    time.sleep(3)  # file provider watch 热加载延迟约 1~2s
+
+
+def main() -> int:
+    log("创建", f"创建 sandbox (template={TEMPLATE})")
+    sbx = Sandbox.create(template=TEMPLATE, timeout=SANDBOX_TIMEOUT, secure=True, **conn_opts())
+    print(f"    sandbox_id = {sbx.sandbox_id}", flush=True)
+
+    procs = []
+    try:
+        # 1. 启动 v1 服务
+        log("1", f"启动 v1 服务: http.server:{V1_PORT}")
+        procs.append(start_backend(sbx, "v1", V1_PORT))
+        if not wait_ready(sbx, V1_PORT, "v1"):
+            raise RuntimeError("v1 未就绪")
+
+        # 起 traefik（初始权重 100/0，此时只有 v1）
+        log("traefik", "下载并启动 traefik")
+        provision_traefik(sbx)
+        set_weights(sbx, 100, 0)
+        procs.append(start_traefik(sbx))
+        if not wait_ready(sbx, TRAEFIK_PORT, "backend="):
+            raise RuntimeError("traefik 入口未就绪")
+        print(f"    对外地址: {url(sbx)}", flush=True)
+
+        # 2. 测试请求 v1 服务（经 traefik，期望全部 v1）
+        log("2", f"测试请求 v1（{N_REQUESTS} 次，期望 100% v1）")
+        check_ratio(sbx, 100, 0)
+
+        # 3. 启动 v2 服务
+        log("3", f"启动 v2 服务: http.server:{V2_PORT}")
+        procs.append(start_backend(sbx, "v2", V2_PORT))
+        if not wait_ready(sbx, V2_PORT, "v2"):
+            raise RuntimeError("v2 未就绪")
+
+        # 4. 分阶段热调权重，每次采样验证占比：100/0 -> 70/30 -> 30/70
+        for w1, w2 in ((100, 0), (70, 30), (30, 70)):
+            log(f"权重 {w1}/{w2}", f"热更新权重并采样 {N_REQUESTS} 次验证占比")
+            reweight(sbx, w1, w2)
+            check_ratio(sbx, w1, w2)
+
+        # 5. Header 定向：带 X-Version 头强制命中指定版本（优先级高于默认加权）
+        for want in ("v1", "v2"):
+            log(f"Header {want}", f"带 {VERSION_HEADER}: {want} 采样 {N_REQUESTS} 次，期望 100% {want}")
+            hits = sample(sbx, N_REQUESTS, version=want)
+            show(hits, N_REQUESTS)
+            assert hits[want] == N_REQUESTS, f"Header 指定 {want} 未全部命中: {dict(hits)}"
+
+        print("\n分阶段加权 + Header 定向验证通过 ✔", flush=True)
+        return 0
+    finally:
+        log("cleanup", "清理进程与 sandbox")
+        for p in procs:
+            try:
+                sbx.commands.kill(p.pid)
+            except Exception:
+                pass
+        sbx.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+设置好环境变量后直接运行即可：
+
+```bash
+export E2B_API_KEY="<your-e2b-api-key>"
+export E2B_DOMAIN="us-west-1.e2b.fc.aliyuncs.com"
+export E2B_API_URL="https://api.us-west-1.e2b.fc.aliyuncs.com"
+python3 canary_demo.py
+```
+
+正常运行会依次打印各阶段的分流占比，实际结果与设定权重高度吻合：
+
+```text
+[创建] 创建 sandbox (template=base)
+    sandbox_id = sbx-xxxxxxxx
+    对外地址: https://8080-sbx-xxxxxxxx.us-west-1.e2b.fc.aliyuncs.com/
+
+[2] 测试请求 v1（100 次，期望 100% v1）
+                  v1:  100  (100.0%)
+
+[权重 70/30] 热更新权重并采样 100 次验证占比
+                  v1:   70  ( 70.0%)
+                  v2:   30  ( 30.0%)
+
+[权重 30/70] 热更新权重并采样 100 次验证占比
+                  v1:   30  ( 30.0%)
+                  v2:   70  ( 70.0%)
+
+[Header v1] 带 X-Version: v1 采样 100 次，期望 100% v1
+                  v1:  100  (100.0%)
+
+[Header v2] 带 X-Version: v2 采样 100 次，期望 100% v2
+                  v2:  100  (100.0%)
+
+分阶段加权 + Header 定向验证通过 ✔
+```
+
+## 相关功能
+
+- [Sandbox 公网 URL](../04.功能说明/06.网络/04.Sandbox%20公网%20URL.md)
+- [公网访问](../04.功能说明/06.网络/03.公网访问.md)
+- [后台命令](../04.功能说明/03.命令/05.后台命令.md)
+- [读写文件](../04.功能说明/04.文件系统/02.读写文件.md)
+- [使用 GHCR 自定义镜像构建 Sandbox 模板](./07.使用%20GHCR%20自定义镜像构建%20Sandbox%20模板.md)


### PR DESCRIPTION
## What

Add a best-practice guide: **Use Traefik for Canary Traffic Routing** inside an FC Agent Sandbox.

- **Weight-based canary**: split default traffic across v1/v2 by weight, hot-adjustable at runtime (Traefik file provider + `watch`, no restart).
- **Header-based pinning**: `X-Version: v1|v2` forces a specific version (higher priority than the weighted split).

## Contents

- Chinese: `docs/zh-CN/01.云沙箱/05.最佳实践/08.使用 Traefik 做服务流量灰度转发.md`
- English: `docs/en-US/01.FC Agent Sandbox/05.Best Practices/08.Use Traefik for Canary Traffic Routing.md`

Structure: Background / About Traefik / Solution overview / Prerequisites / step-by-step Procedure / Advanced usage / FAQ / runnable Complete example.

## Verification

The 5-step procedure and the complete example were both run end-to-end against `us-west-1` (template `base`, Traefik v3.7.8): weighted ratios 100/0, 70/30, 30/70 matched, and header pinning hit the target version 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 面向 FC Agent Sandbox，新增中英文两份 Traefik 灰度流量转发最佳实践文档，属于“最佳实践”章节：

- 英文文档：`docs/en-US/01.FC Agent Sandbox/05.Best Practices/`
- 中文文档：`docs/zh-CN/01.云沙箱/05.最佳实践/`

文档涵盖基于权重的流量分配、请求头版本固定、配置热更新、操作步骤、FAQ 及完整示例。

本次仅新增 2 个文档页面，未删除页面；未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->