### PR TITLE
docs: update image tags for Claude Code and OpenClaw to version 0.0.3…

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/05.Claude Code Custom Image.md
@@ -22,12 +22,12 @@ Select `FROM_IMAGE` by region:
 
 | Region | Image |
 |--------|------|
-| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
-| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/claude-code:v0.0.32` |
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/claude-code:v0.0.37` |
 
 Recommended build specifications: `cpu_count=2`, `memory_mb=8192`.
 
@@ -44,7 +44,7 @@ import time
 
 from e2b import Template, default_build_logger
 
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.32"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37"
 TEMPLATE_NAME = f"claude-code-{int(time.time())}"
 
 OPTS = {
@@ -81,10 +81,10 @@ sandbox = Sandbox.create(
     envs={
         "ANTHROPIC_AUTH_TOKEN": "<your-bailian-api-key>",
         "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
-        "ANTHROPIC_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.6-flash",
+        "ANTHROPIC_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-max",
     },
     timeout=600,
     **OPTS,
@@ -229,6 +229,8 @@ for line in reversed(initial.stdout.strip().split("\n")):
     if line.startswith("{"):
         session_id = json.loads(line)["session_id"]
         break
+else:
+    raise RuntimeError("no session_id in output")
 
 sandbox.commands.run(
     f'claude --dangerously-skip-permissions --resume {session_id} < /dev/null '
@@ -391,6 +393,8 @@ print(result.stdout)
 For project scope, set `remote_root` to `/home/user/repo/.claude/skills/<name>` instead. You can also clone a repository that already contains `.claude/skills/` and use it directly.
 
 > **About Template.copy**: Prefilling files with `.copy("local-dir", "/home/user/.claude/skills/...")` during `Template.build` is **not supported** yet. Use the runtime `files.write` / `files.write_files` approaches above for custom Skills.
+
+---
 
 ## Billing
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/06.OpenClaw Custom Image.md
@@ -22,12 +22,12 @@ Select `FROM_IMAGE` by region:
 
 | Region | Image |
 |--------|------|
-| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
-| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/openclaw:v0.0.32` |
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/openclaw:v0.0.37` |
 
 Recommended build specifications: `cpu_count=2`, `memory_mb=4096`.
 
@@ -44,7 +44,7 @@ import time
 
 from e2b import Template, default_build_logger
 
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.32"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37"
 TEMPLATE_NAME = f"openclaw-{int(time.time())}"
 
 OPTS = {
@@ -69,7 +69,7 @@ After the build completes, the template status in the console should be `ready`.
 
 ### Template Name Restrictions
 
-The `name` must not use the system-reserved prefix **`openclaw-v`** (e.g., `openclaw-v0.0.32`, `openclaw-v032-test`), otherwise the following error will occur:
+The `name` must not use the system-reserved prefix **`openclaw-v`** (e.g., `openclaw-v0.0.37`, `openclaw-v037-test`), otherwise the following error will occur:
 
 ```text
 400: invalid template name '...': must not be a system reserved name openclaw-v*
@@ -216,135 +216,6 @@ print(f"Access Token: {sandbox._envd_access_token}")
 ```
 
 `X-Access-Token` is **not manually requested** and is **not the Gateway Token**. After `Sandbox.create(...)` succeeds, the SDK exposes `_envd_access_token` (i.e., the Sandbox Access Token) on the sandbox object. Each sandbox has its own token, valid only while the sandbox is alive; it becomes invalid after the sandbox is destroyed, and a new sandbox must be created to obtain a new value.
-
-### Extend Capabilities with Skills
-
-OpenClaw extends Agent capabilities through Skills (a directory plus `SKILL.md`). For details, see [OpenClaw Skills](https://docs.openclaw.ai/tools/skills).
-
-The image does not preload custom Skills; use `openclaw skills list` to view loaded Skills (including bundled ones).
-
-| Scope | Path | Source |
-|--------|-------------------|-------------|
-| Workspace | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
-| Managed | `/home/user/.openclaw/skills/<name>/SKILL.md` | managed |
-| Bundled | Shipped with the OpenClaw installation | `openclaw-bundled` |
-
-How to trigger:
-
-1. Explicit: `openclaw agent ... --message "/skill-name"`
-2. Automatic: the model loads the Skill when natural language matches the `description`
-
-> **Note**: Place the file at `<workspace>/skills/<name>/SKILL.md`. Putting `SKILL.md` directly under the workspace root (for example `/home/user/.openclaw/workspace/SKILL.md`) will **not** be recognized as a Skill.
-
-**Write a Managed Skill:**
-
-```python
-sandbox.files.write(
-    "/home/user/.openclaw/skills/summarize-changes/SKILL.md",
-    """---
-name: summarize-changes
-description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
-user-invocable: true
----
-
-## Instructions
-1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
-2. List risks such as missing error handling or hardcoded values.
-3. If the diff is empty, say there are no uncommitted changes.
-""",
-)
-
-# Confirm it appears in the list
-print(sandbox.commands.run("openclaw skills list").stdout)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
-    '--message "/summarize-changes"',
-    timeout=0,
-)
-print(result.stdout)
-```
-
-**Write a Workspace Skill:**
-
-```python
-sandbox.files.write(
-    "/home/user/.openclaw/workspace/skills/api-conventions/SKILL.md",
-    """---
-name: api-conventions
-description: API design conventions. Use when adding or changing HTTP endpoints or /healthz.
-user-invocable: true
----
-
-When writing API endpoints:
-- Use RESTful naming
-- Return consistent error formats
-- Include request validation
-""",
-)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
-    '--message "/api-conventions Add a /healthz endpoint"',
-    timeout=0,
-)
-print(result.stdout)
-```
-
-**Upload a multi-file Skill directory from your local machine:**
-
-If a Skill includes accompanying files such as `scripts/` or `references/`, use `files.write_files` to write them in one batch instead of calling `files.write` for each file:
-
-```python
-from pathlib import Path
-
-def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
-    local = Path(local_dir).resolve()
-    entries = []
-    for path in local.rglob("*"):
-        if path.is_file():
-            rel = path.relative_to(local).as_posix()
-            entries.append({
-                "path": f"{remote_root.rstrip('/')}/{rel}",
-                "data": path.read_bytes(),
-            })
-    sandbox.files.write_files(entries)
-
-# Example local directory layout:
-# ./my-skills/echo-marker/SKILL.md
-# ./my-skills/echo-marker/scripts/marker.txt
-upload_skill_dir(
-    sandbox,
-    "./my-skills/echo-marker",
-    "/home/user/.openclaw/skills/echo-marker",  # Managed; for Workspace use workspace/skills/...
-)
-
-print(sandbox.commands.run("openclaw skills list").stdout)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
-    '--message "/echo-marker"',
-    timeout=0,
-)
-print(result.stdout)
-```
-
-> **About Template.copy**: Prefilling files with `.copy("local-dir", "/home/user/.openclaw/skills/...")` during `Template.build` is **not supported** yet. Use the runtime `files.write` / `files.write_files` approaches above for custom Skills.
-
-**Install from ClawHub (optional):**
-
-The sandbox has public outbound access by default, so you can search for and install community Skills directly (browse [clawhub.ai](https://clawhub.ai)):
-
-```python
-# Search
-result = sandbox.commands.run("openclaw skills search calendar", timeout=120)
-print(result.stdout)
-
-# Install
-sandbox.commands.run("openclaw skills install weather", timeout=180)
-```
-
-You can also preload Skills when building a Template (useful for team reuse) by writing the skill directory into `~/.openclaw/skills/` or the workspace `skills/` directory.
 
 ### Browser Access (FC E2B)
 
@@ -571,6 +442,137 @@ result = sandbox.commands.run(
     timeout=120,
 )
 print(result.stdout)
+```
+
+---
+
+## Extend Capabilities with Skills
+
+OpenClaw extends Agent capabilities through Skills (a directory plus `SKILL.md`). Skills work with both Gateway and Agent CLI. For details, see [OpenClaw Skills](https://docs.openclaw.ai/tools/skills).
+
+The examples below assume you have already created a `sandbox` (via Gateway or Agent CLI). The image does not preload custom Skills; use `openclaw skills list` to view loaded Skills (including bundled ones).
+
+| Scope | Path | Source |
+|--------|------|-------------|
+| Workspace | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
+| Managed | `/home/user/.openclaw/skills/<name>/SKILL.md` | `openclaw-managed` |
+| Bundled | Shipped with the OpenClaw installation | `openclaw-bundled` |
+
+How to trigger:
+
+1. Explicit: `openclaw agent ... --message "/skill-name"`
+2. Automatic: the model loads the Skill when natural language matches the `description`
+
+> **Note**: Place the file at `<workspace>/skills/<name>/SKILL.md`. Putting `SKILL.md` directly under the workspace root (for example `/home/user/.openclaw/workspace/SKILL.md`) will **not** be recognized as a Skill.
+
+The examples below use China Bailian (`BAILIAN_MODEL` from above). For International, change `--model bailian/{BAILIAN_MODEL}` to `openai/gpt-4o`, or omit `--model` to use the configured default.
+
+**Write a Managed Skill:**
+
+```python
+sandbox.files.write(
+    "/home/user/.openclaw/skills/summarize-changes/SKILL.md",
+    """---
+name: summarize-changes
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+user-invocable: true
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+""",
+)
+
+# Confirm it appears in the list
+print(sandbox.commands.run("openclaw skills list").stdout)
+
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    '--message "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**Write a Workspace Skill:**
+
+```python
+sandbox.files.write(
+    "/home/user/.openclaw/workspace/skills/api-conventions/SKILL.md",
+    """---
+name: api-conventions
+description: API design conventions. Use when adding or changing HTTP endpoints or /healthz.
+user-invocable: true
+---
+
+When writing API endpoints:
+- Use RESTful naming
+- Return consistent error formats
+- Include request validation
+""",
+)
+
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    '--message "/api-conventions Add a /healthz endpoint"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**Upload a multi-file Skill directory from your local machine:**
+
+If a Skill includes accompanying files such as `scripts/` or `references/`, use `files.write_files` to write them in one batch instead of calling `files.write` for each file:
+
+```python
+from pathlib import Path
+
+def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
+    local = Path(local_dir).resolve()
+    entries = []
+    for path in local.rglob("*"):
+        if path.is_file():
+            rel = path.relative_to(local).as_posix()
+            entries.append({
+                "path": f"{remote_root.rstrip('/')}/{rel}",
+                "data": path.read_bytes(),
+            })
+    sandbox.files.write_files(entries)
+
+# Example local directory layout:
+# ./my-skills/echo-marker/SKILL.md
+# ./my-skills/echo-marker/scripts/marker.txt
+upload_skill_dir(
+    sandbox,
+    "./my-skills/echo-marker",
+    "/home/user/.openclaw/skills/echo-marker",  # Managed; for Workspace use workspace/skills/...
+)
+
+print(sandbox.commands.run("openclaw skills list").stdout)
+
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    '--message "/echo-marker"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+> **About Template.copy**: Prefilling files with `.copy("local-dir", "/home/user/.openclaw/skills/...")` during `Template.build` is **not supported** yet. Use the runtime `files.write` / `files.write_files` approaches above for custom Skills.
+
+**Install from ClawHub (optional):**
+
+The sandbox has public outbound access by default, so you can search for and install community Skills directly (browse [clawhub.ai](https://clawhub.ai)):
+
+```python
+# Search
+result = sandbox.commands.run("openclaw skills search calendar", timeout=120)
+print(result.stdout)
+
+# Install
+sandbox.commands.run("openclaw skills install weather", timeout=180)
 ```
 
 ---

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/05.Claude Code 自定义镜像.md
@@ -48,7 +48,7 @@ import time
 
 from e2b import Template, default_build_logger
 
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.32"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/claude-code:v0.0.37"
 TEMPLATE_NAME = f"claude-code-{int(time.time())}"
 
 OPTS = {
@@ -86,10 +86,10 @@ sandbox = Sandbox.create(
     envs={
         "ANTHROPIC_AUTH_TOKEN": "<your-bailian-api-key>",
         "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
-        "ANTHROPIC_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.6-flash",
-        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.6-flash",
+        "ANTHROPIC_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-max",
     },
     timeout=600,
     **OPTS,
@@ -237,6 +237,8 @@ for line in reversed(initial.stdout.strip().split("\n")):
     if line.startswith("{"):
         session_id = json.loads(line)["session_id"]
         break
+else:
+    raise RuntimeError("no session_id in output")
 
 sandbox.commands.run(
     f'claude --dangerously-skip-permissions --resume {session_id} < /dev/null '
@@ -400,6 +402,8 @@ print(result.stdout)
 
 > **关于 Template.copy**：**暂不支持** `Template.build` 时用 `.copy("local-dir", "/home/user/.claude/skills/...")` 预置文件。自定义 Skill 请用上方运行时 `files.write` / `files.write_files`。
 
+---
+
 ## 计费说明
 
 Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由模型服务单独结算。详见 [计费概述](../03.产品计费/01.计费概述.md)。
@@ -413,6 +417,6 @@ Sandbox 按 CPU、内存规格与运行时长计费；模型 API 调用费用由
 | 报配置损坏 | `echo '{}' > /home/user/.claude.json` |
 | Agent 无响应 | <!-- @props:china -->确认 `envs` 已注入模型 Key；中国站用百炼 `envs` 配置<!-- @/props --><!-- @props:intl -->确认 `envs` 已注入 `ANTHROPIC_API_KEY`<!-- @/props --> |
 | 构建失败 | 确认 `FROM_IMAGE` 与地域匹配 |
-| name 'TEMPLATE_NAME' is not defined | 控制台获取模版名称并替换 `TEMPLATE_NAME` |
-| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](https://help.aliyun.com/zh/functioncompute/fc/custom-template#问题排查) |
+| name 'TEMPLATE_NAME' is not defined | 控制台获取模板名称并替换 `TEMPLATE_NAME` |
+| 其他 SDK / 构建问题 | 见[自定义模板 — 问题排查](../08.常见问题/05.模板构建.md) |
 ---

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/06.OpenClaw 自定义镜像.md
@@ -48,7 +48,7 @@ import time
 
 from e2b import Template, default_build_logger
 
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.32"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/openclaw:v0.0.37"
 TEMPLATE_NAME = f"openclaw-{int(time.time())}"
 
 OPTS = {
@@ -73,7 +73,7 @@ print(f"template: {build.name}")   # 保存，后续可复用
 
 ### Template name 命名限制
 
-`name` 不得使用系统保留前缀 **`openclaw-v`**（例如 `openclaw-v0.0.32`、`openclaw-v032-test`），否则会报错：
+`name` 不得使用系统保留前缀 **`openclaw-v`**（例如 `openclaw-v0.0.37`、`openclaw-v037-test`），否则会报错：
 
 ```text
 400: invalid template name '...': must not be a system reserved name openclaw-v*
@@ -225,134 +225,6 @@ print(f"Access Token: {sandbox._envd_access_token}")
 
 `X-Access-Token` **不是手动申请的**，也**不是 Gateway Token**。`Sandbox.create(...)` 成功后，SDK 在 sandbox 对象上暴露 `_envd_access_token`（即 Sandbox Access Token）。每个 Sandbox 各有一份，仅在该 Sandbox 存活期间有效；销毁后失效，需重新创建 Sandbox 获取新值。
 
-### 使用 Skill 扩展能力
-
-OpenClaw 通过 Skill（目录 + `SKILL.md`）扩展 Agent 能力。详见 [OpenClaw Skills](https://docs.openclaw.ai/tools/skills)。
-
-镜像不预装自定义 Skill；可用 `openclaw skills list` 查看已加载 Skill（含 bundled）。
-
-| 作用域 | 路径| Source 标识 |
-|--------|-------------------|-------------|
-| Workspace | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
-| Managed | `/home/user/.openclaw/skills/<name>/SKILL.md` | managed |
-| Bundled | 随 OpenClaw 安装自带 | `openclaw-bundled` |
-
-触发方式：
-
-1. 显式：`openclaw agent ... --message "/skill-name"`
-2. 自动：自然语言匹配 `description` 时由模型加载
-
-> **注意**：请写成 `<workspace>/skills/<name>/SKILL.md`。把 `SKILL.md` 直接放在 workspace 根目录（例如 `/home/user/.openclaw/workspace/SKILL.md`）**不会**被识别为 Skill。
-
-**写入 Managed Skill：**
-
-```python
-sandbox.files.write(
-    "/home/user/.openclaw/skills/summarize-changes/SKILL.md",
-    """---
-name: summarize-changes
-description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
-user-invocable: true
----
-
-## Instructions
-1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
-2. List risks such as missing error handling or hardcoded values.
-3. If the diff is empty, say there are no uncommitted changes.
-""",
-)
-
-# 确认已出现在列表中
-print(sandbox.commands.run("openclaw skills list").stdout)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
-    '--message "/summarize-changes"',
-    timeout=0,
-)
-print(result.stdout)
-```
-
-**写入 Workspace Skill：**
-
-```python
-sandbox.files.write(
-    "/home/user/.openclaw/workspace/skills/api-conventions/SKILL.md",
-    """---
-name: api-conventions
-description: API design conventions. Use when adding or changing HTTP endpoints or /healthz.
-user-invocable: true
----
-
-When writing API endpoints:
-- Use RESTful naming
-- Return consistent error formats
-- Include request validation
-""",
-)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
-    '--message "/api-conventions Add a /healthz endpoint"',
-    timeout=0,
-)
-print(result.stdout)
-```
-
-**从本机上传多文件 Skill 目录：**
-
-若 Skill 含 `scripts/`、`references/` 等附属文件，用 `files.write_files` 一次批量写入，不必逐文件调用 `files.write`：
-
-```python
-from pathlib import Path
-
-def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
-    local = Path(local_dir).resolve()
-    entries = []
-    for path in local.rglob("*"):
-        if path.is_file():
-            rel = path.relative_to(local).as_posix()
-            entries.append({
-                "path": f"{remote_root.rstrip('/')}/{rel}",
-                "data": path.read_bytes(),
-            })
-    sandbox.files.write_files(entries)
-
-# 本机目录结构示例：
-# ./my-skills/echo-marker/SKILL.md
-# ./my-skills/echo-marker/scripts/marker.txt
-upload_skill_dir(
-    sandbox,
-    "./my-skills/echo-marker",
-    "/home/user/.openclaw/skills/echo-marker",  # Managed；Workspace 则用 workspace/skills/...
-)
-
-print(sandbox.commands.run("openclaw skills list").stdout)
-
-result = sandbox.commands.run(
-    'openclaw agent --local --agent main --model bailian/qwen3.6-flash '
-    '--message "/echo-marker"',
-    timeout=0,
-)
-print(result.stdout)
-```
-
-> **关于 Template.copy**：**暂不支持** `Template.build` 时用 `.copy("local-dir", "/home/user/.openclaw/skills/...")` 预置文件。自定义 Skill 请用上方运行时 `files.write` / `files.write_files`。
-
-**从 ClawHub 安装（可选）：**
-
-沙箱默认具备公网出站，可直接搜索 / 安装社区 Skill（浏览 [clawhub.ai](https://clawhub.ai)）：
-
-```python
-# 搜索
-result = sandbox.commands.run("openclaw skills search calendar", timeout=120)
-print(result.stdout)
-
-# 安装
-sandbox.commands.run("openclaw skills install weather", timeout=180)
-```
-
-也可在构建 Template 时预置 Skill（适合团队复用），把 skill 目录写入 `~/.openclaw/skills/` 或 workspace `skills/`。
 ### 浏览器访问（FC E2B）
 
 FC E2B 要在浏览器中打开 Gateway Control UI，**须先绑定自定义域名**。默认平台域名（`*.e2b.fc.aliyuncs.com`）会**触发下载而非打开页面**；绑定自定义域名后可正常访问。控制台添加域名、DNS 解析、HTTPS 证书及 SDK 配置的完整步骤，见 [云沙箱自定义域名](../04.功能说明/07.FC%20扩展/03.自定义域名.md)。
@@ -583,6 +455,137 @@ result = sandbox.commands.run(
 print(result.stdout)
 ```
 <!-- @/props -->
+
+---
+
+## 使用 Skill 扩展能力
+
+OpenClaw 通过 Skill（目录 + `SKILL.md`）扩展 Agent 能力，Gateway 与 Agent CLI 均可使用。详见 [OpenClaw Skills](https://docs.openclaw.ai/tools/skills)。
+
+以下示例假设已按上文创建 `sandbox`（Gateway 或 Agent CLI 均可）。镜像不预装自定义 Skill；可用 `openclaw skills list` 查看已加载 Skill（含 bundled）。
+
+| 作用域 | 路径 | Source 标识 |
+|--------|------|-------------|
+| Workspace | `/home/user/.openclaw/workspace/skills/<name>/SKILL.md` | `openclaw-workspace` |
+| Managed | `/home/user/.openclaw/skills/<name>/SKILL.md` | `openclaw-managed` |
+| Bundled | 随 OpenClaw 安装自带 | `openclaw-bundled` |
+
+触发方式：
+
+1. 显式：`openclaw agent ... --message "/skill-name"`
+2. 自动：自然语言匹配 `description` 时由模型加载
+
+> **注意**：请写成 `<workspace>/skills/<name>/SKILL.md`。把 `SKILL.md` 直接放在 workspace 根目录（例如 `/home/user/.openclaw/workspace/SKILL.md`）**不会**被识别为 Skill。
+
+以下以中国站百炼为例（`BAILIAN_MODEL` 见上文）；国际站将 `--model bailian/{BAILIAN_MODEL}` 改为 `openai/gpt-4o`，或省略 `--model` 以沿用已配置的默认模型。
+
+**写入 Managed Skill：**
+
+```python
+sandbox.files.write(
+    "/home/user/.openclaw/skills/summarize-changes/SKILL.md",
+    """---
+name: summarize-changes
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+user-invocable: true
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+""",
+)
+
+# 确认已出现在列表中
+print(sandbox.commands.run("openclaw skills list").stdout)
+
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    '--message "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**写入 Workspace Skill：**
+
+```python
+sandbox.files.write(
+    "/home/user/.openclaw/workspace/skills/api-conventions/SKILL.md",
+    """---
+name: api-conventions
+description: API design conventions. Use when adding or changing HTTP endpoints or /healthz.
+user-invocable: true
+---
+
+When writing API endpoints:
+- Use RESTful naming
+- Return consistent error formats
+- Include request validation
+""",
+)
+
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    '--message "/api-conventions Add a /healthz endpoint"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**从本机上传多文件 Skill 目录：**
+
+若 Skill 含 `scripts/`、`references/` 等附属文件，可以用 `files.write_files` 一次批量写入：
+
+```python
+from pathlib import Path
+
+def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
+    local = Path(local_dir).resolve()
+    entries = []
+    for path in local.rglob("*"):
+        if path.is_file():
+            rel = path.relative_to(local).as_posix()
+            entries.append({
+                "path": f"{remote_root.rstrip('/')}/{rel}",
+                "data": path.read_bytes(),
+            })
+    sandbox.files.write_files(entries)
+
+# 本机目录结构示例：
+# ./my-skills/echo-marker/SKILL.md
+# ./my-skills/echo-marker/scripts/marker.txt
+upload_skill_dir(
+    sandbox,
+    "./my-skills/echo-marker",
+    "/home/user/.openclaw/skills/echo-marker",  # Managed；Workspace 则用 workspace/skills/...
+)
+
+print(sandbox.commands.run("openclaw skills list").stdout)
+
+result = sandbox.commands.run(
+    f'openclaw agent --local --agent main --model bailian/{BAILIAN_MODEL} '
+    '--message "/echo-marker"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+> **关于 Template.copy**：**暂不支持** `Template.build` 时用 `.copy("local-dir", "/home/user/.openclaw/skills/...")` 预置文件。自定义 Skill 请用上方运行时 `files.write` / `files.write_files`。
+
+**从 ClawHub 安装（可选）：**
+
+沙箱默认具备公网出站，可直接搜索 / 安装社区 Skill（浏览 [clawhub.ai](https://clawhub.ai)）：
+
+```python
+# 搜索
+result = sandbox.commands.run("openclaw skills search calendar", timeout=120)
+print(result.stdout)
+
+# 安装
+sandbox.commands.run("openclaw skills install weather", timeout=180)
+```
 
 ---
 


### PR DESCRIPTION
…7 in Chinese documentation

Updated the image tags in the Chinese documentation for both Claude Code and OpenClaw to reflect the latest version (v0.0.37) across all specified regions. This ensures users have access to the most current runtime images in both English and Chinese versions.

Change-Id: I75ead6d5b7369039dbb6ccd180fc7dbb185de8dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 更新了 FC Agent Sandbox 文档中 Claude Code 和 OpenClaw 自定义镜像的相关内容，覆盖中英文版本的“最佳实践”章节。

- 将镜像版本从 `v0.0.32` 更新至 `v0.0.37`，同步调整各区域镜像地址及代码示例。
- Claude Code 文档更新百炼模型配置、会话恢复错误处理及常见问题说明。
- OpenClaw 文档重写并扩展 Skills 使用章节，补充 Managed、Workspace、本地目录上传及 ClawHub 安装示例。
- 未新增或删除文档页面，仅修改现有 Markdown 页面。
- 未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->