### PR TITLE
docs(sandbox): 明确 Template 构建阶段不支持预置 Skill

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Examples/04.Claude Code Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Examples/04.Claude Code Template.md
@@ -165,6 +165,7 @@ sandbox.kill()
 | --- | --- |
 | MCP Gateway | Not supported. Only `claude mcp add` client-side registration of stdio / HTTP MCP Servers is supported; the SDK `mcp` creation parameter and `getMcpUrl()` / `getMcpToken()` are not supported |
 | Model Key | Not preconfigured in the image; must be injected at runtime via `envs` |
+| Preinstalling Skills at build time | Not supported during `Template.build`; write the Skill directory after creating the Sandbox using `files.write` or `files.write_files` |
 
 ## Related documents
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
@@ -302,9 +302,7 @@ for path in local.rglob("*"):
 sandbox.files.write_files(entries)
 ```
 
-For project scope, change `remote_root` to `/home/user/repo/.claude/skills/<name>`. `Template.copy` does not currently support preloading a local directory during `Template.build`; use runtime `files.write` or `files.write_files` instead.
-
-You can also preload Skills when building a Template (useful for team reuse), see [Claude Code Template Example](../04.Features/02.Templates/07.Examples/04.Claude%20Code%20Template.md).
+For project scope, change `remote_root` to `/home/user/repo/.claude/skills/<name>`. Copying or generating a Skill directory during `Template.build` is currently not supported; write it after creating the Sandbox using `files.write` or `files.write_files`.
 
 ---
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
@@ -22,9 +22,30 @@ All examples below assume the template has been built; `E2B_API_KEY`, `E2B_API_U
 
 Start the OpenClaw Gateway to interact with the Agent in a browser. The complete workflow below covers: **Create Sandbox → Configure → Start Gateway → Get Access URL**. For server-side programmatic invocation, see [Agent CLI](#agent-cli).
 
-The following defaults to **Bailian** (recommended for China); international users can follow the OpenAI-compatible variant in the comments. For server-side programmatic invocation, see [Agent CLI](#agent-cli).
+The same script supports both international OpenAI-compatible providers and Bailian; only the provider values in `.env` differ. For server-side programmatic invocation, see [Agent CLI](#agent-cli).
+
+International OpenAI-compatible configuration (using DashScope OpenAI-compatible mode as an example):
+
+```dotenv
+PROVIDER_API_KEY=<your-openai-compatible-api-key>
+PROVIDER_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+PROVIDER_MODEL=qwen3-coder-plus
+PROVIDER_ID=openai-compat
+PROVIDER_COMPATIBILITY=openai
+```
+
+China Bailian configuration:
+
+```dotenv
+PROVIDER_API_KEY=<your-bailian-api-key>
+PROVIDER_BASE_URL=https://dashscope.aliyuncs.com/apps/anthropic
+PROVIDER_MODEL=qwen3.7-max
+PROVIDER_ID=bailian
+PROVIDER_COMPATIBILITY=anthropic
+```
 
 ```python
+import os
 import time
 
 from dotenv import load_dotenv
@@ -39,27 +60,25 @@ TEMPLATE_NAME = "my-openclaw-template"
 TOKEN = "my-gateway-token"
 PORT = 18789
 
-# Bailian (recommended for China)
-BAILIAN_API_KEY = "<your-bailian-api-key>"
-BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
-BAILIAN_MODEL = "qwen3.7-max"
-# International OpenAI-compatible (e.g. DashScope OpenAI-compatible mode):
-# PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
-# PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-# PROVIDER_MODEL = "qwen3-coder-plus"
-# PROVIDER_ID = "openai-compat"
+PROVIDER_API_KEY = os.environ["PROVIDER_API_KEY"]
+PROVIDER_BASE_URL = os.environ["PROVIDER_BASE_URL"]
+PROVIDER_MODEL = os.environ["PROVIDER_MODEL"]
+PROVIDER_ID = os.environ["PROVIDER_ID"]
+PROVIDER_COMPATIBILITY = os.environ["PROVIDER_COMPATIBILITY"]
+
+provider_envs = {"OPENAI_API_KEY": PROVIDER_API_KEY}
+if PROVIDER_COMPATIBILITY == "anthropic":
+    provider_envs = {
+        "ANTHROPIC_AUTH_TOKEN": PROVIDER_API_KEY,
+        "ANTHROPIC_BASE_URL": PROVIDER_BASE_URL,
+        "ANTHROPIC_MODEL": PROVIDER_MODEL,
+    }
 
 # 1. Create Sandbox
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
     timeout=3600,
-    envs={
-        "ANTHROPIC_AUTH_TOKEN": BAILIAN_API_KEY,
-        "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
-        "ANTHROPIC_MODEL": BAILIAN_MODEL,
-    },
-    # International OpenAI-compatible: replace the envs above with
-    # envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
+    envs=provider_envs,
 )
 
 # Register the provider via onboard. Bailian uses anthropic compatibility;
@@ -69,28 +88,18 @@ sandbox = Sandbox.create(
 sandbox.commands.run(
     "openclaw onboard --non-interactive --accept-risk --skip-health "
     "--auth-choice custom-api-key "
-    f"--custom-api-key {BAILIAN_API_KEY} "
-    f"--custom-base-url {BAILIAN_BASE_URL} "
-    "--custom-compatibility anthropic "
-    f"--custom-model-id {BAILIAN_MODEL} "
-    "--custom-provider-id bailian",
-    # International OpenAI-compatible:
-    # f"--custom-api-key {PROVIDER_API_KEY} "
-    # f"--custom-base-url {PROVIDER_BASE_URL} "
-    # "--custom-compatibility openai "
-    # f"--custom-model-id {PROVIDER_MODEL} "
-    # f"--custom-provider-id {PROVIDER_ID}",
+    f"--custom-api-key {PROVIDER_API_KEY} "
+    f"--custom-base-url {PROVIDER_BASE_URL} "
+    f"--custom-compatibility {PROVIDER_COMPATIBILITY} "
+    f"--custom-model-id {PROVIDER_MODEL} "
+    f"--custom-provider-id {PROVIDER_ID}",
     timeout=120,
 )
 
 # 2. Set default model
 sandbox.commands.run(
-    f"openclaw config set agents.defaults.model.primary bailian/{BAILIAN_MODEL}"
+    f"openclaw config set agents.defaults.model.primary {PROVIDER_ID}/{PROVIDER_MODEL}"
 )
-# International OpenAI-compatible:
-# sandbox.commands.run(
-#     f"openclaw config set agents.defaults.model.primary {PROVIDER_ID}/{PROVIDER_MODEL}"
-# )
 
 # 3. Configure Control UI (required for FC E2B public network access)
 origin = f"https://{sandbox.get_host(PORT)}"
@@ -383,9 +392,11 @@ Invoke the Agent programmatically on the server side without starting the Gatewa
 
 If you have already created a Sandbox following the [Deploy Gateway](#deploy-gateway) section above, run the commands below directly on the same `sandbox` — **no need to create another one**.
 
-If you only need the CLI without starting the Gateway:
+If you only need the CLI without starting the Gateway, reuse the provider values in `.env` from above:
 
 ```python
+import os
+
 from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
 
@@ -393,59 +404,44 @@ load_dotenv()
 
 TEMPLATE_NAME = "my-openclaw-template"
 
-# Bailian (recommended for China)
-BAILIAN_API_KEY = "<your-bailian-api-key>"
-BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
-BAILIAN_MODEL = "qwen3.7-max"
-# International OpenAI-compatible (e.g. DashScope OpenAI-compatible mode):
-# PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
-# PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-# PROVIDER_MODEL = "qwen3-coder-plus"
-# PROVIDER_ID = "openai-compat"
+PROVIDER_API_KEY = os.environ["PROVIDER_API_KEY"]
+PROVIDER_BASE_URL = os.environ["PROVIDER_BASE_URL"]
+PROVIDER_MODEL = os.environ["PROVIDER_MODEL"]
+PROVIDER_ID = os.environ["PROVIDER_ID"]
+PROVIDER_COMPATIBILITY = os.environ["PROVIDER_COMPATIBILITY"]
+
+provider_envs = {"OPENAI_API_KEY": PROVIDER_API_KEY}
+if PROVIDER_COMPATIBILITY == "anthropic":
+    provider_envs = {
+        "ANTHROPIC_AUTH_TOKEN": PROVIDER_API_KEY,
+        "ANTHROPIC_BASE_URL": PROVIDER_BASE_URL,
+        "ANTHROPIC_MODEL": PROVIDER_MODEL,
+    }
 
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
     timeout=3600,
-    envs={
-        "ANTHROPIC_AUTH_TOKEN": BAILIAN_API_KEY,
-        "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
-        "ANTHROPIC_MODEL": BAILIAN_MODEL,
-    },
-    # International OpenAI-compatible: envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
+    envs=provider_envs,
 )
 
-# Register the provider via onboard (same pattern for international OpenAI-compatible,
-# but with --custom-compatibility openai). A bare openai/<model> that was never
+# Register the provider via onboard. A bare openai/<model> that was never
 # onboarded will fail with "Unknown model".
 sandbox.commands.run(
     "openclaw onboard --non-interactive --accept-risk --skip-health "
     "--auth-choice custom-api-key "
-    f"--custom-api-key {BAILIAN_API_KEY} "
-    f"--custom-base-url {BAILIAN_BASE_URL} "
-    "--custom-compatibility anthropic "
-    f"--custom-model-id {BAILIAN_MODEL} "
-    "--custom-provider-id bailian",
-    # International OpenAI-compatible:
-    # f"--custom-api-key {PROVIDER_API_KEY} "
-    # f"--custom-base-url {PROVIDER_BASE_URL} "
-    # "--custom-compatibility openai "
-    # f"--custom-model-id {PROVIDER_MODEL} "
-    # f"--custom-provider-id {PROVIDER_ID}",
+    f"--custom-api-key {PROVIDER_API_KEY} "
+    f"--custom-base-url {PROVIDER_BASE_URL} "
+    f"--custom-compatibility {PROVIDER_COMPATIBILITY} "
+    f"--custom-model-id {PROVIDER_MODEL} "
+    f"--custom-provider-id {PROVIDER_ID}",
     timeout=120,
 )
 
-# Bailian
 result = sandbox.commands.run(
-    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    f'openclaw agent --local --agent main --model {PROVIDER_ID}/{PROVIDER_MODEL} '
     '-m "What is 2+2? Reply with just the number."',
     timeout=120,
 )
-# International OpenAI-compatible:
-# result = sandbox.commands.run(
-#     f'openclaw agent --local --agent main --model {PROVIDER_ID}/{PROVIDER_MODEL} '
-#     '-m "What is 2+2? Reply with just the number."',
-#     timeout=120,
-# )
 print(result.stdout)
 ```
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.示例/04.Claude Code 模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.示例/04.Claude Code 模板.md
@@ -173,6 +173,7 @@ sandbox.kill()
 | --- | --- |
 | MCP Gateway | 不支持。仅支持通过 `claude mcp add` 客户端注册 stdio / HTTP MCP Server，不支持 SDK `mcp` 创建参数与 `getMcpUrl()` / `getMcpToken()` |
 | 模型 Key | 不预置在镜像内，必须通过 `envs` 运行时注入 |
+| 构建时预置 Skill | 不支持在 `Template.build` 阶段复制或生成 Skill 目录；创建 Sandbox 后使用 `files.write` 或 `files.write_files` 写入 |
 
 ## 相关文档
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
@@ -310,9 +310,7 @@ for path in local.rglob("*"):
 sandbox.files.write_files(entries)
 ```
 
-项目作用域将 `remote_root` 换成 `/home/user/repo/.claude/skills/<name>`。`Template.copy` 目前不支持在 `Template.build` 时预置本机目录，请改用运行时 `files.write` 或 `files.write_files`。
-
-也可在构建 Template 时预置 Skill（适合团队复用），见 [Claude Code 模板示例](../04.功能说明/02.模板/07.示例/04.Claude%20Code%20模板.md)。
+项目作用域将 `remote_root` 换成 `/home/user/repo/.claude/skills/<name>`。当前不支持在 `Template.build` 阶段复制或生成 Skill 目录，请在创建 Sandbox 后使用 `files.write` 或 `files.write_files` 写入。
 
 ---
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
@@ -24,9 +24,34 @@
 
 ## 部署 Gateway { #deploy-gateway }
 
-启动 OpenClaw Gateway，在浏览器中与 Agent 对话。完整流程：**创建 Sandbox → 配置 → 启动 Gateway → 获取访问地址**。以下以**百炼**（中国站推荐）为例；国际站可按注释中的 OpenAI-compatible 分支调整。服务端编程调用见 [Agent CLI](#agent-cli)。
+启动 OpenClaw Gateway，在浏览器中与 Agent 对话。完整流程：**创建 Sandbox → 配置 → 启动 Gateway → 获取访问地址**。百炼与国际站 OpenAI-compatible 使用同一脚本，仅 `.env` 中的 provider 参数不同。服务端编程调用见 [Agent CLI](#agent-cli)。
+
+<!-- @props:china -->
+中国站百炼配置：
+
+```dotenv
+PROVIDER_API_KEY=<your-bailian-api-key>
+PROVIDER_BASE_URL=https://dashscope.aliyuncs.com/apps/anthropic
+PROVIDER_MODEL=qwen3.7-max
+PROVIDER_ID=bailian
+PROVIDER_COMPATIBILITY=anthropic
+```
+<!-- @/props -->
+
+<!-- @props:intl -->
+国际站 OpenAI-compatible 配置（以 DashScope OpenAI-compatible 模式为例）：
+
+```dotenv
+PROVIDER_API_KEY=<your-openai-compatible-api-key>
+PROVIDER_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+PROVIDER_MODEL=qwen3-coder-plus
+PROVIDER_ID=openai-compat
+PROVIDER_COMPATIBILITY=openai
+```
+<!-- @/props -->
 
 ```python
+import os
 import time
 
 from dotenv import load_dotenv
@@ -41,57 +66,45 @@ TEMPLATE_NAME = "my-openclaw-template"
 TOKEN = "my-gateway-token"
 PORT = 18789
 
-# 百炼（中国站推荐）
-BAILIAN_API_KEY = "<your-bailian-api-key>"
-BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
-BAILIAN_MODEL = "qwen3.7-max"
-# 国际站 OpenAI-compatible（以 DashScope OpenAI-compatible 模式为例）：
-# PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
-# PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-# PROVIDER_MODEL = "qwen3-coder-plus"
-# PROVIDER_ID = "openai-compat"
+PROVIDER_API_KEY = os.environ["PROVIDER_API_KEY"]
+PROVIDER_BASE_URL = os.environ["PROVIDER_BASE_URL"]
+PROVIDER_MODEL = os.environ["PROVIDER_MODEL"]
+PROVIDER_ID = os.environ["PROVIDER_ID"]
+PROVIDER_COMPATIBILITY = os.environ["PROVIDER_COMPATIBILITY"]
+
+provider_envs = {"OPENAI_API_KEY": PROVIDER_API_KEY}
+if PROVIDER_COMPATIBILITY == "anthropic":
+    provider_envs = {
+        "ANTHROPIC_AUTH_TOKEN": PROVIDER_API_KEY,
+        "ANTHROPIC_BASE_URL": PROVIDER_BASE_URL,
+        "ANTHROPIC_MODEL": PROVIDER_MODEL,
+    }
 
 # 1. 创建 Sandbox
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
     timeout=3600,
-    envs={
-        "ANTHROPIC_AUTH_TOKEN": BAILIAN_API_KEY,
-        "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
-        "ANTHROPIC_MODEL": BAILIAN_MODEL,
-    },
-    # 国际站 OpenAI-compatible：将上面 envs 替换为
-    # envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
+    envs=provider_envs,
 )
 
-# 通过 onboard 注册 provider。百炼用 anthropic 兼容；
-# OpenAI-compatible endpoint 用 openai 兼容。下方 model id 须与 provider 实际模型名一致——
+# 通过 onboard 注册 provider。百炼用 anthropic 兼容，OpenAI-compatible endpoint 用 openai 兼容。
+# model id 须与 provider 实际模型名一致；
 # 未注册的裸 openai/<model> 会报 Unknown model。
 sandbox.commands.run(
     "openclaw onboard --non-interactive --accept-risk --skip-health "
     "--auth-choice custom-api-key "
-    f"--custom-api-key {BAILIAN_API_KEY} "
-    f"--custom-base-url {BAILIAN_BASE_URL} "
-    "--custom-compatibility anthropic "
-    f"--custom-model-id {BAILIAN_MODEL} "
-    "--custom-provider-id bailian",
-    # 国际站 OpenAI-compatible：
-    # f"--custom-api-key {PROVIDER_API_KEY} "
-    # f"--custom-base-url {PROVIDER_BASE_URL} "
-    # "--custom-compatibility openai "
-    # f"--custom-model-id {PROVIDER_MODEL} "
-    # f"--custom-provider-id {PROVIDER_ID}",
+    f"--custom-api-key {PROVIDER_API_KEY} "
+    f"--custom-base-url {PROVIDER_BASE_URL} "
+    f"--custom-compatibility {PROVIDER_COMPATIBILITY} "
+    f"--custom-model-id {PROVIDER_MODEL} "
+    f"--custom-provider-id {PROVIDER_ID}",
     timeout=120,
 )
 
 # 2. 设置默认模型
 sandbox.commands.run(
-    f"openclaw config set agents.defaults.model.primary bailian/{BAILIAN_MODEL}"
+    f"openclaw config set agents.defaults.model.primary {PROVIDER_ID}/{PROVIDER_MODEL}"
 )
-# 国际站 OpenAI-compatible：
-# sandbox.commands.run(
-#     f"openclaw config set agents.defaults.model.primary {PROVIDER_ID}/{PROVIDER_MODEL}"
-# )
 
 # 3. 配置 Control UI（FC E2B 公网访问必需）
 origin = f"https://{sandbox.get_host(PORT)}"
@@ -386,9 +399,11 @@ sandbox.commands.run(
 
 若已按上文 [部署 Gateway](#deploy-gateway) 创建了 Sandbox，直接在同一个 `sandbox` 上执行下方命令即可，**无需再次创建**。
 
-若仅需 CLI、不启动 Gateway：
+若仅需 CLI、不启动 Gateway，沿用上文 `.env` 中的 provider 参数：
 
 ```python
+import os
+
 from dotenv import load_dotenv
 from e2b_code_interpreter import Sandbox
 
@@ -396,58 +411,44 @@ load_dotenv()
 
 TEMPLATE_NAME = "my-openclaw-template"
 
-# 百炼（中国站推荐）
-BAILIAN_API_KEY = "<your-bailian-api-key>"
-BAILIAN_BASE_URL = "https://dashscope.aliyuncs.com/apps/anthropic"
-BAILIAN_MODEL = "qwen3.7-max"
-# 国际站 OpenAI-compatible（以 DashScope OpenAI-compatible 模式为例）：
-# PROVIDER_API_KEY = "<your-openai-compatible-api-key>"
-# PROVIDER_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-# PROVIDER_MODEL = "qwen3-coder-plus"
-# PROVIDER_ID = "openai-compat"
+PROVIDER_API_KEY = os.environ["PROVIDER_API_KEY"]
+PROVIDER_BASE_URL = os.environ["PROVIDER_BASE_URL"]
+PROVIDER_MODEL = os.environ["PROVIDER_MODEL"]
+PROVIDER_ID = os.environ["PROVIDER_ID"]
+PROVIDER_COMPATIBILITY = os.environ["PROVIDER_COMPATIBILITY"]
+
+provider_envs = {"OPENAI_API_KEY": PROVIDER_API_KEY}
+if PROVIDER_COMPATIBILITY == "anthropic":
+    provider_envs = {
+        "ANTHROPIC_AUTH_TOKEN": PROVIDER_API_KEY,
+        "ANTHROPIC_BASE_URL": PROVIDER_BASE_URL,
+        "ANTHROPIC_MODEL": PROVIDER_MODEL,
+    }
 
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
     timeout=3600,
-    envs={
-        "ANTHROPIC_AUTH_TOKEN": BAILIAN_API_KEY,
-        "ANTHROPIC_BASE_URL": BAILIAN_BASE_URL,
-        "ANTHROPIC_MODEL": BAILIAN_MODEL,
-    },
-    # 国际站 OpenAI-compatible：envs={"OPENAI_API_KEY": PROVIDER_API_KEY},
+    envs=provider_envs,
 )
 
-# 通过 onboard 注册 provider（国际站 OpenAI-compatible 同模式，但用 --custom-compatibility openai）。
+# 通过 onboard 注册 provider。
 # 未注册的裸 openai/<model> 会报 Unknown model。
 sandbox.commands.run(
     "openclaw onboard --non-interactive --accept-risk --skip-health "
     "--auth-choice custom-api-key "
-    f"--custom-api-key {BAILIAN_API_KEY} "
-    f"--custom-base-url {BAILIAN_BASE_URL} "
-    "--custom-compatibility anthropic "
-    f"--custom-model-id {BAILIAN_MODEL} "
-    "--custom-provider-id bailian",
-    # 国际站 OpenAI-compatible：
-    # f"--custom-api-key {PROVIDER_API_KEY} "
-    # f"--custom-base-url {PROVIDER_BASE_URL} "
-    # "--custom-compatibility openai "
-    # f"--custom-model-id {PROVIDER_MODEL} "
-    # f"--custom-provider-id {PROVIDER_ID}",
+    f"--custom-api-key {PROVIDER_API_KEY} "
+    f"--custom-base-url {PROVIDER_BASE_URL} "
+    f"--custom-compatibility {PROVIDER_COMPATIBILITY} "
+    f"--custom-model-id {PROVIDER_MODEL} "
+    f"--custom-provider-id {PROVIDER_ID}",
     timeout=120,
 )
 
-# 百炼
 result = sandbox.commands.run(
-    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    f'openclaw agent --local --agent main --model {PROVIDER_ID}/{PROVIDER_MODEL} '
     '-m "What is 2+2? Reply with just the number."',
     timeout=120,
 )
-# 国际站 OpenAI-compatible：
-# result = sandbox.commands.run(
-#     f'openclaw agent --local --agent main --model {PROVIDER_ID}/{PROVIDER_MODEL} '
-#     '-m "What is 2+2? Reply with just the number."',
-#     timeout=120,
-# )
 print(result.stdout)
 ```
 


### PR DESCRIPTION
## 背景

PR #77 合并后收到两项评审反馈：Claude Code 模板页缺少构建 Template 时预置 Skill 的示例；OpenClaw 国际站 provider 以注释参数混入函数调用，不能直接复制执行。

## 核对结论

- 杭州生产使用 claude-code:v0.0.37 补跑 Template.from_dockerfile + Dockerfile RUN 写入 SKILL.md
- 构建接口返回 400: steps are not supported
- Template.copy 当前也不支持目录复制
- 因此现阶段不能在 Template.build 阶段预置 Skill，只能在 Sandbox 创建后通过 files.write 或 files.write_files 写入
- OpenClaw 百炼 anthropic-compatible 与国际 OpenAI-compatible 的 onboard/Agent 链路此前均已真机跑通，可共用 provider 参数化脚本

## 文档修正

- 中英文 Claude Code 模板页限制表补充构建时预置 Skill 不支持
- 中英文 Claude Code 最佳实践删除可以构建时预置 Skill 的错误引导
- 中英文 OpenClaw 最佳实践改为由 .env 提供统一 provider 参数，Gateway 与 Agent CLI 不再使用注释代码分支
- 运行时个人/项目 Skill 与多文件目录上传示例保持不变

## 验证

- 临时失败 Template 已删除并回查 404
- 全部 Python 代码围栏语法解析通过
- 中英文 OpenClaw 最佳实践代码围栏 28/28 对齐
- git diff --check 通过
- prepare-mkdocs 通过
- mkdocs build 通过，目标页面零新增告警

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 更新云沙箱产品中 Claude Code 相关文档，涉及中英文版本的：

- Claude Code 模板示例章节
- Claude Code 自定义镜像最佳实践章节

文档明确说明当前不支持在 `Template.build` 阶段预置或生成 Skill，应在 Sandbox 创建后通过 `files.write` 或 `files.write_files` 写入，并移除相关错误引导。

未新增或删除页面，未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->