### PR TITLE
docs(faq): 明确模板构建 FAQ 不支持 E2B steps 与 Dockerfile

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md
+++ b/docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md
@@ -1,10 +1,12 @@
 # Template Builds
 
-## How should I handle dependency installation failures or insufficient space?
+## The E2B Template does not support passing steps or a Dockerfile inline; how do I build dependencies?
 
-The Template Build API currently does not support declaring `steps` (installation steps) in the build request. Passing `steps` returns `400 steps are not supported`, so do not try to install dependencies online through build steps.
+The Template Build API currently does not support passing `steps` (installation steps) or a Dockerfile inline in an E2B Template definition. Passing `steps` returns `400 steps are not supported`, so do not try to install dependencies online through build steps.
 
-Dependencies should be installed during the Dockerfile or external image build phase, and then the finished image should be pushed to an image registry so the template only builds from that image. This avoids downloading and installing dependencies during the template build or after every Sandbox creation.
+Only this usage—passing `steps` or a Dockerfile inline through the E2B Template definition—is unsupported; the Dockerfile itself still works. You can still build a finished image with a Dockerfile externally, and then build the template from your image registry with `from_image`.
+
+Therefore, dependencies should be installed during the Dockerfile or external image build phase, and then the finished image should be pushed to an image registry so the template only builds from that image. This avoids downloading and installing dependencies during the template build or after every Sandbox creation.
 
 Minimal Dockerfile example:
 

--- a/docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建.md
+++ b/docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建.md
@@ -1,10 +1,12 @@
 # 模板构建
 
-## 依赖安装失败或空间不足，怎么处理？
+## 不支持通过 E2B Template 内联传入 steps 或 Dockerfile，如何构建依赖？
 
-当前 Template Build API 不支持在构建请求里声明 `steps`（安装步骤）。传入 `steps` 会返回 `400 steps are not supported`，因此不要试图用构建步骤在线安装依赖。
+当前 Template Build API 不支持在 E2B Template 定义中内联传入 `steps`（安装步骤）或 Dockerfile。传入 `steps` 会返回 `400 steps are not supported`，因此不要试图用构建步骤在线安装依赖。
 
-依赖应在 Dockerfile 或外部镜像构建阶段装好，再把成品镜像推送到镜像仓库，模板只负责从该镜像构建。这样可以避免在模板构建或每次创建 Sandbox 后重复下载和安装依赖。
+这里不支持的只是「通过 E2B Template 定义内联传入 steps 或 Dockerfile」这种用法；Dockerfile 本身仍然可用：你可以照常在外部用 Dockerfile 构建出成品镜像，再通过 `from_image` 从镜像仓库构建模板。
+
+因此，依赖应在 Dockerfile 或外部镜像构建阶段装好，再把成品镜像推送到镜像仓库，模板只负责从该镜像构建。这样可以避免在模板构建或每次创建 Sandbox 后重复下载和安装依赖。
 
 精简的 Dockerfile 示例：
 


### PR DESCRIPTION
## 背景

模板构建 FAQ 的首个标题「依赖安装失败或空间不足，怎么处理？」未能直接表达核心限制：不支持通过 E2B Template 内联传入 `steps` 或 Dockerfile。用户容易误以为「Dockerfile 完全不可用」。

## 改动范围

仅修改两处直接相关的中英文 FAQ 页面：

- `docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建.md`
- `docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md`

具体调整：

1. 首个标题改为面向用户、简洁准确地表达「不支持通过 E2B Template 内联传入 steps 或 Dockerfile」。
2. 正文明确：这里不支持的只是「通过 E2B Template 定义内联传入 steps 或 Dockerfile」这种用法；Dockerfile 本身仍可在外部构建成品镜像，再通过 `from_image` 从镜像仓库构建模板，避免「Dockerfile 完全不可用」的误解。

未改动其他页面，保持范围纯净。

## 验证

- `git diff` 复核：仅两页 FAQ 变更，无越界改动。
- 确认无任何页面通过锚点引用被修改的标题，标题修改不会产生死链。
- 复核两页内保留的内部链接（构建自定义镜像模板、GHCR 最佳实践）目标文件均存在。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 更新 E2B 云沙箱产品的模板构建 FAQ，涉及中英文两页“模板构建”章节：

- `docs/en-US/01.FC Agent Sandbox/08.FAQ/05.Template Builds.md`
- `docs/zh-CN/01.云沙箱/08.常见问题/05.模板构建.md`

内容明确不支持在 E2B Template 定义中内联传入 `steps` 或 Dockerfile，并补充通过外部构建镜像后使用 `from_image` 创建模板的方式。

未新增或删除页面，也未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->