### PR TITLE
docs(sandbox): 补充 Claude Code 与 OpenClaw 模板文档

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Examples/04.Claude Code Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Examples/04.Claude Code Template.md
@@ -1,0 +1,173 @@
+# Claude Code Template Example
+
+Claude Code is Anthropic's terminal-based AI coding agent that can read code, modify files, and execute commands within a sandbox. The Claude Code template is built from the official `claude-code` image, with the Claude Code CLI and its runtime dependencies preinstalled and ready to use. This page covers capabilities, default configuration, build and minimal verification, and limitations. For real-task tutorials such as cloning repositories, connecting MCP, extending Skills, and getting structured output, see [Claude Code Custom Image](../../../05.Best%20Practices/05.Claude%20Code%20Custom%20Image.md).
+
+We have pre-built `claude-code` images in ACR across all regions, so you don't need to push images or configure ACREE yourself. Simply select an image address below and build a template using `from_image` + `Template.build` to get started.
+
+## Features
+
+| **Feature** | **Description** |
+| --- | --- |
+| Coding agent | Ships with the Claude Code CLI, which can read code, modify files, and execute commands in the sandbox; supports non-interactive mode `-p` and `--dangerously-skip-permissions` |
+| Session management | Supports `--resume` to restore previous sessions and `--output-format json` for structured results |
+| Native MCP | Claude Code natively supports [MCP](https://modelcontextprotocol.io/); register stdio / HTTP MCP Servers via `claude mcp add` |
+| Skill extension | Extend Agent capabilities through a filesystem convention of a directory plus `SKILL.md`, effective per repository or working directory |
+| Secure isolation | Each Claude Code sandbox instance has its own file system and process space |
+
+## Default configuration
+
+| **Item** | **Default** | **Description** |
+| --- | --- | --- |
+| Container image | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37` | Prebuilt claude-code image in ACR per region; select the address below by region |
+| Default port | None | Claude Code runs as a CLI and does not expose a fixed service port |
+| CPU | 2 vCPU | Recommended build specification |
+| Memory | 8192 MB | Recommended build specification |
+| Operating system | Ubuntu 25.04 | OS inside the image |
+| Claude Code path | `/home/user/.local/bin/claude` | CLI executable path |
+| Default user / working directory | `user` / `/home/user` | Default sandbox identity |
+| MCP Gateway | Not supported | The image offers no MCP Gateway; only `claude mcp add` client-side registration is supported |
+
+## Image Addresses
+
+Select `FROM_IMAGE` by region:
+
+| Region | Image |
+|--------|------|
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+
+## Build and minimal verification
+
+Usage has two phases: first **build the template** (materialize a named template from the `claude-code` image), then **run the template** (create a sandbox, inject the model Key, and run a minimal CLI verification).
+
+> **Note**: The `E2B_API_KEY`, `E2B_API_URL`, and `E2B_DOMAIN` environment variables must be set (via `.env` or `export`) to the endpoint of the corresponding region before running the examples — the SDK reads them automatically, no need to pass them into method calls. The model API Key is not preconfigured in the image; inject it via `envs` when creating the sandbox.
+
+### Prepare the local environment
+
+```bash
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install e2b==2.31.0 e2b-code-interpreter==2.8.1 python-dotenv
+```
+
+Obtain a model API Key to inject via `envs`; the image does not include preconfigured keys:
+
+- International: Obtain `ANTHROPIC_API_KEY` from the [Anthropic Console](https://console.anthropic.com/)
+- China: Obtain an API Key (starting with `sk-`) from the [Bailian Console](https://bailian.console.aliyun.com/)
+
+### Build the Claude Code template
+
+Build a named template from the `claude-code` image, specifying CPU and memory (2 vCPU / 8192 MB recommended) at build time.
+
+```python
+"""Claude Code template build example."""
+
+from dotenv import load_dotenv
+from e2b import Template, default_build_logger
+
+load_dotenv()
+
+# The SDK reads E2B_API_KEY / E2B_API_URL / E2B_DOMAIN automatically.
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37"
+
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name="my-claude-code-template",
+    cpu_count=2,
+    memory_mb=8192,
+    on_build_logs=default_build_logger(),
+)
+print(f"template_id: {build.template_id}")
+```
+
+After the build completes, the template status in the console should be `ready`. You can create multiple sandboxes from the same template name without rebuilding each time.
+
+### Run the template and verify
+
+Inject the model API Key via `envs` when creating the sandbox. You must initialize `~/.claude.json` before the first run, otherwise a corrupted config error may occur.
+
+**Anthropic API-compatible configuration**
+
+```python
+"""Claude Code template run example: create sandbox -> init config -> minimal verification."""
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# The SDK reads E2B_API_KEY / E2B_API_URL / E2B_DOMAIN automatically.
+sandbox = Sandbox.create(
+    template="my-claude-code-template",
+    envs={"ANTHROPIC_API_KEY": "<your-anthropic-api-key>"},
+    timeout=600,
+)
+
+# You must initialize ~/.claude.json before the first run, otherwise a corrupted config error may occur.
+sandbox.commands.run("echo '{}' > /home/user/.claude.json")
+
+# Minimal verification: non-interactive mode + skip permissions; < /dev/null avoids stdin waiting.
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null '
+    '-p "Reply with just: ok"',
+    timeout=0,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+
+**China: Bailian DashScope**
+
+```python
+"""Claude Code template run example: create sandbox -> init config -> minimal verification."""
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# The SDK reads E2B_API_KEY / E2B_API_URL / E2B_DOMAIN automatically.
+sandbox = Sandbox.create(
+    template="my-claude-code-template",
+    envs={
+        "ANTHROPIC_AUTH_TOKEN": "<your-bailian-api-key>",
+        "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
+        "ANTHROPIC_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-max",
+    },
+    timeout=600,
+)
+
+# You must initialize ~/.claude.json before the first run, otherwise a corrupted config error may occur.
+sandbox.commands.run("echo '{}' > /home/user/.claude.json")
+
+# Minimal verification: non-interactive mode + skip permissions; < /dev/null avoids stdin waiting.
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null '
+    '-p "Reply with just: ok"',
+    timeout=0,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+
+## Limitations
+
+| **Item** | **Constraint** |
+| --- | --- |
+| MCP Gateway | Not supported. Only `claude mcp add` client-side registration of stdio / HTTP MCP Servers is supported; the SDK `mcp` creation parameter and `getMcpUrl()` / `getMcpToken()` are not supported |
+| Model Key | Not preconfigured in the image; must be injected at runtime via `envs` |
+
+## Related documents
+
+- [Claude Code Custom Image](../../../05.Best%20Practices/05.Claude%20Code%20Custom%20Image.md) (full real-task tutorials: clone repositories, MCP, Skills, structured output)
+- [Built-in Templates](../02.Built-in%20Templates.md)
+- [Template Names and Versioning](../06.Template%20Names%20and%20Versioning.md)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Examples/05.OpenClaw Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Examples/05.OpenClaw Template.md
@@ -1,0 +1,209 @@
+# OpenClaw Template Example
+
+OpenClaw is an open-source agent framework that supports CLI-based programmatic invocation and a Gateway Web UI. The OpenClaw template is built from the official `openclaw` image, with the OpenClaw CLI and its runtime dependencies preinstalled and ready to use. This page covers capabilities, default configuration, build and minimal verification, and limitations. For real-task tutorials such as Gateway deployment, Agent CLI usage, Skill extension, and custom domain access, see [OpenClaw Custom Image](../../../05.Best%20Practices/06.OpenClaw%20Custom%20Image.md).
+
+We have pre-built `openclaw` images in ACR across all regions, so you don't need to push images or configure ACREE yourself. Simply select an image address below and build a template using `from_image` + `Template.build` to get started.
+
+## Features
+
+| **Feature** | **Description** |
+| --- | --- |
+| Coding agent | Ships with the OpenClaw CLI, supporting non-interactive programmatic invocation via `openclaw agent --local` |
+| Gateway Web UI | Supports `openclaw gateway` to start a Web UI; interact with the Agent in a browser via `sandbox.get_host(PORT)` (with `X-Access-Token`) |
+| Multi-model adapter | Ships with `openclaw onboard` to register custom providers such as Bailian and OpenAI |
+| Skill extension | Extend Agent capabilities through a filesystem convention of a directory plus `SKILL.md`, with workspace / managed / bundled scopes |
+| Secure isolation | Each OpenClaw sandbox instance has its own file system and process space |
+
+## Default configuration
+
+| **Item** | **Default** | **Description** |
+| --- | --- | --- |
+| Container image | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37` | Prebuilt openclaw image in ACR per region; select the address below by region |
+| Gateway default port | 18789 | Port listened on by `openclaw gateway --port` |
+| CPU | 2 vCPU | Recommended build specification |
+| Memory | 4096 MB | Recommended build specification |
+| Operating system | Debian 13 (trixie) | OS inside the image |
+| OpenClaw path | `/home/user/.openclaw/bin/openclaw` | CLI executable path |
+| Bundled Node | v22.x | `/home/user/.openclaw/tools/node/bin/node` |
+| Default user / working directory | `user` / `/home/user` | Default sandbox identity |
+
+## Image Addresses
+
+Select `FROM_IMAGE` by region:
+
+| Region | Image |
+|--------|------|
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+
+## Build and minimal verification
+
+Usage has two phases: first **build the template** (materialize a named template from the `openclaw` image), then **run the template** (create a sandbox, inject the model Key, and run a minimal CLI verification).
+
+> **Note**: The `E2B_API_KEY`, `E2B_API_URL`, and `E2B_DOMAIN` environment variables must be set (via `.env` or `export`) to the endpoint of the corresponding region before running the examples — the SDK reads them automatically, no need to pass them into method calls. The model API Key is not preconfigured in the image; inject it via `envs` when creating the sandbox.
+
+### Prepare the local environment
+
+```bash
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install e2b==2.31.0 e2b-code-interpreter==2.8.1 python-dotenv
+```
+
+Obtain a model API Key to inject via `envs`; the image does not include preconfigured keys:
+
+- International: Obtain an API Key, Base URL, and model name from your OpenAI-compatible provider; the example below uses DashScope OpenAI-compatible mode
+- China: Obtain an API Key (starting with `sk-`) from the [Bailian Console](https://bailian.console.aliyun.com/)
+
+### Build the OpenClaw template
+
+Build a named template from the `openclaw` image, specifying CPU and memory (2 vCPU / 4096 MB recommended) at build time.
+
+```python
+"""OpenClaw template build example."""
+
+from dotenv import load_dotenv
+from e2b import Template, default_build_logger
+
+load_dotenv()
+
+# The SDK reads E2B_API_KEY / E2B_API_URL / E2B_DOMAIN automatically.
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37"
+
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name="my-openclaw-template",
+    cpu_count=2,
+    memory_mb=4096,
+    on_build_logs=default_build_logger(),
+)
+print(f"template_id: {build.template_id}")
+```
+
+After the build completes, the template status in the console should be `ready`. You can create multiple sandboxes from the same template name without rebuilding each time.
+
+### Template name restrictions
+
+The `name` must not use the system-reserved prefix **`openclaw-v`** (e.g., `openclaw-v0.0.37`, `openclaw-v037-test`), otherwise the following error will occur:
+
+```text
+400: invalid template name '...': must not be a system reserved name openclaw-v*
+```
+
+Custom names such as `my-openclaw-{timestamp}` are recommended. Names starting with `openclaw-` that do **not** contain `openclaw-v` (e.g., `openclaw-1783153993`) are generally acceptable.
+
+### Run the template and verify
+
+Inject the model API Key via `envs` when creating the sandbox.
+
+**International: OpenAI-compatible**
+
+```python
+"""OpenClaw template run example: create sandbox -> onboard provider -> minimal CLI verification."""
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# The SDK reads E2B_API_KEY / E2B_API_URL / E2B_DOMAIN automatically.
+# Example uses DashScope OpenAI-compatible mode.
+PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
+PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+PROVIDER_MODEL = "qwen3-coder-plus"
+PROVIDER_ID = "openai-compat"
+
+sandbox = Sandbox.create(
+    template="my-openclaw-template",
+    timeout=600,
+    envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
+)
+
+# Register the OpenAI-compatible provider; an unregistered bare openai/<model> fails with "Unknown model".
+sandbox.commands.run(
+    "openclaw onboard --non-interactive --accept-risk --skip-health "
+    "--auth-choice custom-api-key "
+    f"--custom-api-key {PROVIDER_API_KEY} "
+    f"--custom-base-url {PROVIDER_BASE_URL} "
+    "--custom-compatibility openai "
+    f"--custom-model-id {PROVIDER_MODEL} "
+    f"--custom-provider-id {PROVIDER_ID}",
+    timeout=120,
+)
+
+# Minimal verification
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model {PROVIDER_ID}/{PROVIDER_MODEL} '
+    '-m "Reply with just: ok"',
+    timeout=120,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+
+**China: Bailian**
+
+```python
+"""OpenClaw template run example: create sandbox -> onboard provider -> minimal CLI verification."""
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# The SDK reads E2B_API_KEY / E2B_API_URL / E2B_DOMAIN automatically.
+BAILIAN_API_KEY = "<your-bailian-api-key>"
+BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
+BAILIAN_MODEL = "qwen3.7-max"
+
+sandbox = Sandbox.create(
+    template="my-openclaw-template",
+    timeout=600,
+    envs={
+        "ANTHROPIC_AUTH_TOKEN": BAILIAN_API_KEY,
+        "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
+        "ANTHROPIC_MODEL": BAILIAN_MODEL,
+    },
+)
+
+# Register the Bailian provider
+sandbox.commands.run(
+    "openclaw onboard --non-interactive --accept-risk --skip-health "
+    "--auth-choice custom-api-key "
+    f"--custom-api-key {BAILIAN_API_KEY} "
+    f"--custom-base-url {BAILIAN_BASE_URL} "
+    "--custom-compatibility anthropic "
+    f"--custom-model-id {BAILIAN_MODEL} "
+    "--custom-provider-id bailian",
+    timeout=120,
+)
+
+# Minimal verification
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    '-m "Reply with just: ok"',
+    timeout=120,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+
+## Limitations
+
+| **Item** | **Constraint** |
+| --- | --- |
+| Template name | Must not use the system-reserved prefix `openclaw-v*` (e.g., `openclaw-v0.0.37`) |
+| Model Key | Not preconfigured in the image; must be injected at runtime via `envs`. Both Bailian and OpenAI-compatible flows require `openclaw onboard` to register the provider first; an unregistered bare `openai/<model>` fails with "Unknown model" |
+| Gateway browser access | Reachable directly via `sandbox.get_host(PORT)` on the default platform domain; requests must carry `X-Access-Token`. A custom domain is an optional stable-hostname alternative, not a requirement |
+
+## Related documents
+
+- [OpenClaw Custom Image](../../../05.Best%20Practices/06.OpenClaw%20Custom%20Image.md) (full tutorials: Gateway deployment, Agent CLI usage, Skill extension, custom domain access)
+- [Built-in Templates](../02.Built-in%20Templates.md)
+- [Template Names and Versioning](../06.Template%20Names%20and%20Versioning.md)

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
@@ -1,116 +1,79 @@
 # Claude Code Custom Image
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's terminal-based AI coding agent that can read code, modify files, and execute commands within a sandbox. We have pre-built Claude Code images in ACR across all regions, so you don't need to push images or configure ACREE yourself. Simply select an image address below and build a template using `from_image` + `Template.build` to get started.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is Anthropic's terminal-based AI coding agent that can read code, modify files, and execute commands within a sandbox. This page focuses on real-world tasks: cloning repositories, connecting MCP, extending Skills, structured output, and session resumption. For image addresses, build steps, and minimal verification, see [Claude Code Template Example](../04.Features/02.Templates/07.Examples/04.Claude%20Code%20Template.md).
 
-If this is your first time, please complete the SLR authorization, API Key, and SDK setup described in [Create Your First Cloud Sandbox via the SDK](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk).
+If this is your first time, complete the SLR authorization, API Key, and SDK configuration in [Create Your First Cloud Sandbox via the SDK](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk).
 
 ---
 
 ## Prerequisites
 
-- Completed [SDK integration](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk) (E2B API Key, `api_url`, `domain`)
-- Installed dependencies: `pip install e2b==2.31.0 e2b-code-interpreter==2.8.1`
+- Completed [SDK integration](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk) and configured `E2B_API_KEY`, `E2B_API_URL`, `E2B_DOMAIN` via environment variables (SDK reads automatically)
+- Built a template with `ready` status following [Claude Code Template Example](../04.Features/02.Templates/07.Examples/04.Claude%20Code%20Template.md) and noted the template name (referred to as `TEMPLATE_NAME` below)
 - Prepared a model API Key to inject via `envs` when creating the sandbox — images do not include pre-configured keys
-  - China: Obtain an API Key (starting with `sk-`) from the [Bailian Console](https://bailian.console.aliyun.com/)
   - International: Obtain `ANTHROPIC_API_KEY` from the [Anthropic Console](https://console.anthropic.com/)
+  - China: Obtain an API Key (starting with `sk-`) from the [Bailian Console](https://bailian.console.aliyun.com/)
+
+All examples below assume: template built; `sandbox` created; `~/.claude.json` initialized; `E2B_API_KEY`, `E2B_API_URL`, `E2B_DOMAIN` configured via environment variables or `.env`.
 
 ---
 
-## Image Addresses
+## Create Sandbox and Run
 
-Select `FROM_IMAGE` by region:
+Create a sandbox from your built template and inject the model Key via `envs`. The Bailian (Anthropic-compatible) flow has been verified end-to-end; the Anthropic-compatible / Bailian API configuration is the supported path. Initialize `~/.claude.json` before the first run, otherwise a corrupted config error may occur.
 
-| Region | Image |
-|--------|------|
-| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-
-Recommended build specifications: `cpu_count=2`, `memory_mb=8192`.
-
----
-
-## Quick Start
-
-The following example uses the Beijing region and consists of four steps: **Build Template → Create Sandbox → Run Claude Code → Destroy Sandbox**.
-
-### Build Template
+### China: Bailian DashScope
 
 ```python
-import time
-
-from e2b import Template, default_build_logger
-
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.32"
-TEMPLATE_NAME = f"claude-code-{int(time.time())}"
-
-OPTS = {
-    "api_key": "<your E2B API Key>",
-    "api_url": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
-    "domain": "cn-beijing.e2b.fc.aliyuncs.com",
-}
-
-build = Template.build(
-    Template().from_image(FROM_IMAGE),
-    name=TEMPLATE_NAME,
-    cpu_count=2,
-    memory_mb=8192,
-    on_build_logs=default_build_logger(),
-    **OPTS,
-)
-
-print(f"template: {build.name}")   # Save for later reuse
-```
-
-After the build completes, the template status in the console should be `ready`. You can create multiple sandboxes from the same template name without rebuilding each time.
-
-### Create Sandbox
-
-Inject the model API Key via `envs` when creating the sandbox.
-
-**China: Bailian DashScope**
-
-```python
+from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# The SDK reads E2B_API_KEY / E2B_API_URL / E2B_DOMAIN automatically.
+TEMPLATE_NAME = "my-claude-code-template"  # from Claude Code Template Example
 
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
     envs={
         "ANTHROPIC_AUTH_TOKEN": "<your-bailian-api-key>",
         "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
-        "ANTHROPIC_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.6-flash",
+        "ANTHROPIC_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-max",
     },
     timeout=600,
-    **OPTS,
 )
 
-# You must initialize `~/.claude.json` before the first run, otherwise a corrupted config error may occur.
+# Initialize ~/.claude.json before the first run, otherwise a corrupted config error may occur.
 sandbox.commands.run("echo '{}' > /home/user/.claude.json")
 ```
 
-**International: Anthropic direct connection**
+### Anthropic API-compatible configuration
+
+The following injects an Anthropic API Key directly. Use this only when you have a valid Anthropic API Key for an Anthropic-compatible endpoint; the Bailian flow above is the verified path.
 
 ```python
+from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# The SDK reads E2B_API_KEY / E2B_API_URL / E2B_DOMAIN automatically.
+TEMPLATE_NAME = "my-claude-code-template"  # from Claude Code Template Example
 
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
     envs={"ANTHROPIC_API_KEY": "<your-anthropic-api-key>"},
     timeout=600,
-    **OPTS,
 )
 
-# You must initialize `~/.claude.json` before the first run, otherwise a corrupted config error may occur.
+# Initialize ~/.claude.json before the first run, otherwise a corrupted config error may occur.
 sandbox.commands.run("echo '{}' > /home/user/.claude.json")
 ```
 
-### Run Claude Code
+## Running Claude Code
 
 Use `-p` for non-interactive mode; within the sandbox you can add `--dangerously-skip-permissions` to skip permission confirmations. It is recommended to add `< /dev/null` to avoid stdin waiting warnings:
 
@@ -123,7 +86,7 @@ result = sandbox.commands.run(
 print(result.stdout)
 ```
 
-### Destroy Sandbox
+### Destroying the Sandbox
 
 Release resources when the task is complete:
 
@@ -133,20 +96,7 @@ sandbox.kill()
 
 ---
 
-## Environment Overview
-
-| Item | Specification |
-|------|------|
-| Operating System | Ubuntu 25.04 |
-| Claude Code Path | `/home/user/.local/bin/claude` |
-| Default User / Working Directory | `user` / `/home/user` |
-| MCP Gateway | **Not supported** |
-
----
-
 ## Usage Scenarios
-
-The following examples assume that the Template has been built, the `sandbox` has been created, and `~/.claude.json` has been initialized.
 
 ### Clone a Repository and Execute a Task
 
@@ -191,28 +141,7 @@ else:
 print(response.get("result") or response)
 ```
 
-### Streaming JSONL Output
-
-```python
-import json
-
-def handle_event(data):
-    for line in data.strip().split("\n"):
-        if line.startswith("{"):
-            event = json.loads(line)
-            if event["type"] == "assistant":
-                usage = event.get("message", {}).get("usage", {})
-                print(f"[assistant] tokens: {usage.get('output_tokens')}")
-            elif event["type"] == "result":
-                print(f"[done] {event['subtype']} in {event['duration_ms']}ms")
-
-sandbox.commands.run(
-    'claude --dangerously-skip-permissions --verbose --output-format stream-json < /dev/null '
-    '-p "Find and fix all TODO comments" 2>&1',
-    on_stdout=handle_event,
-    timeout=0,
-)
-```
+> **Note**: The `--output-format stream-json` option with the SDK's `on_stdout` callback is not supported here. Because streaming output does not emit a terminal end event, `sandbox.commands.run(..., on_stdout=...)` raises `Command ended without an end event`. Use `--output-format json` (one-shot structured result) instead.
 
 ### Resume a Session
 
@@ -303,7 +232,7 @@ The image does not preload custom Skills. A Skill is a Claude Code filesystem co
 | Personal (global within this sandbox) | `/home/user/.claude/skills/<name>/SKILL.md` |
 | Project | `<project>/.claude/skills/<name>/SKILL.md` |
 
-How to trigger: explicitly call `/skill-name` in the `-p` prompt, or describe a matching task so the model loads it automatically. Claude Code also ships bundled skills such as `/debug` and `/code-review` that require no extra installation.
+How to trigger: explicitly call `/skill-name` in the `-p` prompt, or describe a matching task so the model loads it automatically.
 
 **Write a personal Skill at runtime:**
 
@@ -354,47 +283,43 @@ sandbox.commands.run(
 
 **Upload a multi-file Skill directory from your local machine:**
 
-If a Skill includes accompanying files such as `scripts/` or `references/`, use `files.write_files` to write them in one batch instead of calling `files.write` for each file:
+If a Skill includes files such as `scripts/` or `references/`, batch-write the directory with `files.write_files`:
 
 ```python
 from pathlib import Path
 
-def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
-    local = Path(local_dir).resolve()
-    entries = []
-    for path in local.rglob("*"):
-        if path.is_file():
-            rel = path.relative_to(local).as_posix()
-            entries.append({
-                "path": f"{remote_root.rstrip('/')}/{rel}",
-                "data": path.read_bytes(),
-            })
-    sandbox.files.write_files(entries)
+local = Path("./my-skills/echo-marker").resolve()
+remote_root = "/home/user/.claude/skills/echo-marker"
+entries = []
+for path in local.rglob("*"):
+    if path.is_file():
+        relative = path.relative_to(local).as_posix()
+        entries.append({
+            "path": f"{remote_root}/{relative}",
+            "data": path.read_bytes(),
+        })
 
-# Example local directory layout:
-# ./my-skills/echo-marker/SKILL.md
-# ./my-skills/echo-marker/scripts/marker.txt
-upload_skill_dir(
-    sandbox,
-    "./my-skills/echo-marker",
-    "/home/user/.claude/skills/echo-marker",
-)
-
-result = sandbox.commands.run(
-    'claude --dangerously-skip-permissions < /dev/null '
-    '-p "/echo-marker"',
-    timeout=0,
-)
-print(result.stdout)
+sandbox.files.write_files(entries)
 ```
 
-For project scope, set `remote_root` to `/home/user/repo/.claude/skills/<name>` instead. You can also clone a repository that already contains `.claude/skills/` and use it directly.
+For project scope, change `remote_root` to `/home/user/repo/.claude/skills/<name>`. `Template.copy` does not currently support preloading a local directory during `Template.build`; use runtime `files.write` or `files.write_files` instead.
 
-> **About Template.copy**: Prefilling files with `.copy("local-dir", "/home/user/.claude/skills/...")` during `Template.build` is **not supported** yet. Use the runtime `files.write` / `files.write_files` approaches above for custom Skills.
+You can also preload Skills when building a Template (useful for team reuse), see [Claude Code Template Example](../04.Features/02.Templates/07.Examples/04.Claude%20Code%20Template.md).
+
+---
+
+## Production Recommendations
+
+- Isolate login state, Git tokens, and model API Keys per task, inject them at runtime via `envs`, and do not write them into templates or images.
+- Limit per-task timeout and output size; when using `--dangerously-skip-permissions` in non-interactive mode, ensure no sensitive data is persisted in the sandbox.
+- Record prompts, model versions, tool call traces, and artifact paths for auditing.
+- Web or repository content may contain prompt injection; do not let the Agent execute external instructions without validation.
+
+---
 
 ## Billing
 
-Sandboxes are billed based on CPU and memory specifications and runtime duration; model API call costs are billed separately by the model provider. See [Billing Overview](../03.Pricing/01.Billing%20Overview.md) for details.
+Sandboxes are billed based on CPU and memory specifications and runtime duration; model API call costs are billed separately by model providers such as Anthropic or Bailian. See [Billing Overview](../03.Pricing/01.Billing%20Overview.md) for details.
 
 ---
 
@@ -404,8 +329,12 @@ Sandboxes are billed based on CPU and memory specifications and runtime duration
 |------|------|
 | Corrupted config error | `echo '{}' > /home/user/.claude.json` |
 | Agent not responding | Verify that `envs` includes the model Key; for China, use the Bailian `envs` configuration |
-| Build failure | Verify that `FROM_IMAGE` matches the region |
-| name 'TEMPLATE_NAME' is not defined | Obtain the template name from the console and replace `TEMPLATE_NAME` |
+| name 'TEMPLATE_NAME' is not defined | Replace `TEMPLATE_NAME` with the template name from [Claude Code Template Example](../04.Features/02.Templates/07.Examples/04.Claude%20Code%20Template.md) |
 | Other SDK / build issues | See [Custom Templates — Troubleshooting](../08.FAQ/05.Template%20Builds.md) |
 
 ---
+
+## References
+
+- [Claude Code Template Example](../04.Features/02.Templates/07.Examples/04.Claude%20Code%20Template.md) (image addresses, build and minimal verification, environment overview)
+- [E2B SDK Connection Parameters](../07.Developer%20Reference/02.E2B%20SDK%20Connection%20Parameters.md)

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
@@ -1,6 +1,6 @@
-# OpenClaw Custom Image
+# Using the OpenClaw Custom Image
 
-[OpenClaw](https://github.com/openclaw/openclaw) is an open-source agent framework that supports CLI-based programmatic invocation and a Gateway Web UI. We have pre-built OpenClaw images in ACR across all regions, so you don't need to push images or configure ACREE yourself. Simply select an image address below and build a template using `from_image` + `Template.build` to get started.
+[OpenClaw](https://github.com/openclaw/openclaw) is an open-source agent framework that supports CLI-based programmatic invocation and a Gateway Web UI. This page focuses on real-world tasks: Gateway deployment, programmatic Agent CLI invocation, Skill extension, custom domain access, and security and operations. For image addresses, build steps, and minimal verification, see [OpenClaw Template Example](../04.Features/02.Templates/07.Examples/05.OpenClaw%20Template.md).
 
 If this is your first time, please complete the SLR authorization, API Key, and SDK setup described in [Create Your First Cloud Sandbox via the SDK](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk).
 
@@ -8,74 +8,13 @@ If this is your first time, please complete the SLR authorization, API Key, and 
 
 ## Prerequisites
 
-- Completed [SDK integration](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk) (E2B API Key, `api_url`, `domain`)
-- Installed dependencies: `pip install e2b==2.31.0 e2b-code-interpreter==2.8.1`
+- Completed [SDK integration](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk) and configured `E2B_API_KEY`, `E2B_API_URL`, `E2B_DOMAIN` via environment variables (SDK reads automatically)
+- Built a template with `ready` status following [OpenClaw Template Example](../04.Features/02.Templates/07.Examples/05.OpenClaw%20Template.md) and noted the template name (referred to as `TEMPLATE_NAME` below)
 - Prepared a model API Key to inject via `envs` when creating the sandbox — images do not include pre-configured keys
-  - China: Obtain an API Key (starting with `sk-`) from the [Bailian Console](https://bailian.console.aliyun.com/)
-  - International: Obtain `OPENAI_API_KEY` from the [OpenAI Platform](https://platform.openai.com/)
+  - International: Obtain an API Key, Base URL, and model name from your OpenAI-compatible provider; the example below uses DashScope OpenAI-compatible mode
+  - China (recommended): Obtain an API Key (starting with `sk-`) from the [Bailian Console](https://bailian.console.aliyun.com/)
 
----
-
-## Image Addresses
-
-Select `FROM_IMAGE` by region:
-
-| Region | Image |
-|--------|------|
-| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-
-Recommended build specifications: `cpu_count=2`, `memory_mb=4096`.
-
----
-
-## Build Template
-
-A custom template requires building the image into a Template first — **this only needs to be done once**. Save the template name for reuse when creating sandboxes later.
-
-The following example uses the Beijing region:
-
-```python
-import time
-
-from e2b import Template, default_build_logger
-
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.32"
-TEMPLATE_NAME = f"openclaw-{int(time.time())}"
-
-OPTS = {
-    "api_key": "<your E2B API Key>",
-    "api_url": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
-    "domain": "cn-beijing.e2b.fc.aliyuncs.com",
-}
-
-build = Template.build(
-    Template().from_image(FROM_IMAGE),
-    name=TEMPLATE_NAME,
-    cpu_count=2,
-    memory_mb=4096,
-    on_build_logs=default_build_logger(),
-    **OPTS,
-)
-
-print(f"template: {build.name}")   # Save for later reuse
-```
-
-After the build completes, the template status in the console should be `ready`. You can create multiple sandboxes from the same template name without rebuilding each time.
-
-### Template Name Restrictions
-
-The `name` must not use the system-reserved prefix **`openclaw-v`** (e.g., `openclaw-v0.0.32`, `openclaw-v032-test`), otherwise the following error will occur:
-
-```text
-400: invalid template name '...': must not be a system reserved name openclaw-v*
-```
-
-Custom names such as `my-openclaw-{timestamp}` are recommended. Names starting with `openclaw-` that do **not** contain `openclaw-v` (e.g., `openclaw-1783153993`) are generally acceptable.
+All examples below assume the template has been built; `E2B_API_KEY`, `E2B_API_URL`, `E2B_DOMAIN` are configured via environment variables or `.env` (read automatically by the SDK).
 
 ---
 
@@ -83,22 +22,32 @@ Custom names such as `my-openclaw-{timestamp}` are recommended. Names starting w
 
 Start the OpenClaw Gateway to interact with the Agent in a browser. The complete workflow below covers: **Create Sandbox → Configure → Start Gateway → Get Access URL**. For server-side programmatic invocation, see [Agent CLI](#agent-cli).
 
-### China: Bailian
+The following defaults to **Bailian** (recommended for China); international users can follow the OpenAI-compatible variant in the comments. For server-side programmatic invocation, see [Agent CLI](#agent-cli).
 
 ```python
 import time
 
+from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+TEMPLATE_NAME = "my-openclaw-template"
 
 # Gateway auth Token: set any string you like — no need to obtain it from an API.
 # Pass it to openclaw gateway --token at startup; the browser accesses it via the URL ?token= parameter.
-# The official docs also support the OPENCLAW_APP_TOKEN environment variable, which is equivalent.
 TOKEN = "my-gateway-token"
 PORT = 18789
 
+# Bailian (recommended for China)
 BAILIAN_API_KEY = "<your-bailian-api-key>"
 BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
 BAILIAN_MODEL = "qwen3.7-max"
+# International OpenAI-compatible (e.g. DashScope OpenAI-compatible mode):
+# PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
+# PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+# PROVIDER_MODEL = "qwen3-coder-plus"
+# PROVIDER_ID = "openai-compat"
 
 # 1. Create Sandbox
 sandbox = Sandbox.create(
@@ -109,10 +58,14 @@ sandbox = Sandbox.create(
         "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
         "ANTHROPIC_MODEL": BAILIAN_MODEL,
     },
-    **OPTS,
+    # International OpenAI-compatible: replace the envs above with
+    # envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
 )
 
-# Register the Bailian provider
+# Register the provider via onboard. Bailian uses anthropic compatibility;
+# OpenAI-compatible endpoints use openai compatibility. The model id below must
+# match the provider's actual model name — unregistered model ids (e.g. a bare
+# openai/<model> that was never onboarded) will fail with "Unknown model".
 sandbox.commands.run(
     "openclaw onboard --non-interactive --accept-risk --skip-health "
     "--auth-choice custom-api-key "
@@ -121,6 +74,12 @@ sandbox.commands.run(
     "--custom-compatibility anthropic "
     f"--custom-model-id {BAILIAN_MODEL} "
     "--custom-provider-id bailian",
+    # International OpenAI-compatible:
+    # f"--custom-api-key {PROVIDER_API_KEY} "
+    # f"--custom-base-url {PROVIDER_BASE_URL} "
+    # "--custom-compatibility openai "
+    # f"--custom-model-id {PROVIDER_MODEL} "
+    # f"--custom-provider-id {PROVIDER_ID}",
     timeout=120,
 )
 
@@ -128,62 +87,10 @@ sandbox.commands.run(
 sandbox.commands.run(
     f"openclaw config set agents.defaults.model.primary bailian/{BAILIAN_MODEL}"
 )
-
-# 3. Configure Control UI (required for FC E2B public network access)
-origin = f"https://{sandbox.get_host(PORT)}"
-sandbox.commands.run(
-    f"openclaw config set gateway.controlUi.allowedOrigins '[\"{origin}\"]'"
-)
-
-# 4. Start Gateway (run in background)
-sandbox.commands.run(
-    f"bash -lc 'openclaw config set gateway.controlUi.allowInsecureAuth true && "
-    f"openclaw config set gateway.controlUi.dangerouslyDisableDeviceAuth true && "
-    f"openclaw gateway --allow-unconfigured --bind lan --auth token "
-    f"--token {TOKEN} --port {PORT}'",
-    background=True,
-)
-
-# 5. Wait for Gateway to be ready
-for _ in range(45):
-    probe = sandbox.commands.run(
-        f'bash -lc \'ss -ltn | grep -q ":{PORT} " && echo ready || echo waiting\''
-    )
-    if probe.stdout.strip() == "ready":
-        break
-    time.sleep(1)
-
-url = f"https://{sandbox.get_host(PORT)}/?token={TOKEN}"
-print(f"Gateway: {url}")
-# X-Access-Token is returned by the SDK after Sandbox.create succeeds, used for FC E2B public port proxy authentication
-print(f"Access Token: {sandbox._envd_access_token}")
-```
-
-### International: OpenAI
-
-```python
-import time
-
-from e2b_code_interpreter import Sandbox
-
-# Gateway auth Token: set any string you like — no need to obtain it from an API.
-# Pass it to openclaw gateway --token at startup; the browser accesses it via the URL ?token= parameter.
-# The official docs also support the OPENCLAW_APP_TOKEN environment variable, which is equivalent.
-TOKEN = "my-gateway-token"
-PORT = 18789
-
-# 1. Create Sandbox
-sandbox = Sandbox.create(
-    template=TEMPLATE_NAME,
-    timeout=3600,
-    envs={"OPENAI_API_KEY": "<your-openai-api-key>"},
-    **OPTS,
-)
-
-# 2. Set default model
-sandbox.commands.run(
-    "openclaw config set agents.defaults.model.primary openai/gpt-4o"
-)
+# International OpenAI-compatible:
+# sandbox.commands.run(
+#     f"openclaw config set agents.defaults.model.primary {PROVIDER_ID}/{PROVIDER_MODEL}"
+# )
 
 # 3. Configure Control UI (required for FC E2B public network access)
 origin = f"https://{sandbox.get_host(PORT)}"
@@ -223,10 +130,10 @@ OpenClaw extends Agent capabilities through Skills (a directory plus `SKILL.md`)
 
 The image does not preload custom Skills; use `openclaw skills list` to view loaded Skills (including bundled ones).
 
-| Scope | Path | Source |
+| Scope | Path (verified on this image) | Source |
 |--------|-------------------|-------------|
-| Workspace | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
-| Managed | `/home/user/.openclaw/skills/<name>/SKILL.md` | managed |
+| Workspace (preferred) | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
+| Managed / shared on this host | `/home/user/.openclaw/skills/<name>/SKILL.md` | `openclaw-managed` |
 | Bundled | Shipped with the OpenClaw installation | `openclaw-bundled` |
 
 How to trigger:
@@ -258,7 +165,7 @@ user-invocable: true
 print(sandbox.commands.run("openclaw skills list").stdout)
 
 result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
+    'openclaw agent --local --agent main --model bailian/qwen3.7-max '
     '--message "/summarize-changes"',
     timeout=0,
 )
@@ -284,7 +191,7 @@ When writing API endpoints:
 )
 
 result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
+    'openclaw agent --local --agent main --model bailian/qwen3.7-max '
     '--message "/api-conventions Add a /healthz endpoint"',
     timeout=0,
 )
@@ -293,95 +200,47 @@ print(result.stdout)
 
 **Upload a multi-file Skill directory from your local machine:**
 
-If a Skill includes accompanying files such as `scripts/` or `references/`, use `files.write_files` to write them in one batch instead of calling `files.write` for each file:
+If a Skill includes files such as `scripts/` or `references/`, batch-write the directory with `files.write_files`:
 
 ```python
 from pathlib import Path
 
-def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
-    local = Path(local_dir).resolve()
-    entries = []
-    for path in local.rglob("*"):
-        if path.is_file():
-            rel = path.relative_to(local).as_posix()
-            entries.append({
-                "path": f"{remote_root.rstrip('/')}/{rel}",
-                "data": path.read_bytes(),
-            })
-    sandbox.files.write_files(entries)
+local = Path("./my-skills/echo-marker").resolve()
+remote_root = "/home/user/.openclaw/skills/echo-marker"
+entries = []
+for path in local.rglob("*"):
+    if path.is_file():
+        relative = path.relative_to(local).as_posix()
+        entries.append({
+            "path": f"{remote_root}/{relative}",
+            "data": path.read_bytes(),
+        })
 
-# Example local directory layout:
-# ./my-skills/echo-marker/SKILL.md
-# ./my-skills/echo-marker/scripts/marker.txt
-upload_skill_dir(
-    sandbox,
-    "./my-skills/echo-marker",
-    "/home/user/.openclaw/skills/echo-marker",  # Managed; for Workspace use workspace/skills/...
-)
-
+sandbox.files.write_files(entries)
 print(sandbox.commands.run("openclaw skills list").stdout)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
-    '--message "/echo-marker"',
-    timeout=0,
-)
-print(result.stdout)
 ```
 
-> **About Template.copy**: Prefilling files with `.copy("local-dir", "/home/user/.openclaw/skills/...")` during `Template.build` is **not supported** yet. Use the runtime `files.write` / `files.write_files` approaches above for custom Skills.
+For workspace scope, change `remote_root` to `/home/user/.openclaw/workspace/skills/<name>`. `Template.copy` does not currently support preloading a local directory during `Template.build`; use runtime `files.write` or `files.write_files` instead.
 
-**Install from ClawHub (optional):**
+**Search ClawHub (optional):**
 
-The sandbox has public outbound access by default, so you can search for and install community Skills directly (browse [clawhub.ai](https://clawhub.ai)):
+The sandbox has public outbound access by default, so you can search community Skills directly (browse [clawhub.ai](https://clawhub.ai)). Note that `openclaw skills search` only queries the ClawHub catalog; whether a given skill can be installed depends on ClawHub availability.
 
 ```python
-# Search
+# Search the ClawHub catalog
 result = sandbox.commands.run("openclaw skills search calendar", timeout=120)
 print(result.stdout)
-
-# Install
-sandbox.commands.run("openclaw skills install weather", timeout=180)
 ```
 
-You can also preload Skills when building a Template (useful for team reuse) by writing the skill directory into `~/.openclaw/skills/` or the workspace `skills/` directory.
+You can also preload Skills when building a Template (useful for team reuse), see [OpenClaw Template Example](../04.Features/02.Templates/07.Examples/05.OpenClaw%20Template.md).
 
 ### Browser Access (FC E2B)
 
-To open the Gateway Control UI in a browser on FC E2B, **a custom domain must be bound first**. The default platform domain (`*.e2b.fc.aliyuncs.com`) will **trigger a download instead of opening the page**; after binding a custom domain, the page loads normally. For the complete steps on adding a domain in the console, DNS resolution, HTTPS certificates, and SDK configuration, see [Cloud Sandbox Custom Domains](../04.Features/07.FC%20Extensions/03.Custom%20Domains.md).
-
-#### Configure Custom Domain
-
-**Step 1: Console configuration.** Bind a custom domain for the cloud sandbox in the Function Compute console, configure certificates and DNS (`api.<your-custom-domain>` / `*.<your-custom-domain>`).
-
-**Step 2: Update `OPTS` in the SDK.** Replace the default `OPTS` from the [Build Template](#build-template) section above:
-
-```python
-OPTS = {
-    "api_key": "<your E2B API Key>",
-    "api_url": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
-    "domain": "cn-beijing.e2b.fc.aliyuncs.com",
-}
-```
-
-Replace it with the custom domain matching the console (`api_key` must belong to the **same account that bound the custom domain**):
-
-```python
-OPTS = {
-    "api_key": "<your E2B API Key>",
-    "api_url": "https://api.<your-custom-domain>",
-    "domain": "<your-custom-domain>",
-}
-```
-
-**Step 3: Pass `OPTS` throughout the workflow.** `Template.build(..., **OPTS)`, `Sandbox.create(..., **OPTS)`, and all other SDK calls in this documentation use the above `OPTS` — no additional parameters are needed.
-
-After completion, `sandbox.get_host(PORT)` will return `{PORT}-sbx-{sandbox_id}.<your-custom-domain>`; the Gateway's `allowedOrigins`, the browser address bar, and the `<host>` in the `curl` command below all use this address.
-
+On FC E2B the Gateway Control UI is reachable directly via the default platform domain (`*.e2b.fc.aliyuncs.com`) returned by `sandbox.get_host(PORT)` — requests must carry the `X-Access-Token` header. A custom domain is an optional stable-hostname alternative, not a requirement. For the complete steps on adding a domain in the console, DNS resolution, HTTPS certificates, and SDK configuration, see [Cloud Sandbox Custom Domains](../04.Features/07.FC%20Extensions/03.Custom%20Domains.md).
 
 #### Open the Control UI
 
-After configuring the custom domain and [deploying the Gateway](#deploy-gateway), public network access requires two layers of authentication:
+After [deploying the Gateway](#deploy-gateway), public network access requires two layers of authentication:
 
 | Authentication | Source | Purpose | How to Pass |
 |------|------|------|----------|
@@ -404,6 +263,18 @@ The expected response should include `200`; receiving an HTML page indicates the
 
 If you see a "browser origin not allowed" error, make sure `allowedOrigins` exactly matches the address bar URL (`https://{sandbox.get_host(PORT)}`, with no trailing `/`), then [restart the Gateway](#restart-gateway) after making changes.
 
+#### Custom Domain (optional)
+
+If you want a stable hostname instead of the per-sandbox default domain, bind a custom domain in the Function Compute console, configure certificates and DNS (`api.<your-custom-domain>` / `*.<your-custom-domain>`), then point the SDK environment variables at it (`E2B_API_KEY` must belong to the **same account that bound the custom domain**):
+
+```bash
+export E2B_API_KEY="<your E2B API Key>"
+export E2B_API_URL="https://api.<your-custom-domain>"
+export E2B_DOMAIN="<your-custom-domain>"
+```
+
+The SDK reads these variables automatically across `Template.build(...)`, `Sandbox.create(...)`, and all other calls — no need to pass connection parameters into method calls. After completion, `sandbox.get_host(PORT)` will return `{PORT}-sbx-{sandbox_id}.<your-custom-domain>`; the Gateway's `allowedOrigins`, the browser address bar, and the `<host>` in the `curl` command above all use this address.
+
 ### How It Works
 
 | Step | Description |
@@ -412,7 +283,7 @@ If you see a "browser origin not allowed" error, make sure `allowedOrigins` exac
 | `--auth token` | Authentication via URL parameter `?token=` |
 | Browser opens URL | Gateway serves the UI, browser establishes WebSocket |
 | `code=1008 pairing required` | Security mode requires device approval first |
-| `devices approve` | Approve the browser device fingerprint |
+| `devices approve` | Approves the browser device fingerprint |
 | Browser reconnects | WebSocket connection succeeds, UI is available |
 
 ### Gateway Parameters
@@ -514,14 +385,23 @@ If you have already created a Sandbox following the [Deploy Gateway](#deploy-gat
 
 If you only need the CLI without starting the Gateway:
 
-### China: Bailian
-
 ```python
+from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
 
+load_dotenv()
+
+TEMPLATE_NAME = "my-openclaw-template"
+
+# Bailian (recommended for China)
 BAILIAN_API_KEY = "<your-bailian-api-key>"
 BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
 BAILIAN_MODEL = "qwen3.7-max"
+# International OpenAI-compatible (e.g. DashScope OpenAI-compatible mode):
+# PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
+# PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+# PROVIDER_MODEL = "qwen3-coder-plus"
+# PROVIDER_ID = "openai-compat"
 
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
@@ -531,10 +411,12 @@ sandbox = Sandbox.create(
         "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
         "ANTHROPIC_MODEL": BAILIAN_MODEL,
     },
-    **OPTS,
+    # International OpenAI-compatible: envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
 )
 
-# Register the Bailian provider
+# Register the provider via onboard (same pattern for international OpenAI-compatible,
+# but with --custom-compatibility openai). A bare openai/<model> that was never
+# onboarded will fail with "Unknown model".
 sandbox.commands.run(
     "openclaw onboard --non-interactive --accept-risk --skip-health "
     "--auth-choice custom-api-key "
@@ -543,33 +425,27 @@ sandbox.commands.run(
     "--custom-compatibility anthropic "
     f"--custom-model-id {BAILIAN_MODEL} "
     "--custom-provider-id bailian",
+    # International OpenAI-compatible:
+    # f"--custom-api-key {PROVIDER_API_KEY} "
+    # f"--custom-base-url {PROVIDER_BASE_URL} "
+    # "--custom-compatibility openai "
+    # f"--custom-model-id {PROVIDER_MODEL} "
+    # f"--custom-provider-id {PROVIDER_ID}",
     timeout=120,
 )
 
+# Bailian
 result = sandbox.commands.run(
     f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
     '-m "What is 2+2? Reply with just the number."',
     timeout=120,
 )
-print(result.stdout)
-```
-
-### International: OpenAI
-
-```python
-from e2b_code_interpreter import Sandbox
-
-sandbox = Sandbox.create(
-    template=TEMPLATE_NAME,
-    timeout=3600,
-    envs={"OPENAI_API_KEY": "<your-openai-api-key>"},
-    **OPTS,
-)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --message "What is 2+2? Reply with just the number."',
-    timeout=120,
-)
+# International OpenAI-compatible:
+# result = sandbox.commands.run(
+#     f'openclaw agent --local --agent main --model {PROVIDER_ID}/{PROVIDER_MODEL} '
+#     '-m "What is 2+2? Reply with just the number."',
+#     timeout=120,
+# )
 print(result.stdout)
 ```
 
@@ -585,20 +461,9 @@ sandbox.kill()
 
 ---
 
-## Environment Overview
-
-| Item | Specification |
-|------|------|
-| Operating System | Debian |
-| OpenClaw Path | `/home/user/.openclaw/bin/openclaw` |
-| Bundled Node | v22.x (`/home/user/.openclaw/tools/node/bin/node`) |
-| Default User / Working Directory | `user` / `/home/user` |
-
----
-
 ## Billing
 
-Sandboxes are billed based on CPU and memory specifications and runtime duration; model API call costs are billed separately by the model provider. See [Billing Overview](../03.Pricing/01.Billing%20Overview.md) for details.
+Sandboxes are billed based on CPU and memory specifications and runtime duration; model API call costs are billed separately by model providers such as Bailian or OpenAI. See [Billing Overview](../03.Pricing/01.Billing%20Overview.md) for details.
 
 ---
 
@@ -606,19 +471,20 @@ Sandboxes are billed based on CPU and memory specifications and runtime duration
 
 | Issue | Solution |
 |------|------|
-| Agent not responding | Verify that `envs` includes the model Key; for China Bailian, confirm `onboard` has been completed; for International, confirm `OPENAI_API_KEY` is injected |
+| Agent not responding | Verify that `envs` includes the model Key; for Bailian, confirm `onboard` has been completed |
 | Gateway not opening in browser | Add the `X-Access-Token` request header; ensure the URL contains `?token=` |
-| Browser triggers a download | A custom domain must be bound; see [Cloud Sandbox Custom Domains](../04.Features/07.FC%20Extensions/03.Custom%20Domains.md) and [Browser Access (FC E2B)](#browser-access-fc-e2b) |
 | `sandbox account mismatch` | The API Key and custom domain must belong to the same account; see [Cloud Sandbox Custom Domains](../04.Features/07.FC%20Extensions/03.Custom%20Domains.md) |
 | Origin not allowed | Ensure `allowedOrigins` exactly matches the address bar URL, then restart the Gateway |
-| Build failure | Verify that `FROM_IMAGE` matches the region; do not use the `openclaw-v*` prefix for `name` |
+| name 'TEMPLATE_NAME' is not defined | Replace `TEMPLATE_NAME` with the template name from [OpenClaw Template Example](../04.Features/02.Templates/07.Examples/05.OpenClaw%20Template.md) |
 | Other SDK / build issues | See [Custom Templates — Troubleshooting](../08.FAQ/05.Template%20Builds.md) |
 
 ---
 
 ## References
 
+- [OpenClaw Template Example](../04.Features/02.Templates/07.Examples/05.OpenClaw%20Template.md) (image addresses, build and minimal verification, environment overview)
 - [Cloud Sandbox Custom Domains](../04.Features/07.FC%20Extensions/03.Custom%20Domains.md)
+- [E2B SDK Connection Parameters](../07.Developer%20Reference/02.E2B%20SDK%20Connection%20Parameters.md)
 - [E2B OpenClaw Gateway](https://e2b.dev/docs/agents/openclaw/openclaw-gateway)
 - [OpenClaw Control UI](https://docs.openclaw.ai/web/control-ui)
 - [OpenClaw Project](https://github.com/openclaw/openclaw)

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.示例/04.Claude Code 模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.示例/04.Claude Code 模板.md
@@ -1,0 +1,181 @@
+# Claude Code 模板示例
+
+Claude Code 是 Anthropic 的终端 AI 编程 Agent，可在沙箱内读代码、改文件、执行命令。Claude Code 模板从官方 `claude-code` 镜像构建，预置 Claude Code CLI 与运行依赖，开箱可用。本页介绍能力、默认配置、构建与最小验证、使用限制；克隆仓库、连接 MCP、扩展 Skill、获取结构化输出等真实任务教程见[使用 Claude Code 自定义镜像](../../../05.最佳实践/05.Claude%20Code%20自定义镜像.md)。
+
+我们已在各地域 ACR 预置 `claude-code` 镜像，您无需自行推送镜像或配置 ACREE，选取下方镜像地址，通过 `from_image` + `Template.build` 构建模板后即可使用。
+
+## 功能特性
+
+| **特性** | **说明** |
+| --- | --- |
+| 编程 Agent | 内置 Claude Code CLI，可在沙箱内读代码、改文件、执行命令，支持非交互模式 `-p` 与 `--dangerously-skip-permissions` |
+| 会话管理 | 支持 `--resume` 恢复历史会话、`--output-format json` 获取结构化结果 |
+| MCP 原生支持 | Claude Code 原生支持 [MCP](https://modelcontextprotocol.io/)，可通过 `claude mcp add` 注册 stdio / HTTP MCP Server |
+| Skill 扩展 | 通过目录 + `SKILL.md` 的文件系统约定扩展 Agent 能力，随仓库或工作目录生效 |
+| 安全隔离 | 每个 Claude Code 沙箱实例拥有独立的文件系统和进程空间 |
+
+## 默认配置
+
+| **配置项** | **默认值** | **说明** |
+| --- | --- | --- |
+| 容器镜像 | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37` | 各地域 ACR 预置 claude-code 镜像，按地域选取下方地址 |
+| 默认端口 | 无 | Claude Code 以 CLI 形式运行，不暴露固定服务端口 |
+| CPU | 2 vCPU | 推荐构建规格 |
+| 内存 | 8192 MB | 推荐构建规格 |
+| 操作系统 | Ubuntu 25.04 | 镜像内 OS |
+| Claude Code 路径 | `/home/user/.local/bin/claude` | CLI 可执行文件路径 |
+| 默认用户 / 工作目录 | `user` / `/home/user` | 沙箱默认身份 |
+| MCP Gateway | 不支持 | 镜像不提供 MCP Gateway 能力，仅支持 `claude mcp add` 客户端注册 |
+
+## 镜像地址
+
+按地域选取 `FROM_IMAGE`：
+
+| Region | 镜像 |
+|--------|------|
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+
+## 构建与最小验证
+
+Claude Code 模板的用法分为两个阶段：先**构建模板**（从 `claude-code` 镜像固化出一个带名称的模板），再**运行模板**（创建沙箱、注入模型 Key、运行最小 CLI 验证）。
+
+> **说明**：示例中的 `E2B_API_KEY`、`E2B_API_URL`、`E2B_DOMAIN` 需在运行前通过环境变量（如 `.env` 或 `export`）配置为对应地域的接入地址，SDK 会自动读取，无需在方法调用中显式传入。模型 API Key 不预置在镜像内，创建沙箱时通过 `envs` 注入。
+
+### 准备本地环境
+
+```bash
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install e2b==2.31.0 e2b-code-interpreter==2.8.1 python-dotenv
+```
+
+模型 API Key 通过 `envs` 注入，镜像内不预置：
+
+<!-- @props:china -->
+- 中国站：[百炼控制台](https://bailian.console.aliyun.com/) 获取 API Key（`sk-` 开头）
+<!-- @/props -->
+<!-- @props:intl -->
+- 国际站：[Anthropic Console](https://console.anthropic.com/) 获取 `ANTHROPIC_API_KEY`
+<!-- @/props -->
+
+### 构建 Claude Code 模板
+
+从 `claude-code` 镜像构建一个带名称的模板，构建时指定 CPU 与内存规格（推荐 2 vCPU / 8192 MB）。
+
+```python
+"""Claude Code 模板构建示例。"""
+
+from dotenv import load_dotenv
+from e2b import Template, default_build_logger
+
+load_dotenv()
+
+# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37"
+
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name="my-claude-code-template",
+    cpu_count=2,
+    memory_mb=8192,
+    on_build_logs=default_build_logger(),
+)
+print(f"template_id: {build.template_id}")
+```
+
+构建完成后控制台模板状态应为 `ready`。同一模板名称可多次创建 Sandbox，无需每次重新构建。
+
+### 运行模板并验证
+
+创建沙箱时通过 `envs` 注入模型 API Key，首次运行前须初始化 `~/.claude.json`，否则可能报配置损坏。
+
+<!-- @props:china -->
+**中国站：百炼 DashScope**
+
+```python
+"""Claude Code 模板运行示例：创建沙箱 -> 初始化配置 -> 运行最小验证。"""
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+sandbox = Sandbox.create(
+    template="my-claude-code-template",
+    envs={
+        "ANTHROPIC_AUTH_TOKEN": "<your-bailian-api-key>",
+        "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
+        "ANTHROPIC_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-max",
+    },
+    timeout=600,
+)
+
+# 首次运行前须初始化 ~/.claude.json，否则可能报配置损坏。
+sandbox.commands.run("echo '{}' > /home/user/.claude.json")
+
+# 最小验证：非交互模式 + 跳过权限确认，< /dev/null 避免 stdin 等待。
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null '
+    '-p "Reply with just: ok"',
+    timeout=0,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+<!-- @/props -->
+
+<!-- @props:intl -->
+**Anthropic API-compatible 配置**
+
+```python
+"""Claude Code 模板运行示例：创建沙箱 -> 初始化配置 -> 运行最小验证。"""
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+sandbox = Sandbox.create(
+    template="my-claude-code-template",
+    envs={"ANTHROPIC_API_KEY": "<your-anthropic-api-key>"},
+    timeout=600,
+)
+
+# 首次运行前须初始化 ~/.claude.json，否则可能报配置损坏。
+sandbox.commands.run("echo '{}' > /home/user/.claude.json")
+
+# 最小验证：非交互模式 + 跳过权限确认，< /dev/null 避免 stdin 等待。
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null '
+    '-p "Reply with just: ok"',
+    timeout=0,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+<!-- @/props -->
+
+## 使用限制
+
+| **限制项** | **约束** |
+| --- | --- |
+| MCP Gateway | 不支持。仅支持通过 `claude mcp add` 客户端注册 stdio / HTTP MCP Server，不支持 SDK `mcp` 创建参数与 `getMcpUrl()` / `getMcpToken()` |
+| 模型 Key | 不预置在镜像内，必须通过 `envs` 运行时注入 |
+
+## 相关文档
+
+- [使用 Claude Code 自定义镜像](../../../05.最佳实践/05.Claude%20Code%20自定义镜像.md)（克隆仓库、MCP、Skill、结构化输出等真实任务完整教程）
+- [内置模板](../02.内置模板.md)
+- [模板名称与版本](../06.模板名称与版本.md)

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.示例/05.OpenClaw 模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.示例/05.OpenClaw 模板.md
@@ -1,0 +1,217 @@
+# OpenClaw 模板示例
+
+OpenClaw 是开源 Agent 框架，支持 CLI 编程调用与 Gateway Web UI。OpenClaw 模板从官方 `openclaw` 镜像构建，预置 OpenClaw CLI 与运行依赖，开箱可用。本页介绍能力、默认配置、构建与最小验证、使用限制；Gateway 部署、Agent CLI 实战、Skill 扩展、自定义域名接入等真实任务教程见[使用 OpenClaw 自定义镜像](../../../05.最佳实践/06.OpenClaw%20自定义镜像.md)。
+
+我们已在各地域 ACR 预置 `openclaw` 镜像，您无需自行推送镜像或配置 ACREE，选取下方镜像地址，通过 `from_image` + `Template.build` 构建模板后即可使用。
+
+## 功能特性
+
+| **特性** | **说明** |
+| --- | --- |
+| 编程 Agent | 内置 OpenClaw CLI，支持 `openclaw agent --local` 非交互式编程调用 |
+| Gateway Web UI | 支持 `openclaw gateway` 启动 Web UI；通过 `sandbox.get_host(PORT)` 获取默认平台域名，并携带 `X-Access-Token` 即可在浏览器中访问 |
+| 多模型适配 | 内置 `openclaw onboard` 命令，可注册百炼、OpenAI 等自定义 provider |
+| Skill 扩展 | 通过目录 + `SKILL.md` 的文件系统约定扩展 Agent 能力，支持 workspace / managed / bundled 三种作用域 |
+| 安全隔离 | 每个 OpenClaw 沙箱实例拥有独立的文件系统和进程空间 |
+
+## 默认配置
+
+| **配置项** | **默认值** | **说明** |
+| --- | --- | --- |
+| 容器镜像 | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37` | 各地域 ACR 预置 openclaw 镜像，按地域选取下方地址 |
+| Gateway 默认端口 | 18789 | `openclaw gateway --port` 监听端口 |
+| CPU | 2 vCPU | 推荐构建规格 |
+| 内存 | 4096 MB | 推荐构建规格 |
+| 操作系统 | Debian 13 (trixie) | 镜像内 OS |
+| OpenClaw 路径 | `/home/user/.openclaw/bin/openclaw` | CLI 可执行文件路径 |
+| 自带 Node | v22.x | `/home/user/.openclaw/tools/node/bin/node` |
+| 默认用户 / 工作目录 | `user` / `/home/user` | 沙箱默认身份 |
+
+## 镜像地址
+
+按地域选取 `FROM_IMAGE`：
+
+| Region | 镜像 |
+|--------|------|
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+
+## 构建与最小验证
+
+OpenClaw 模板的用法分为两个阶段：先**构建模板**（从 `openclaw` 镜像固化出一个带名称的模板），再**运行模板**（创建沙箱、注入模型 Key、运行最小 CLI 验证）。
+
+> **说明**：示例中的 `E2B_API_KEY`、`E2B_API_URL`、`E2B_DOMAIN` 需在运行前通过环境变量（如 `.env` 或 `export`）配置为对应地域的接入地址，SDK 会自动读取，无需在方法调用中显式传入。模型 API Key 不预置在镜像内，创建沙箱时通过 `envs` 注入。
+
+### 准备本地环境
+
+```bash
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install e2b==2.31.0 e2b-code-interpreter==2.8.1 python-dotenv
+```
+
+模型 API Key 通过 `envs` 注入，镜像内不预置：
+
+<!-- @props:china -->
+- 中国站：[百炼控制台](https://bailian.console.aliyun.com/) 获取 API Key（`sk-` 开头）
+<!-- @/props -->
+<!-- @props:intl -->
+- 国际站：从所选 OpenAI-compatible provider 获取 API Key、Base URL 与模型名；下例使用 DashScope OpenAI-compatible 模式
+<!-- @/props -->
+
+### 构建 OpenClaw 模板
+
+从 `openclaw` 镜像构建一个带名称的模板，构建时指定 CPU 与内存规格（推荐 2 vCPU / 4096 MB）。
+
+```python
+"""OpenClaw 模板构建示例。"""
+
+from dotenv import load_dotenv
+from e2b import Template, default_build_logger
+
+load_dotenv()
+
+# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37"
+
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name="my-openclaw-template",
+    cpu_count=2,
+    memory_mb=4096,
+    on_build_logs=default_build_logger(),
+)
+print(f"template_id: {build.template_id}")
+```
+
+构建完成后控制台模板状态应为 `ready`。同一模板名称可多次创建 Sandbox，无需每次重新构建。
+
+### Template name 命名限制
+
+`name` 不得使用系统保留前缀 **`openclaw-v`**（例如 `openclaw-v0.0.37`、`openclaw-v037-test`），否则会报错：
+
+```text
+400: invalid template name '...': must not be a system reserved name openclaw-v*
+```
+
+推荐使用 `my-openclaw-{timestamp}` 等自定义名称。以 `openclaw-` 开头但**不含** `openclaw-v` 的名称（如 `openclaw-1783153993`）通常可用。
+
+### 运行模板并验证
+
+创建沙箱时通过 `envs` 注入模型 API Key。
+
+<!-- @props:china -->
+**中国站：百炼**
+
+```python
+"""OpenClaw 模板运行示例：创建沙箱 -> 注册 provider -> 运行最小 CLI 验证。"""
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+BAILIAN_API_KEY = "<your-bailian-api-key>"
+BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
+BAILIAN_MODEL = "qwen3.7-max"
+
+sandbox = Sandbox.create(
+    template="my-openclaw-template",
+    timeout=600,
+    envs={
+        "ANTHROPIC_AUTH_TOKEN": BAILIAN_API_KEY,
+        "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
+        "ANTHROPIC_MODEL": BAILIAN_MODEL,
+    },
+)
+
+# 注册百炼 provider
+sandbox.commands.run(
+    "openclaw onboard --non-interactive --accept-risk --skip-health "
+    "--auth-choice custom-api-key "
+    f"--custom-api-key {BAILIAN_API_KEY} "
+    f"--custom-base-url {BAILIAN_BASE_URL} "
+    "--custom-compatibility anthropic "
+    f"--custom-model-id {BAILIAN_MODEL} "
+    "--custom-provider-id bailian",
+    timeout=120,
+)
+
+# 最小验证
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    '-m "Reply with just: ok"',
+    timeout=120,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+<!-- @/props -->
+
+<!-- @props:intl -->
+**国际站：OpenAI-compatible**
+
+```python
+"""OpenClaw 模板运行示例：创建沙箱 -> onboard provider -> 运行最小 CLI 验证。"""
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+# 以 DashScope OpenAI-compatible 模式为例
+PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
+PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+PROVIDER_MODEL = "qwen3-coder-plus"
+PROVIDER_ID = "openai-compat"
+
+sandbox = Sandbox.create(
+    template="my-openclaw-template",
+    timeout=600,
+    envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
+)
+
+# 注册 OpenAI-compatible provider；未注册的裸 openai/<model> 会报 Unknown model
+sandbox.commands.run(
+    "openclaw onboard --non-interactive --accept-risk --skip-health "
+    "--auth-choice custom-api-key "
+    f"--custom-api-key {PROVIDER_API_KEY} "
+    f"--custom-base-url {PROVIDER_BASE_URL} "
+    "--custom-compatibility openai "
+    f"--custom-model-id {PROVIDER_MODEL} "
+    f"--custom-provider-id {PROVIDER_ID}",
+    timeout=120,
+)
+
+# 最小验证
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model {PROVIDER_ID}/{PROVIDER_MODEL} '
+    '-m "Reply with just: ok"',
+    timeout=120,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+<!-- @/props -->
+
+## 使用限制
+
+| **限制项** | **约束** |
+| --- | --- |
+| Template name | 不得使用系统保留前缀 `openclaw-v*`（例如 `openclaw-v0.0.37`） |
+| 模型 Key | 不预置在镜像内，必须通过 `envs` 运行时注入；百炼与 OpenAI-compatible 均须先 `openclaw onboard` 注册 provider，未注册的裸 `openai/<model>` 会报 Unknown model |
+| Gateway 浏览器访问 | 默认平台域名可通过 `sandbox.get_host(PORT)` 直接访问，请求须带 `X-Access-Token`；自定义域名为可选的稳定域名方案，非必需 |
+
+## 相关文档
+
+- [使用 OpenClaw 自定义镜像](../../../05.最佳实践/06.OpenClaw%20自定义镜像.md)（Gateway 部署、Agent CLI 实战、Skill 扩展、自定义域名接入等完整教程）
+- [内置模板](../02.内置模板.md)
+- [模板名称与版本](../06.模板名称与版本.md)

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
@@ -1,6 +1,6 @@
-# Claude Code 自定义镜像
+# 使用 Claude Code 自定义镜像
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) 是 Anthropic 的终端 AI 编程 Agent，可在沙箱内读代码、改文件、执行命令。我们已在各地域 ACR 预置 Claude Code 镜像，您无需自行推送镜像或配置 ACREE，选取下方镜像地址，通过 `from_image` + `Template.build` 构建模板后即可使用。
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) 是 Anthropic 的终端 AI 编程 Agent，可在沙箱内读代码、改文件、执行命令。本文聚焦真实任务场景：克隆仓库、连接 MCP、扩展 Skill、获取结构化输出与会话恢复。镜像地址、构建与最小验证见 [Claude Code 模板示例](../04.功能说明/02.模板/07.示例/04.Claude%20Code%20模板.md)。
 
 首次使用请先完成 [通过 SDK 创建第一个云沙箱](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk) 中的 SLR 授权、API Key 与 SDK 配置。
 
@@ -8,8 +8,8 @@
 
 ## 前置条件
 
-- 已完成 [SDK 接入](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk)（E2B API Key、`api_url`、`domain`）
-- 已安装依赖：`pip install e2b==2.31.0 e2b-code-interpreter==2.8.1`
+- 已完成 [SDK 接入](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk)，并通过环境变量配置 `E2B_API_KEY`、`E2B_API_URL`、`E2B_DOMAIN`（SDK 自动读取）
+- 已按 [Claude Code 模板示例](../04.功能说明/02.模板/07.示例/04.Claude%20Code%20模板.md) 构建出状态为 `ready` 的模板，并记录模板名称（下文以 `TEMPLATE_NAME` 表示）
 - 已准备模型 API Key，创建沙箱时通过 `envs` 注入 — 镜像内不预置
   <!-- @props:china -->
   - 中国站：[百炼控制台](https://bailian.console.aliyun.com/) 获取 API Key（`sk-` 开头）
@@ -18,107 +18,70 @@
   - 国际站：[Anthropic Console](https://console.anthropic.com/) 获取 `ANTHROPIC_API_KEY`
   <!-- @/props -->
 
----
-
-## 镜像地址
-
-按地域选取 `FROM_IMAGE`：
-
-| Region | 镜像 |
-|--------|------|
-| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
-| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
-| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
-| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
-| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
-| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
-
-推荐构建规格：`cpu_count=2`，`memory_mb=8192`。
+本文示例均假设：已完成模板构建；`sandbox` 已创建；`~/.claude.json` 已初始化；`E2B_API_KEY`、`E2B_API_URL`、`E2B_DOMAIN` 已通过环境变量或 `.env` 配置。
 
 ---
 
-## 快速开始
+## 创建沙箱并运行
 
-以下以北京地域为例，分四步：**构建 Template → 创建 Sandbox → 运行 Claude Code → 销毁沙箱**。
-
-### 构建 Template
-
-```python
-import time
-
-from e2b import Template, default_build_logger
-
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.32"
-TEMPLATE_NAME = f"claude-code-{int(time.time())}"
-
-OPTS = {
-    "api_key": "<你的 E2B API Key>",
-    "api_url": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
-    "domain": "cn-beijing.e2b.fc.aliyuncs.com",
-}
-
-build = Template.build(
-    Template().from_image(FROM_IMAGE),
-    name=TEMPLATE_NAME,
-    cpu_count=2,
-    memory_mb=8192,
-    on_build_logs=default_build_logger(),
-    **OPTS,
-)
-
-print(f"template: {build.name}")   # 保存，后续可复用
-```
-
-构建完成后控制台模板状态应为 `ready`。同一模板名称可多次创建 Sandbox，无需每次重新构建。
-
-### 创建 Sandbox
-
-创建沙箱时通过 `envs` 注入模型 API Key。
+从已构建的模板创建沙箱，通过 `envs` 注入模型 Key。百炼（Anthropic-compatible）流程已端到端验证，Anthropic-compatible / 百炼 API 配置为受支持路径。首次运行前须初始化 `~/.claude.json`，否则可能报配置损坏。
 
 <!-- @props:china -->
-**中国站：百炼 DashScope**
+### 中国站：百炼 DashScope
 
 ```python
+from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+TEMPLATE_NAME = "my-claude-code-template"  # 来自 Claude Code 模板示例
 
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
     envs={
         "ANTHROPIC_AUTH_TOKEN": "<your-bailian-api-key>",
         "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
-        "ANTHROPIC_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.6-flash",
+        "ANTHROPIC_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-max",
     },
     timeout=600,
-    **OPTS,
 )
 
-# 首次运行前须初始化 `~/.claude.json`，否则可能报配置损坏。
+# 首次运行前须初始化 ~/.claude.json，否则可能报配置损坏。
 sandbox.commands.run("echo '{}' > /home/user/.claude.json")
 ```
 <!-- @/props -->
 
 <!-- @props:intl -->
-**国际站：Anthropic 直连**
+### Anthropic API-compatible 配置
+
+下例直接注入 Anthropic API Key。仅当您持有面向 Anthropic-compatible endpoint 的有效 Anthropic API Key 时使用；上文百炼流程为已验证路径。
 
 ```python
+from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+TEMPLATE_NAME = "my-claude-code-template"  # 来自 Claude Code 模板示例
 
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
     envs={"ANTHROPIC_API_KEY": "<your-anthropic-api-key>"},
     timeout=600,
-    **OPTS,
 )
 
-# 首次运行前须初始化 `~/.claude.json`，否则可能报配置损坏。
+# 首次运行前须初始化 ~/.claude.json，否则可能报配置损坏。
 sandbox.commands.run("echo '{}' > /home/user/.claude.json")
 ```
 <!-- @/props -->
 
-### 运行 Claude Code
+## 运行 Claude Code
 
 非交互模式使用 `-p`；在沙箱内可加 `--dangerously-skip-permissions` 跳过权限确认。建议加 `< /dev/null` 避免 stdin 等待警告：
 
@@ -141,20 +104,7 @@ sandbox.kill()
 
 ---
 
-## 环境概览
-
-| 项目 | 规格 |
-|------|------|
-| 操作系统 | Ubuntu 25.04 |
-| Claude Code 路径 | `/home/user/.local/bin/claude` |
-| 默认用户 / 工作目录 | `user` / `/home/user` |
-| MCP Gateway | **不支持** |
-
----
-
 ## 使用场景
-
-以下示例假设已完成 Template 构建，`sandbox` 已创建且已初始化 `~/.claude.json`。
 
 ### 克隆仓库并执行任务
 
@@ -199,28 +149,7 @@ else:
 print(response.get("result") or response)
 ```
 
-### 流式 JSONL 输出
-
-```python
-import json
-
-def handle_event(data):
-    for line in data.strip().split("\n"):
-        if line.startswith("{"):
-            event = json.loads(line)
-            if event["type"] == "assistant":
-                usage = event.get("message", {}).get("usage", {})
-                print(f"[assistant] tokens: {usage.get('output_tokens')}")
-            elif event["type"] == "result":
-                print(f"[done] {event['subtype']} in {event['duration_ms']}ms")
-
-sandbox.commands.run(
-    'claude --dangerously-skip-permissions --verbose --output-format stream-json < /dev/null '
-    '-p "Find and fix all TODO comments" 2>&1',
-    on_stdout=handle_event,
-    timeout=0,
-)
-```
+> **说明**：`--output-format stream-json` 配合 SDK 的 `on_stdout` 回调在此不支持。流式输出不产生终止结束事件，`sandbox.commands.run(..., on_stdout=...)` 会抛出 `Command ended without an end event`。请改用 `--output-format json`（一次性结构化结果）。
 
 ### 恢复会话
 
@@ -311,7 +240,7 @@ result = sandbox.commands.run(
 | 个人（本沙箱内全局） | `/home/user/.claude/skills/<name>/SKILL.md` |
 | 项目 | `<项目>/.claude/skills/<name>/SKILL.md` |
 
-触发方式：在 `-p` 提示词中写 `/skill-name` 显式调用，或描述匹配任务由模型自动加载。Claude Code 还自带 `/debug`、`/code-review` 等 bundled skill，无需额外安装。
+触发方式：在 `-p` 提示词中写 `/skill-name` 显式调用，或描述匹配任务由模型自动加载。
 
 **运行时写入个人 Skill：**
 
@@ -362,43 +291,39 @@ sandbox.commands.run(
 
 **从本机上传多文件 Skill 目录：**
 
-若 Skill 含 `scripts/`、`references/` 等附属文件，用 `files.write_files` 一次批量写入，不必逐文件调用 `files.write`：
+若 Skill 含 `scripts/`、`references/` 等附属文件，可用 `files.write_files` 批量写入整个目录：
 
 ```python
 from pathlib import Path
 
-def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
-    local = Path(local_dir).resolve()
-    entries = []
-    for path in local.rglob("*"):
-        if path.is_file():
-            rel = path.relative_to(local).as_posix()
-            entries.append({
-                "path": f"{remote_root.rstrip('/')}/{rel}",
-                "data": path.read_bytes(),
-            })
-    sandbox.files.write_files(entries)
+local = Path("./my-skills/echo-marker").resolve()
+remote_root = "/home/user/.claude/skills/echo-marker"
+entries = []
+for path in local.rglob("*"):
+    if path.is_file():
+        relative = path.relative_to(local).as_posix()
+        entries.append({
+            "path": f"{remote_root}/{relative}",
+            "data": path.read_bytes(),
+        })
 
-# 本机目录结构示例：
-# ./my-skills/echo-marker/SKILL.md
-# ./my-skills/echo-marker/scripts/marker.txt
-upload_skill_dir(
-    sandbox,
-    "./my-skills/echo-marker",
-    "/home/user/.claude/skills/echo-marker",
-)
-
-result = sandbox.commands.run(
-    'claude --dangerously-skip-permissions < /dev/null '
-    '-p "/echo-marker"',
-    timeout=0,
-)
-print(result.stdout)
+sandbox.files.write_files(entries)
 ```
 
-项目作用域同理，把 `remote_root` 换成 `/home/user/repo/.claude/skills/<name>`。也可克隆已含 `.claude/skills/` 的仓库后直接使用。
+项目作用域将 `remote_root` 换成 `/home/user/repo/.claude/skills/<name>`。`Template.copy` 目前不支持在 `Template.build` 时预置本机目录，请改用运行时 `files.write` 或 `files.write_files`。
 
-> **关于 Template.copy**：**暂不支持** `Template.build` 时用 `.copy("local-dir", "/home/user/.claude/skills/...")` 预置文件。自定义 Skill 请用上方运行时 `files.write` / `files.write_files`。
+也可在构建 Template 时预置 Skill（适合团队复用），见 [Claude Code 模板示例](../04.功能说明/02.模板/07.示例/04.Claude%20Code%20模板.md)。
+
+---
+
+## 上线建议
+
+- 登录态、Git Token、模型 API Key 应按任务隔离，通过 `envs` 运行时注入，不写入模板或镜像。
+- 限制单次任务超时与输出大小；非交互模式加 `--dangerously-skip-permissions` 时确保沙箱内无敏感数据落盘。
+- 记录提示词、模型版本、工具调用轨迹与产物路径，便于复盘。
+- 网页或仓库内容可能包含 prompt injection，不要让 Agent 未经校验地执行外部指令。
+
+---
 
 ## 计费说明
 
@@ -412,7 +337,12 @@ Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由
 |------|------|
 | 报配置损坏 | `echo '{}' > /home/user/.claude.json` |
 | Agent 无响应 | <!-- @props:china -->确认 `envs` 已注入模型 Key；中国站用百炼 `envs` 配置<!-- @/props --><!-- @props:intl -->确认 `envs` 已注入 `ANTHROPIC_API_KEY`<!-- @/props --> |
-| 构建失败 | 确认 `FROM_IMAGE` 与地域匹配 |
-| name 'TEMPLATE_NAME' is not defined | 控制台获取模版名称并替换 `TEMPLATE_NAME` |
+| name 'TEMPLATE_NAME' is not defined | 用 [Claude Code 模板示例](../04.功能说明/02.模板/07.示例/04.Claude%20Code%20模板.md) 中的模板名替换 `TEMPLATE_NAME` |
 | 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
+
 ---
+
+## 参考
+
+- [Claude Code 模板示例](../04.功能说明/02.模板/07.示例/04.Claude%20Code%20模板.md)（镜像地址、构建与最小验证、环境概览）
+- [E2B SDK 接入参数说明](../07.开发参考/02.E2B%20SDK%20接入参数说明.md)

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
@@ -1,6 +1,6 @@
-# OpenClaw 自定义镜像
+# 使用 OpenClaw 自定义镜像
 
-[OpenClaw](https://github.com/openclaw/openclaw) 是开源 Agent 框架，支持 CLI 编程调用与 Gateway Web UI。我们已在各地域 ACR 预置 OpenClaw 镜像，您无需自行推送镜像或配置 ACREE，选取下方镜像地址，通过 `from_image` + `Template.build` 构建模板后即可使用。
+[OpenClaw](https://github.com/openclaw/openclaw) 是开源 Agent 框架，支持 CLI 编程调用与 Gateway Web UI。本文聚焦真实任务场景：Gateway 部署、Agent CLI 编程调用、Skill 扩展、自定义域名接入、安全与运维。镜像地址、构建与最小验证见 [OpenClaw 模板示例](../04.功能说明/02.模板/07.示例/05.OpenClaw%20模板.md)。
 
 首次使用请先完成 [通过 SDK 创建第一个云沙箱](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk) 中的 SLR 授权、API Key 与 SDK 配置。
 
@@ -8,102 +8,48 @@
 
 ## 前置条件
 
-- 已完成 [SDK 接入](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk)（E2B API Key、`api_url`、`domain`）
-- 已安装依赖：`pip install e2b==2.31.0 e2b-code-interpreter==2.8.1`
+- 已完成 [SDK 接入](https://help.aliyun.com/zh/functioncompute/create-your-first-cloud-sandbox-via-the-sdk)，并通过环境变量配置 `E2B_API_KEY`、`E2B_API_URL`、`E2B_DOMAIN`（SDK 自动读取）
+- 已按 [OpenClaw 模板示例](../04.功能说明/02.模板/07.示例/05.OpenClaw%20模板.md) 构建出状态为 `ready` 的模板，并记录模板名称（下文以 `TEMPLATE_NAME` 表示）
 - 已准备模型 API Key，创建沙箱时通过 `envs` 注入 — 镜像内不预置
   <!-- @props:china -->
   - 中国站：[百炼控制台](https://bailian.console.aliyun.com/) 获取 API Key（`sk-` 开头）
   <!-- @/props -->
   <!-- @props:intl -->
-  - 国际站：[OpenAI Platform](https://platform.openai.com/) 获取 `OPENAI_API_KEY`
+  - 国际站：从所选 OpenAI-compatible provider 获取 API Key、Base URL 与模型名；下例使用 DashScope OpenAI-compatible 模式
   <!-- @/props -->
 
----
-
-## 镜像地址
-
-按地域选取 `FROM_IMAGE`：
-
-| Region | 镜像 |
-|--------|------|
-| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
-| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
-| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
-| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
-| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
-| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
-
-推荐构建规格：`cpu_count=2`，`memory_mb=4096`。
+本文示例均假设已完成模板构建；`E2B_API_KEY`、`E2B_API_URL`、`E2B_DOMAIN` 已通过环境变量或 `.env` 配置（SDK 自动读取）。
 
 ---
 
-## 构建 Template
+## 部署 Gateway { #deploy-gateway }
 
-自定义模板需先将镜像构建为 Template，**只需执行一次**。完成后保存模板名称，后续创建 Sandbox 时直接复用。
-
-以下以北京地域为例：
+启动 OpenClaw Gateway，在浏览器中与 Agent 对话。完整流程：**创建 Sandbox → 配置 → 启动 Gateway → 获取访问地址**。以下以**百炼**（中国站推荐）为例；国际站可按注释中的 OpenAI-compatible 分支调整。服务端编程调用见 [Agent CLI](#agent-cli)。
 
 ```python
 import time
 
-from e2b import Template, default_build_logger
-
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.32"
-TEMPLATE_NAME = f"openclaw-{int(time.time())}"
-
-OPTS = {
-    "api_key": "<你的 E2B API Key>",
-    "api_url": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
-    "domain": "cn-beijing.e2b.fc.aliyuncs.com",
-}
-
-build = Template.build(
-    Template().from_image(FROM_IMAGE),
-    name=TEMPLATE_NAME,
-    cpu_count=2,
-    memory_mb=4096,
-    on_build_logs=default_build_logger(),
-    **OPTS,
-)
-
-print(f"template: {build.name}")   # 保存，后续可复用
-```
-
-构建完成后控制台模板状态应为 `ready`。同一模板名称可多次创建 Sandbox，无需每次重新构建。
-
-### Template name 命名限制
-
-`name` 不得使用系统保留前缀 **`openclaw-v`**（例如 `openclaw-v0.0.32`、`openclaw-v032-test`），否则会报错：
-
-```text
-400: invalid template name '...': must not be a system reserved name openclaw-v*
-```
-
-推荐使用 `my-openclaw-{timestamp}` 等自定义名称。以 `openclaw-` 开头但**不含** `openclaw-v` 的名称（如 `openclaw-1783153993`）通常可用。
-
----
-
-## 部署 Gateway
-
-启动 OpenClaw Gateway，在浏览器中与 Agent 对话。以下完整流程：**创建 Sandbox → 配置 → 启动 Gateway → 获取访问地址**。服务端编程调用见 [Agent CLI](#agent-cli)。
-
-<!-- @props:china -->
-### 中国站：百炼
-
-```python
-import time
-
+from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+TEMPLATE_NAME = "my-openclaw-template"
 
 # Gateway 鉴权 Token：自行设定任意字符串，无需从 API 获取。
 # 启动时传给 openclaw gateway --token；浏览器访问时通过 URL ?token= 携带。
-# 官方文档亦支持 OPENCLAW_APP_TOKEN 环境变量，本质相同。
 TOKEN = "my-gateway-token"
 PORT = 18789
 
+# 百炼（中国站推荐）
 BAILIAN_API_KEY = "<your-bailian-api-key>"
 BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
 BAILIAN_MODEL = "qwen3.7-max"
+# 国际站 OpenAI-compatible（以 DashScope OpenAI-compatible 模式为例）：
+# PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
+# PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+# PROVIDER_MODEL = "qwen3-coder-plus"
+# PROVIDER_ID = "openai-compat"
 
 # 1. 创建 Sandbox
 sandbox = Sandbox.create(
@@ -114,10 +60,13 @@ sandbox = Sandbox.create(
         "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
         "ANTHROPIC_MODEL": BAILIAN_MODEL,
     },
-    **OPTS,
+    # 国际站 OpenAI-compatible：将上面 envs 替换为
+    # envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
 )
 
-# 注册百炼 provider
+# 通过 onboard 注册 provider。百炼用 anthropic 兼容；
+# OpenAI-compatible endpoint 用 openai 兼容。下方 model id 须与 provider 实际模型名一致——
+# 未注册的裸 openai/<model> 会报 Unknown model。
 sandbox.commands.run(
     "openclaw onboard --non-interactive --accept-risk --skip-health "
     "--auth-choice custom-api-key "
@@ -126,6 +75,12 @@ sandbox.commands.run(
     "--custom-compatibility anthropic "
     f"--custom-model-id {BAILIAN_MODEL} "
     "--custom-provider-id bailian",
+    # 国际站 OpenAI-compatible：
+    # f"--custom-api-key {PROVIDER_API_KEY} "
+    # f"--custom-base-url {PROVIDER_BASE_URL} "
+    # "--custom-compatibility openai "
+    # f"--custom-model-id {PROVIDER_MODEL} "
+    # f"--custom-provider-id {PROVIDER_ID}",
     timeout=120,
 )
 
@@ -133,6 +88,10 @@ sandbox.commands.run(
 sandbox.commands.run(
     f"openclaw config set agents.defaults.model.primary bailian/{BAILIAN_MODEL}"
 )
+# 国际站 OpenAI-compatible：
+# sandbox.commands.run(
+#     f"openclaw config set agents.defaults.model.primary {PROVIDER_ID}/{PROVIDER_MODEL}"
+# )
 
 # 3. 配置 Control UI（FC E2B 公网访问必需）
 origin = f"https://{sandbox.get_host(PORT)}"
@@ -163,65 +122,6 @@ print(f"Gateway: {url}")
 # X-Access-Token 在 Sandbox.create 成功后由 SDK 返回，用于 FC E2B 公网端口代理鉴权
 print(f"Access Token: {sandbox._envd_access_token}")
 ```
-<!-- @/props -->
-
-<!-- @props:intl -->
-### 国际站：OpenAI
-
-```python
-import time
-
-from e2b_code_interpreter import Sandbox
-
-# Gateway 鉴权 Token：自行设定任意字符串，无需从 API 获取。
-# 启动时传给 openclaw gateway --token；浏览器访问时通过 URL ?token= 携带。
-# 官方文档亦支持 OPENCLAW_APP_TOKEN 环境变量，本质相同。
-TOKEN = "my-gateway-token"
-PORT = 18789
-
-# 1. 创建 Sandbox
-sandbox = Sandbox.create(
-    template=TEMPLATE_NAME,
-    timeout=3600,
-    envs={"OPENAI_API_KEY": "<your-openai-api-key>"},
-    **OPTS,
-)
-
-# 2. 设置默认模型
-sandbox.commands.run(
-    "openclaw config set agents.defaults.model.primary openai/gpt-4o"
-)
-
-# 3. 配置 Control UI（FC E2B 公网访问必需）
-origin = f"https://{sandbox.get_host(PORT)}"
-sandbox.commands.run(
-    f"openclaw config set gateway.controlUi.allowedOrigins '[\"{origin}\"]'"
-)
-
-# 4. 启动 Gateway（后台运行）
-sandbox.commands.run(
-    f"bash -lc 'openclaw config set gateway.controlUi.allowInsecureAuth true && "
-    f"openclaw config set gateway.controlUi.dangerouslyDisableDeviceAuth true && "
-    f"openclaw gateway --allow-unconfigured --bind lan --auth token "
-    f"--token {TOKEN} --port {PORT}'",
-    background=True,
-)
-
-# 5. 等待 Gateway 就绪
-for _ in range(45):
-    probe = sandbox.commands.run(
-        f'bash -lc \'ss -ltn | grep -q ":{PORT} " && echo ready || echo waiting\''
-    )
-    if probe.stdout.strip() == "ready":
-        break
-    time.sleep(1)
-
-url = f"https://{sandbox.get_host(PORT)}/?token={TOKEN}"
-print(f"Gateway: {url}")
-# X-Access-Token 在 Sandbox.create 成功后由 SDK 返回，用于 FC E2B 公网端口代理鉴权
-print(f"Access Token: {sandbox._envd_access_token}")
-```
-<!-- @/props -->
 
 `X-Access-Token` **不是手动申请的**，也**不是 Gateway Token**。`Sandbox.create(...)` 成功后，SDK 在 sandbox 对象上暴露 `_envd_access_token`（即 Sandbox Access Token）。每个 Sandbox 各有一份，仅在该 Sandbox 存活期间有效；销毁后失效，需重新创建 Sandbox 获取新值。
 
@@ -231,10 +131,10 @@ OpenClaw 通过 Skill（目录 + `SKILL.md`）扩展 Agent 能力。详见 [Open
 
 镜像不预装自定义 Skill；可用 `openclaw skills list` 查看已加载 Skill（含 bundled）。
 
-| 作用域 | 路径| Source 标识 |
+| 作用域 | 路径（本镜像实测） | Source 标识 |
 |--------|-------------------|-------------|
-| Workspace | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
-| Managed | `/home/user/.openclaw/skills/<name>/SKILL.md` | managed |
+| Workspace（优先） | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
+| Managed / 本机共享 | `/home/user/.openclaw/skills/<name>/SKILL.md` | `openclaw-managed` |
 | Bundled | 随 OpenClaw 安装自带 | `openclaw-bundled` |
 
 触发方式：
@@ -265,8 +165,9 @@ user-invocable: true
 # 确认已出现在列表中
 print(sandbox.commands.run("openclaw skills list").stdout)
 
+# 需先按上文 onboard 注册 provider；下例为百炼，国际站替换为 PROVIDER_ID/PROVIDER_MODEL
 result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
+    'openclaw agent --local --agent main --model bailian/qwen3.7-max '
     '--message "/summarize-changes"',
     timeout=0,
 )
@@ -291,8 +192,9 @@ When writing API endpoints:
 """,
 )
 
+# 需先按上文 onboard 注册 provider；下例为百炼，国际站替换为 PROVIDER_ID/PROVIDER_MODEL
 result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
+    'openclaw agent --local --agent main --model bailian/qwen3.7-max '
     '--message "/api-conventions Add a /healthz endpoint"',
     timeout=0,
 )
@@ -301,94 +203,47 @@ print(result.stdout)
 
 **从本机上传多文件 Skill 目录：**
 
-若 Skill 含 `scripts/`、`references/` 等附属文件，用 `files.write_files` 一次批量写入，不必逐文件调用 `files.write`：
+若 Skill 含 `scripts/`、`references/` 等附属文件，可用 `files.write_files` 批量写入整个目录：
 
 ```python
 from pathlib import Path
 
-def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
-    local = Path(local_dir).resolve()
-    entries = []
-    for path in local.rglob("*"):
-        if path.is_file():
-            rel = path.relative_to(local).as_posix()
-            entries.append({
-                "path": f"{remote_root.rstrip('/')}/{rel}",
-                "data": path.read_bytes(),
-            })
-    sandbox.files.write_files(entries)
+local = Path("./my-skills/echo-marker").resolve()
+remote_root = "/home/user/.openclaw/skills/echo-marker"
+entries = []
+for path in local.rglob("*"):
+    if path.is_file():
+        relative = path.relative_to(local).as_posix()
+        entries.append({
+            "path": f"{remote_root}/{relative}",
+            "data": path.read_bytes(),
+        })
 
-# 本机目录结构示例：
-# ./my-skills/echo-marker/SKILL.md
-# ./my-skills/echo-marker/scripts/marker.txt
-upload_skill_dir(
-    sandbox,
-    "./my-skills/echo-marker",
-    "/home/user/.openclaw/skills/echo-marker",  # Managed；Workspace 则用 workspace/skills/...
-)
-
+sandbox.files.write_files(entries)
 print(sandbox.commands.run("openclaw skills list").stdout)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
-    '--message "/echo-marker"',
-    timeout=0,
-)
-print(result.stdout)
 ```
 
-> **关于 Template.copy**：**暂不支持** `Template.build` 时用 `.copy("local-dir", "/home/user/.openclaw/skills/...")` 预置文件。自定义 Skill 请用上方运行时 `files.write` / `files.write_files`。
+Workspace 作用域将 `remote_root` 换成 `/home/user/.openclaw/workspace/skills/<name>`。`Template.copy` 目前不支持在 `Template.build` 时预置本机目录，请改用运行时 `files.write` 或 `files.write_files`。
 
-**从 ClawHub 安装（可选）：**
+**搜索 ClawHub（可选）：**
 
-沙箱默认具备公网出站，可直接搜索 / 安装社区 Skill（浏览 [clawhub.ai](https://clawhub.ai)）：
+沙箱默认具备公网出站，可直接搜索社区 Skill（浏览 [clawhub.ai](https://clawhub.ai)）。注意 `openclaw skills search` 仅查询 ClawHub 目录；具体 Skill 能否安装取决于 ClawHub 可用性。
 
 ```python
-# 搜索
+# 搜索 ClawHub 目录
 result = sandbox.commands.run("openclaw skills search calendar", timeout=120)
 print(result.stdout)
-
-# 安装
-sandbox.commands.run("openclaw skills install weather", timeout=180)
 ```
 
-也可在构建 Template 时预置 Skill（适合团队复用），把 skill 目录写入 `~/.openclaw/skills/` 或 workspace `skills/`。
-### 浏览器访问（FC E2B）
+也可在构建 Template 时预置 Skill（适合团队复用），见 [OpenClaw 模板示例](../04.功能说明/02.模板/07.示例/05.OpenClaw%20模板.md)。
 
-FC E2B 要在浏览器中打开 Gateway Control UI，**须先绑定自定义域名**。默认平台域名（`*.e2b.fc.aliyuncs.com`）会**触发下载而非打开页面**；绑定自定义域名后可正常访问。控制台添加域名、DNS 解析、HTTPS 证书及 SDK 配置的完整步骤，见 [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md)。
+### 浏览器访问（FC E2B） { #browser-access-fc-e2b }
 
-#### 配置自定义域名
-
-**第一步：控制台配置。** 在函数计算控制台为云沙箱绑定自定义域名，配置证书与 DNS（`api.<你的自定义域名>` / `*.<你的自定义域名>`）。
-
-**第二步：SDK 改 `OPTS`。** 将上文 [构建 Template](#构建-template) 中的默认 `OPTS`：
-
-```python
-OPTS = {
-    "api_key": "<你的 E2B API Key>",
-    "api_url": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
-    "domain": "cn-beijing.e2b.fc.aliyuncs.com",
-}
-```
-
-替换为与控制台一致的自定义域名（`api_key` 须为**绑定该自定义域名同一账号**下的 Key）：
-
-```python
-OPTS = {
-    "api_key": "<你的 E2B API Key>",
-    "api_url": "https://api.<你的自定义域名>",
-    "domain": "<你的自定义域名>",
-}
-```
-
-**第三步：全流程传入 `OPTS`。** `Template.build(..., **OPTS)`、`Sandbox.create(..., **OPTS)` 及文档中其他 SDK 调用均使用上述 `OPTS`，无需额外参数。
-
-完成后 `sandbox.get_host(PORT)` 将返回 `{PORT}-sbx-{sandbox_id}.<你的自定义域名>`；Gateway 的 `allowedOrigins`、浏览器地址栏与下文 `curl` 中的 `<host>` 均使用该地址。
-
+FC E2B 中 Gateway Control UI 可通过 `sandbox.get_host(PORT)` 返回的默认平台域名（`*.e2b.fc.aliyuncs.com`）直接访问，请求须带 `X-Access-Token` 请求头。自定义域名为可选的稳定域名方案，非必需。控制台添加域名、DNS 解析、HTTPS 证书及 SDK 配置的完整步骤，见 [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md)。
 
 #### 打开 Control UI
 
-完成自定义域名配置并 [部署 Gateway](#部署-gateway) 后，公网访问还需两层鉴权：
+[部署 Gateway](#deploy-gateway) 后，公网访问还需两层鉴权：
 
 | 鉴权 | 来源 | 作用 | 传递方式 |
 |------|------|------|----------|
@@ -409,7 +264,19 @@ curl -sI \
 
 期望响应含 `200`；返回 HTML 页面即表示 Gateway 正常。
 
-若出现「浏览器来源不被允许」，确认 `allowedOrigins` 与地址栏来源完全一致（`https://{sandbox.get_host(PORT)}`，无尾部 `/`），修改后 [重启 Gateway](#重启-gateway)。
+若出现「浏览器来源不被允许」，确认 `allowedOrigins` 与地址栏来源完全一致（`https://{sandbox.get_host(PORT)}`，无尾部 `/`），修改后 [重启 Gateway](#restart-gateway)。
+
+#### 自定义域名（可选）
+
+若希望使用稳定域名而非按沙箱分配的默认域名，可在函数计算控制台绑定自定义域名，配置证书与 DNS（`api.<你的自定义域名>` / `*.<你的自定义域名>`），并将 SDK 环境变量指向该域名（`E2B_API_KEY` 须为**绑定该自定义域名同一账号**下的 Key）：
+
+```bash
+export E2B_API_KEY="<你的 E2B API Key>"
+export E2B_API_URL="https://api.<你的自定义域名>"
+export E2B_DOMAIN="<你的自定义域名>"
+```
+
+`Template.build(...)`、`Sandbox.create(...)` 及本文其他 SDK 调用均自动读取上述环境变量，无需在方法调用中显式传入连接参数。完成后 `sandbox.get_host(PORT)` 将返回 `{PORT}-sbx-{sandbox_id}.<你的自定义域名>`；Gateway 的 `allowedOrigins`、浏览器地址栏与上文 `curl` 中的 `<host>` 均使用该地址。
 
 ### 工作原理
 
@@ -458,7 +325,7 @@ for _ in range(30):
     time.sleep(2)
 ```
 
-### 重启 Gateway
+### 重启 Gateway { #restart-gateway }
 
 修改模型或配置后，在**当前 Sandbox** 中执行：
 
@@ -517,19 +384,27 @@ sandbox.commands.run(
 
 在服务端以编程方式调用 Agent，无需启动 Gateway。
 
-若已按上文 [部署 Gateway](#部署-gateway) 创建了 Sandbox，直接在同一个 `sandbox` 上执行下方命令即可，**无需再次创建**。
+若已按上文 [部署 Gateway](#deploy-gateway) 创建了 Sandbox，直接在同一个 `sandbox` 上执行下方命令即可，**无需再次创建**。
 
 若仅需 CLI、不启动 Gateway：
 
-<!-- @props:china -->
-### 中国站：百炼
-
 ```python
+from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
 
+load_dotenv()
+
+TEMPLATE_NAME = "my-openclaw-template"
+
+# 百炼（中国站推荐）
 BAILIAN_API_KEY = "<your-bailian-api-key>"
 BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
 BAILIAN_MODEL = "qwen3.7-max"
+# 国际站 OpenAI-compatible（以 DashScope OpenAI-compatible 模式为例）：
+# PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
+# PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+# PROVIDER_MODEL = "qwen3-coder-plus"
+# PROVIDER_ID = "openai-compat"
 
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
@@ -539,10 +414,11 @@ sandbox = Sandbox.create(
         "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
         "ANTHROPIC_MODEL": BAILIAN_MODEL,
     },
-    **OPTS,
+    # 国际站 OpenAI-compatible：envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
 )
 
-# 注册百炼 provider
+# 通过 onboard 注册 provider（国际站 OpenAI-compatible 同模式，但用 --custom-compatibility openai）。
+# 未注册的裸 openai/<model> 会报 Unknown model。
 sandbox.commands.run(
     "openclaw onboard --non-interactive --accept-risk --skip-health "
     "--auth-choice custom-api-key "
@@ -551,38 +427,29 @@ sandbox.commands.run(
     "--custom-compatibility anthropic "
     f"--custom-model-id {BAILIAN_MODEL} "
     "--custom-provider-id bailian",
+    # 国际站 OpenAI-compatible：
+    # f"--custom-api-key {PROVIDER_API_KEY} "
+    # f"--custom-base-url {PROVIDER_BASE_URL} "
+    # "--custom-compatibility openai "
+    # f"--custom-model-id {PROVIDER_MODEL} "
+    # f"--custom-provider-id {PROVIDER_ID}",
     timeout=120,
 )
 
+# 百炼
 result = sandbox.commands.run(
     f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
     '-m "What is 2+2? Reply with just the number."',
     timeout=120,
 )
+# 国际站 OpenAI-compatible：
+# result = sandbox.commands.run(
+#     f'openclaw agent --local --agent main --model {PROVIDER_ID}/{PROVIDER_MODEL} '
+#     '-m "What is 2+2? Reply with just the number."',
+#     timeout=120,
+# )
 print(result.stdout)
 ```
-<!-- @/props -->
-
-<!-- @props:intl -->
-### 国际站：OpenAI
-
-```python
-from e2b_code_interpreter import Sandbox
-
-sandbox = Sandbox.create(
-    template=TEMPLATE_NAME,
-    timeout=3600,
-    envs={"OPENAI_API_KEY": "<your-openai-api-key>"},
-    **OPTS,
-)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --message "What is 2+2? Reply with just the number."',
-    timeout=120,
-)
-print(result.stdout)
-```
-<!-- @/props -->
 
 ---
 
@@ -596,17 +463,6 @@ sandbox.kill()
 
 ---
 
-## 环境概览
-
-| 项目 | 规格 |
-|------|------|
-| 操作系统 | Debian |
-| OpenClaw 路径 | `/home/user/.openclaw/bin/openclaw` |
-| 自带 Node | v22.x（`/home/user/.openclaw/tools/node/bin/node`） |
-| 默认用户 / 工作目录 | `user` / `/home/user` |
-
----
-
 ## 计费说明
 
 Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由模型服务单独结算。详见 [计费概述](../03.产品计费/01.计费概述.md)。
@@ -617,19 +473,20 @@ Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由
 
 | 现象 | 处理 |
 |------|------|
-| Agent 无响应 | <!-- @props:china -->确认 `envs` 已注入模型 Key；中国站百炼场景确认已 `onboard`<!-- @/props --><!-- @props:intl -->确认 `envs` 已注入 `OPENAI_API_KEY`<!-- @/props --> |
+| Agent 无响应 | <!-- @props:china -->确认 `envs` 已注入模型 Key；中国站百炼场景确认已 `onboard`<!-- @/props --><!-- @props:intl -->确认 `envs` 已注入模型 Key 并完成 `onboard`<!-- @/props --> |
 | Gateway 浏览器打不开 | 添加 `X-Access-Token` 请求头；URL 含 `?token=` |
-| 浏览器触发下载 | 须绑定自定义域名，见 [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md) 与 [浏览器访问（FC E2B）](#浏览器访问fc-e2b) |
 | `sandbox account mismatch` | API Key 与自定义域名须为同一账号，见 [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md) |
 | 来源不被允许 | `allowedOrigins` 与地址栏 URL 完全一致，重启 Gateway |
-| 构建失败 | 确认 `FROM_IMAGE` 与地域匹配；`name` 勿用 `openclaw-v*` 前缀 |
+| name 'TEMPLATE_NAME' is not defined | 用 [OpenClaw 模板示例](../04.功能说明/02.模板/07.示例/05.OpenClaw%20模板.md) 中的模板名替换 `TEMPLATE_NAME` |
 | 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](../08.常见问题/05.模板构建.md) |
 
 ---
 
 ## 参考
 
+- [OpenClaw 模板示例](../04.功能说明/02.模板/07.示例/05.OpenClaw%20模板.md)（镜像地址、构建与最小验证、环境概览）
 - [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md)
+- [E2B SDK 接入参数说明](../07.开发参考/02.E2B%20SDK%20接入参数说明.md)
 - [E2B OpenClaw Gateway](https://e2b.dev/docs/agents/openclaw/openclaw-gateway)
 - [OpenClaw Control UI](https://docs.openclaw.ai/web/control-ui)
 - [OpenClaw 项目](https://github.com/openclaw/openclaw)


### PR DESCRIPTION
## 变更说明

- 新增 Claude Code 与 OpenClaw 模板说明，中英文各两篇
- 重构对应最佳实践，与 Browser 文档的模板/实践分工保持一致
- 同步中国站与国际站的镜像、Region、模型接入、参数和限制
- 保留主干新增的多文件 Skill 上传说明，并明确 Template.copy 当前不支持目录递归复制

## 验证

- 杭州与新加坡真实 Template.build、Sandbox.create、CLI、Gateway、Skill、Git、MCP 场景验证
- Claude Code、OpenClaw、中英文/国内外同步三组独立逐行验收均 PASS
- git diff --check 通过
- python3 scripts/prepare-mkdocs.py 通过
- mkdocs build --config-file mkdocs.generated.yml 通过，目标 8 篇零告警
- 临时云端资源已清理

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 面向云沙箱（E2B）产品，覆盖中英文文档：

- 新增模板示例页面：Claude Code 模板、OpenClaw 模板。
- 重构最佳实践页面：Claude Code 自定义镜像、OpenClaw 自定义镜像。
- 涉及章节包括模板示例、最佳实践、模板构建与运行、Gateway、Skill、浏览器访问、Agent CLI、模型配置及常见问题。
- 保留并完善多文件 Skill 上传说明，并明确 `Template.copy` 暂不支持递归目录复制。
- 新增 4 个页面（中英文各 2 个），未删除页面；原有最佳实践页面均为内容重写和调整。
- PR 描述提到图片资源同步，但提供的变更清单未显示图片文件新增、删除或修改。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->