### PR TITLE
docs(sandbox): add supported regions

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/01.Getting Started/04.Usage Constraints.md
+++ b/docs/en-US/01.FC Agent Sandbox/01.Getting Started/04.Usage Constraints.md
@@ -10,8 +10,12 @@ FC Agent Sandbox APIs and SDK access are currently available in the following re
 - China East 2 (Shanghai)
 - China East 1 (Hangzhou)
 - China South 1 (Shenzhen)
+- China (Hong Kong)
+- Singapore
+- US (Virginia)
+- US (Silicon Valley)
 
-The `<region>` value in the SDK endpoint must match the region where your FC Agent Sandbox resources are deployed. Supported `<region>` values are `cn-beijing`, `cn-shanghai`, `cn-hangzhou`, and `cn-shenzhen`.
+The `<region>` value in the SDK endpoint must match the region where your FC Agent Sandbox resources are deployed. Supported `<region>` values are `cn-beijing`, `cn-shanghai`, `cn-hangzhou`, `cn-shenzhen`, `cn-hongkong`, `ap-southeast-1`, `us-east-1`, and `us-west-1`.
 
 ```bash
 export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"

--- a/docs/en-US/01.FC Agent Sandbox/07.Developer Reference/02.E2B SDK Connection Parameters.md
+++ b/docs/en-US/01.FC Agent Sandbox/07.Developer Reference/02.E2B SDK Connection Parameters.md
@@ -14,7 +14,7 @@ export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
 export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
 ```
 
-The `<region>` value must match the region where FC Agent Sandbox is deployed. Supported `<region>` values are `cn-beijing`, `cn-shanghai`, `cn-hangzhou`, and `cn-shenzhen`. If the API URL, domain, template, and sandbox are not in the same region, common outcomes include creation failures, connection failures, or templates not being visible.
+The `<region>` value must match the region where FC Agent Sandbox is deployed. Supported `<region>` values are `cn-beijing`, `cn-shanghai`, `cn-hangzhou`, `cn-shenzhen`, `cn-hongkong`, `ap-southeast-1`, `us-east-1`, and `us-west-1`. If the API URL, domain, template, and sandbox are not in the same region, common outcomes include creation failures, connection failures, or templates not being visible.
 
 API keys must be created and managed in the Function Compute console. Do not manage FC Agent Sandbox API keys through the E2B SDK, and do not write API keys into source repositories, logs, screenshots, or frontend pages.
 

--- a/docs/en-US/01.FC Agent Sandbox/09.Support/02.Supported Regions.md
+++ b/docs/en-US/01.FC Agent Sandbox/09.Support/02.Supported Regions.md
@@ -6,5 +6,9 @@ FC Agent Sandbox API and SDK are currently available in the following regions:
 - China East 2 (Shanghai): `cn-shanghai`
 - China East 1 (Hangzhou): `cn-hangzhou`
 - China South 1 (Shenzhen): `cn-shenzhen`
+- China (Hong Kong): `cn-hongkong`
+- Singapore: `ap-southeast-1`
+- US (Virginia): `us-east-1`
+- US (Silicon Valley): `us-west-1`
 
 This topic will be updated when new regions are added.

--- a/docs/zh-CN/01.云沙箱/01.开始使用/04.使用约束.md
+++ b/docs/zh-CN/01.云沙箱/01.开始使用/04.使用约束.md
@@ -10,8 +10,12 @@
 - 华东 2（上海）
 - 华东 1（杭州）
 - 华南 1（深圳）
+- 中国（香港）
+- 新加坡
+- 美国（弗吉尼亚）
+- 美国（硅谷）
 
-SDK Endpoint 中的 `<region>` 需要与云沙箱所在地域一致。当前支持的 `<region>` 包括 `cn-beijing`、`cn-shanghai`、`cn-hangzhou` 和 `cn-shenzhen`。
+SDK Endpoint 中的 `<region>` 需要与云沙箱所在地域一致。当前支持的 `<region>` 包括 `cn-beijing`、`cn-shanghai`、`cn-hangzhou`、`cn-shenzhen`、`cn-hongkong`、`ap-southeast-1`、`us-east-1` 和 `us-west-1`。
 
 ```bash
 export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"

--- a/docs/zh-CN/01.云沙箱/07.开发参考/02.E2B SDK 接入参数说明.md
+++ b/docs/zh-CN/01.云沙箱/07.开发参考/02.E2B SDK 接入参数说明.md
@@ -14,7 +14,7 @@ export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
 export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
 ```
 
-其中 `<region>` 需要与云沙箱所在地域一致。当前支持的 `<region>` 包括 `cn-beijing`、`cn-shanghai`、`cn-hangzhou` 和 `cn-shenzhen`。如果 API URL、域名、模板和 Sandbox 不在同一地域，常见结果是创建失败、连接失败或模板不可见。
+其中 `<region>` 需要与云沙箱所在地域一致。当前支持的 `<region>` 包括 `cn-beijing`、`cn-shanghai`、`cn-hangzhou`、`cn-shenzhen`、`cn-hongkong`、`ap-southeast-1`、`us-east-1` 和 `us-west-1`。如果 API URL、域名、模板和 Sandbox 不在同一地域，常见结果是创建失败、连接失败或模板不可见。
 
 API Key 应在函数计算控制台创建和管理，具体步骤参见[创建 API Key](../01.开始使用/02.创建%20API%20Key.md)。不要通过 E2B SDK 管理云沙箱 API Key，也不要把 API Key 写入代码仓库、日志、截图或前端页面。
 

--- a/docs/zh-CN/01.云沙箱/09.服务支持/02.支持地域.md
+++ b/docs/zh-CN/01.云沙箱/09.服务支持/02.支持地域.md
@@ -6,5 +6,9 @@
 - 华东 2（上海）：`cn-shanghai`
 - 华东 1（杭州）：`cn-hangzhou`
 - 华南 1（深圳）：`cn-shenzhen`
+- 中国（香港）：`cn-hongkong`
+- 新加坡：`ap-southeast-1`
+- 美国（弗吉尼亚）：`us-east-1`
+- 美国（硅谷）：`us-west-1`
 
 后续新增地域会同步更新本文。


### PR DESCRIPTION
Document the new Hong Kong, Singapore, US East, and US West regions and their endpoint identifiers in Chinese and English guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 面向云沙箱（FC Agent Sandbox）产品，更新中英文文档中的地域支持说明：

- 更新“使用约束”及“E2B SDK 接入参数说明”，补充中国香港、新加坡、美国弗吉尼亚和美国硅谷及对应区域代码。
- 更新“支持地域”页面，新增上述四个地域条目。
- 未新增或删除页面，未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->