### PR TITLE
docs(desktop): add Computer Use Sandbox English guide

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/04.Use Computer Use Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/04.Use Computer Use Sandbox.md
@@ -1,3 +1,217 @@
-# Use Computer Use Sandbox (Not Yet Released)
+# Use Computer Use Sandbox
 
-> The Computer Use Sandbox feature has not been released yet. This page does not currently provide integration instructions or sample code. It will be published once the feature, SDK, and examples have been verified.
+Computer Use Sandbox is designed for Agents that need to see the screen, move the mouse, and type on the keyboard. It runs a complete Linux desktop environment in a cloud sandbox. An Agent perceives the interface through screenshots, uses the mouse and keyboard to operate GUI applications such as browsers, file managers, editors, and terminals, and lets you observe the process in real time.
+
+If a task only requires accessing web pages, clicking, filling forms, taking screenshots, or scraping dynamic pages, use [Browser Use Sandbox](02.Use%20Browser%20Use%20Sandbox.md) and control the browser precisely through CDP. Use Computer Use Sandbox only when a task must operate desktop applications outside the browser or drive an interface visually through pixel coordinates and screenshots.
+
+## Use Cases
+
+| Scenario | Description |
+| --- | --- |
+| Vision-driven Computer Use Agents | Let a vision model produce mouse coordinates and keyboard actions from screenshots to operate a desktop in a closed loop. |
+| Desktop application automation | Control GUI applications outside the browser, such as editors, office software, and desktop clients. |
+| End-to-end GUI testing | Test graphical interfaces in an isolated desktop without polluting local or CI environments. |
+| Demonstrations and remote observation | Watch every Agent action through a live stream for demonstrations, debugging, and audits. |
+
+## Comparison with Browser Use Sandbox
+
+| Item | Computer Use Sandbox | Browser Use Sandbox |
+| --- | --- | --- |
+| Environment | Complete Linux desktop | Browser instance without a desktop |
+| Target | Any desktop GUI application | Browser pages only |
+| Control method | Screenshots, mouse coordinates, and keyboard | CDP over WebSocket |
+| SDK | `e2b-desktop` / `@e2b/desktop` | `e2b` / `@e2b/code-interpreter` with Puppeteer or Playwright |
+| Live view | Built into the SDK | Provided by the browser template |
+| Best for | Desktop-level and vision-driven tasks | Web scraping, forms, and lightweight E2E testing |
+
+## Prerequisites
+
+1. Build a template such as `my-desktop-template` by following the [Desktop Template example](../04.Features/02.Templates/07.Examples/03.Desktop%20Template.md).
+2. Configure `E2B_API_KEY`, `E2B_API_URL`, and `E2B_DOMAIN` for the same region as the template.
+3. Install the Desktop SDK for your language.
+
+**Python** (`e2b-desktop` 2.4.1):
+
+```bash
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install e2b-desktop==2.4.1 python-dotenv
+```
+
+**Node.js** (`@e2b/desktop` 2.3.1):
+
+```json
+{
+  "name": "computer-use-sandbox-demo",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@e2b/desktop": "2.3.1",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.23.1"
+  }
+}
+```
+
+> **Note**: Store credentials in `.env`, exclude the file through `.gitignore`, and never commit it to version control. The SDK reads the connection environment variables automatically, so you do not need to pass them explicitly to methods.
+
+## Python Example
+
+The following example creates a desktop sandbox, launches Chrome, takes a screenshot, performs mouse and keyboard actions, and starts an authenticated live stream.
+
+```python
+"""Computer Use Sandbox example."""
+
+import os
+
+from dotenv import load_dotenv
+from e2b_desktop import Sandbox
+
+load_dotenv()
+
+TEMPLATE = os.environ.get("E2B_DESKTOP_TEMPLATE", "my-desktop-template")
+
+desktop = None
+try:
+    # timeout is in seconds and must cover desktop startup and the entire task.
+    desktop = Sandbox.create(template=TEMPLATE, timeout=600)
+
+    # Launch Chrome and wait for the window to render. wait is in milliseconds.
+    desktop.launch("google-chrome", "https://example.com")
+    desktop.wait(10000)
+
+    # Mouse actions.
+    desktop.move_mouse(640, 400)
+    desktop.left_click()
+    desktop.double_click()
+    desktop.scroll("down", 5)
+
+    # Type in a terminal to verify keyboard input and shortcuts.
+    desktop.launch("xfce4-terminal")
+    desktop.wait(3000)
+    desktop.write("computer use")
+    desktop.press(["ctrl", "a"])
+    desktop.write("echo ")
+    desktop.press("enter")
+    desktop.wait(1000)
+
+    # screenshot returns PNG bytes for a vision model or local file.
+    image = desktop.screenshot()
+    with open("desktop.png", "wb") as f:
+        f.write(image)
+
+    # Start a live stream protected by a VNC password.
+    desktop.stream.start(require_auth=True)
+    auth_key = desktop.stream.get_auth_key()
+    stream_url = desktop.stream.get_url(auth_key=auth_key)
+    # Pass stream_url to a controlled backend. Do not write it to public logs.
+
+    # Run the Agent's screenshot -> decision -> action loop here.
+
+    desktop.stream.stop()
+finally:
+    if desktop is not None:
+        desktop.kill()
+```
+
+## TypeScript Example
+
+Save the following code as `computer-use.ts`:
+
+```typescript
+import "dotenv/config";
+import { writeFileSync } from "node:fs";
+import { Sandbox } from "@e2b/desktop";
+
+const TEMPLATE = process.env.E2B_DESKTOP_TEMPLATE ?? "my-desktop-template";
+
+let desktop: Sandbox | undefined;
+try {
+  // timeoutMs is in milliseconds and must cover desktop startup and the entire task.
+  desktop = await Sandbox.create(TEMPLATE, { timeoutMs: 600_000 });
+
+  await desktop.launch("google-chrome", "https://example.com");
+  // Wait for the application window to render before taking a screenshot.
+  await desktop.wait(10_000);
+
+  await desktop.moveMouse(640, 400);
+  await desktop.leftClick();
+  await desktop.doubleClick();
+  await desktop.scroll("down", 5);
+
+  await desktop.launch("xfce4-terminal");
+  await desktop.wait(3_000);
+  await desktop.write("computer use");
+  await desktop.press(["ctrl", "a"]);
+  await desktop.write("echo ");
+  await desktop.press("enter");
+  await desktop.wait(1_000);
+
+  const image = await desktop.screenshot();
+  writeFileSync("desktop.png", image);
+
+  await desktop.stream.start({ requireAuth: true });
+  const authKey = desktop.stream.getAuthKey();
+  const streamUrl = desktop.stream.getUrl({ authKey });
+  // Pass streamUrl to a controlled backend. Do not write it to public logs.
+
+  // Run the Agent's screenshot -> decision -> action loop here.
+
+  await desktop.stream.stop();
+} finally {
+  await desktop?.kill();
+}
+```
+
+Run the example:
+
+```bash
+npm install
+npx tsx computer-use.ts
+```
+
+## Common Capabilities
+
+| Capability | Python | TypeScript |
+| --- | --- | --- |
+| Create a sandbox | `Sandbox.create(template=..., timeout=...)` | `Sandbox.create(template, { timeoutMs })` |
+| Launch an application | `desktop.launch("google-chrome", url)` | `desktop.launch("google-chrome", url)` |
+| Wait | `desktop.wait(10000)` | `desktop.wait(10000)` |
+| Take a screenshot | `desktop.screenshot()` | `desktop.screenshot()` |
+| Move the mouse | `desktop.move_mouse(x, y)` | `desktop.moveMouse(x, y)` |
+| Left-click, double-click, or right-click | `left_click()` / `double_click()` / `right_click()` | `leftClick()` / `doubleClick()` / `rightClick()` |
+| Scroll | `desktop.scroll("down", amount)` | `desktop.scroll("down", amount)` |
+| Drag | `desktop.drag((x1, y1), (x2, y2))` | `desktop.drag([x1, y1], [x2, y2])` |
+| Type text | `desktop.write("...")` | `desktop.write("...")` |
+| Press a key or shortcut | `press("enter")` / `press(["ctrl", "c"])` | `press("enter")` / `press(["ctrl", "c"])` |
+| Get the current window ID | `desktop.get_current_window_id()` | `desktop.getCurrentWindowId()` |
+| Start or stop a live stream | `stream.start()` / `stream.stop()` | `stream.start()` / `stream.stop()` |
+| Get the stream URL | `stream.get_url(auth_key=...)` | `stream.getUrl({ authKey })` |
+| Kill the sandbox | `desktop.kill()` | `desktop.kill()` |
+
+## Live Streaming and Authentication
+
+- `stream.start(require_auth=True)` / `stream.start({ requireAuth: true })` generates a password for the VNC stream.
+- You must call `get_auth_key()` / `getAuthKey()` only after enabling `require_auth` / `requireAuth`. Otherwise, the SDK throws an error.
+- `stream.get_url()` returns a noVNC URL. For read-only observation, use `view_only=True` in Python or `viewOnly: true` in TypeScript.
+- Only one stream can run at a time. Version 0.0.37 supports whole-desktop streaming but does not support streaming an individual window.
+
+Accessing `/vnc.html` and `/websockify` through the Function Compute public gateway also requires the sandbox `X-Access-Token`. The `auth_key` generated by `require_auth` is the VNC stream password. These are two independent authentication layers. Because standard browsers cannot add arbitrary request headers to pages and WebSocket connections, expose live viewing to end users through a controlled reverse proxy that injects `X-Access-Token`. Do not expose the sandbox token to the frontend or public logs.
+
+## Security and Production Recommendations
+
+- **Credential isolation**: Inject model keys, account passwords, and business tokens through runtime environment variables. Do not write them into the template image.
+- **Stream access control**: Enable `require_auth` for live streams, use `view_only` for read-only demonstrations, and do not write URLs containing passwords to public logs.
+- **Prompt injection protection**: Do not let an Agent treat on-screen text as system instructions without validation. Require human approval for sensitive actions such as submitting, deleting, or making payments.
+- **Resources and lifecycle**: Set a reasonable task timeout and always call `kill()` in `finally`.
+- **Action auditing**: Record the necessary screenshots, mouse coordinates, key sequences, and target windows for reproduction and tracing.
+- **Least privilege**: Restrict the domains, applications, and writable directories available to the sandbox.
+
+## Related Documentation
+
+- [Desktop Template](../04.Features/02.Templates/07.Examples/03.Desktop%20Template.md)
+- [Browser Use Sandbox](02.Use%20Browser%20Use%20Sandbox.md)
+- [AIO Sandbox](03.Use%20AIO%20Sandbox.md)
+- [Upload and Download Files](../04.Features/04.Filesystem/03.Upload%20and%20Download%20Files.md)


### PR DESCRIPTION
## Summary

- replace the unreleased placeholder with a complete English Computer Use Sandbox guide
- align use cases, prerequisites, SDK examples, capability reference, streaming authentication, and security guidance with the Chinese page
- preserve the verified Python and TypeScript SDK versions and APIs

## Validation

- checked Python and JSON syntax
- parsed the TypeScript example with Prettier
- verified all relative link targets
- ran git diff --check
- ran python scripts/prepare-mkdocs.py and mkdocs build --config-file mkdocs.generated.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 仅涉及 **FC Agent Sandbox** 产品下的英文文档，具体为 **Best Practices > Use Computer Use Sandbox** 章节。

- 将原有的未发布占位说明替换为完整的 Computer Use Sandbox 使用指南。
- 新增功能定位、适用场景、与 Browser Use Sandbox 对比、前置条件、Python/TypeScript SDK 示例、能力对照、实时流媒体与认证、安全及生产实践、相关文档链接等内容。
- 未新增或删除页面，仅修改现有文档页面。
- 未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->