### PR TITLE
docs: 添加私网访问文档并更新公网访问文档

### DIFF
--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/03.公网访问.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/03.公网访问.md
@@ -38,6 +38,7 @@ Python 示例：
 ```python
 import os
 import urllib.request
+import time
 
 from e2b import Sandbox
 
@@ -53,7 +54,7 @@ try:
         "python3 -m http.server 8000",
         background=True,
     )
-
+    time.sleep(2)  # Wait for http.server to start
     host = sandbox.get_host(8000)
     url = f"https://{host}"
     print(url)

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/06.私网访问.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/06.私网访问.md
@@ -1,0 +1,102 @@
+# 私网访问
+
+[私网连接（PrivateLink）](https://help.aliyun.com/zh/privatelink/?spm=5176.30275541.J_ZGek9Blx07Hclc3Ddt9dg.3.2ef92f3d1hN06v&scm=20140722.S_card@@%E4%BA%A7%E5%93%81@@423913.S_new~UND~card.ID_card@@%E4%BA%A7%E5%93%81@@423913-RL_%E7%A7%81%E7%BD%91%E8%BF%9E%E6%8E%A5privatelink-LOC_2024SPSearchCard-OR_ser-PAR1_0abb781617846867256234663e7d3a-V_4-RE_new5-P0_0-P1_0)能够实现专有网络VPC与阿里云上的服务建立安全稳定的私有连接，简化网络架构，实现私网访问服务，避免通过公网访问服务带来的潜在安全风险。我们已在各地域开通终端节点服务，您可通过终端节点连接，从而通过内网访问您的服务。
+
+首次使用请先开通私网连接（PrivateLink）服务。
+
+## 创建终端节点
+
+登陆[私网连接控制台](https://vpc.console.aliyun.com/endpoint/cn-beijing/endpoints)，选择**接口终端节点**创建终端节点。
+
+**基础配置**填写**所属地域、节点名称，类型**选择`阿里云服务`，**可用的服务**选择`com.aliyuncs.privatelink.<region>.fc.e2b`。
+
+![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/XNkOM5KzJR6QROY7/img/19027522-6319-4028-8a21-af5b1c9908e7.png)
+
+![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/XNkOM5KzJR6QROY7/img/f4206a83-01e0-4e80-b217-ac3a474c1acd.png)
+
+配置**专有网络、可用区与交换机、安全组**（若无请自行创建相应资源）**。**
+
+![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/XNkOM5KzJR6QROY7/img/d25aa7b0-9b07-40db-9f4a-adb4dc2c6fde.png)
+
+**确认创建**后确认状态，如果**自定义服务域名**未启动，请手动启用。
+
+![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/XNkOM5KzJR6QROY7/img/cf4d8c2d-827c-45b8-8c33-662518941220.png)
+
+用户即可在自己 vpc 通过上述域名访问。
+
+![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/XNkOM5KzJR6QROY7/img/8f26ebef-76ad-4e49-8bce-b7f4d6694060.png)
+
+## 启动服务并通过私网访问
+
+配置环境变量，`E2B_API_URL`、`E2B_DOMAIN`均设置为私网。
+
+```shell
+export E2B_API_KEY="<your-api-key>"
+export E2B_API_URL="https://api.<region>-vpc.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="<region>-vpc.e2b.fc.aliyuncs.com"
+```
+
+以下代码需要在自己 VPC 中运行。
+
+TypeScript 示例：
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
+
+try {
+  const process = await sandbox.commands.run("python3 -m http.server 8000", {
+    background: true,
+  });
+
+  const host = sandbox.getHost(8000);
+  const url = `https://${host}`;
+  console.log(url);
+
+  const response = await fetch(url);
+  console.log(await response.text());
+
+  await process.kill();
+} finally {
+  await sandbox.kill();
+}
+```
+
+Python 示例：
+
+```python
+import os
+import urllib.request
+import time
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    process = sandbox.commands.run(
+        "python3 -m http.server 8000",
+        background=True,
+    )
+    time.sleep(2)  # Wait for http.server to start
+    host = sandbox.get_host(8000)
+    url = f"https://{host}"
+    print(url)
+
+    with urllib.request.urlopen(url, timeout=10) as response:
+        print(response.read().decode())
+
+    process.kill()
+finally:
+    sandbox.kill()
+```


### PR DESCRIPTION
1. 添加私网访问文档
2. 公网访问文档python代码会因服务启动时序问题出现报错，sleep一下更稳妥。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
本次 PR 面向云沙箱产品，涉及“功能说明 > 网络”章节下的文档：

- 更新“公网访问”（03.公网访问.md）里的“启动服务并访问”Python 示例：在后台启动 `python3 -m http.server 8000` 后、获取宿主地址前增加 `time.sleep(2)`，以等待服务就绪降低启动时序报错概率。
- 新增“私网访问”（06.私网访问.md）：补充通过 VPC/PrivateLink 进行私网访问的配置说明与环境变量/TypeScript/ Python 示例流程。

页面层面：新增 1 个页面（私网访问），未删除页面。图片资源：未改动。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->