### PR TITLE
docs(sandbox): add English version of private access document

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/03.Public Access.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/03.Public Access.md
@@ -38,6 +38,7 @@ Python example:
 ```python
 import os
 import urllib.request
+import time
 
 from e2b import Sandbox
 
@@ -53,7 +54,7 @@ try:
         "python3 -m http.server 8000",
         background=True,
     )
-
+    time.sleep(2)  # Wait for http.server to start
     host = sandbox.get_host(8000)
     url = f"https://{host}"
     print(url)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/06.Private Access.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/06.Private Access.md
@@ -1,0 +1,94 @@
+# Private Access
+
+[PrivateLink](https://help.aliyun.com/en/privatelink/) enables you to establish secure and stable private connections between your VPC and services on Alibaba Cloud. It simplifies network architecture, enables private access to services, and avoids potential security risks associated with public network access. We have enabled endpoint services in all supported regions. You can connect through endpoints to access your services over the internal network.
+
+If this is your first time, please activate the PrivateLink service first.
+
+## Create an Endpoint
+
+Log in to the [PrivateLink console](https://vpc.console.aliyun.com/endpoint/cn-beijing/endpoints) and select **Interface Endpoint** to create an endpoint.
+
+In **Basic Settings**, fill in the **Region** and **Endpoint Name**, set **Type** to `Alibaba Cloud Service`, and select `com.aliyuncs.privatelink.<region>.fc.e2b` for **Alibaba Cloud Service**.
+
+Configure the **VPC, Zone and vSwitch, and Security Group** (create the corresponding resources if you don't have them).
+
+In **Advanced Settings**, set **Enable Custom Domain Name?** to `Enable`.
+
+Click the **OK** button to create, then check the status. If the **Custom Domain Name** is not enabled, enable it manually.
+
+You can then access the service through the **Custom Domain Name** within your VPC.
+
+## Start a Service and Access via Private Network
+
+Set the environment variables `E2B_API_URL` and `E2B_DOMAIN` to the private network endpoints.
+
+```shell
+export E2B_API_KEY="<your-api-key>"
+export E2B_API_URL="https://api.<region>-vpc.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="<region>-vpc.e2b.fc.aliyuncs.com"
+```
+
+The following code must be run within your VPC.
+
+TypeScript example:
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create("code-interpreter-v1", {
+  apiKey: process.env.E2B_API_KEY,
+  apiUrl: process.env.E2B_API_URL,
+  domain: process.env.E2B_DOMAIN,
+});
+
+try {
+  const process = await sandbox.commands.run("python3 -m http.server 8000", {
+    background: true,
+  });
+
+  const host = sandbox.getHost(8000);
+  const url = `https://${host}`;
+  console.log(url);
+
+  const response = await fetch(url);
+  console.log(await response.text());
+
+  await process.kill();
+} finally {
+  await sandbox.kill();
+}
+```
+
+Python example:
+
+```python
+import os
+import urllib.request
+import time
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=os.environ["E2B_API_KEY"],
+    api_url=os.environ["E2B_API_URL"],
+    domain=os.environ["E2B_DOMAIN"],
+)
+
+try:
+    process = sandbox.commands.run(
+        "python3 -m http.server 8000",
+        background=True,
+    )
+    time.sleep(2)  # Wait for http.server to start
+    host = sandbox.get_host(8000)
+    url = f"https://{host}"
+    print(url)
+
+    with urllib.request.urlopen(url, timeout=10) as response:
+        print(response.read().decode())
+
+    process.kill()
+finally:
+    sandbox.kill()
+```


### PR DESCRIPTION
add English version of private access document
fix   public access code bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
本 PR 涉及 **FC Agent Sandbox** 产品的“**网络（Network）**”相关文档章节：

- **新增**英文页面：《Private Access》（`docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/06.Private Access.md`）  
  内容包含：PrivateLink 能力与首次激活要求、在 PrivateLink 控制台创建 Interface Endpoint 的步骤、在私网环境配置 `E2B_API_URL`/`E2B_DOMAIN`，以及在 VPC 内通过 TypeScript/Python 示例访问函数服务。

- **修改**英文页面：《Public Access》（`docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/03.Public Access.md`）  
  修复 Python 示例的访问时序问题：新增 `import time`，并在后台启动 `python3 -m http.server 8000` 后、调用 `sandbox.getHost(8000)` 之前加入 `time.sleep(2)`，等待服务就绪后再构造并请求公网访问 URL。

变更情况：
- **新增页面**：1 个  
- **删除页面**：无  
- **图片资源**：未改动（本次变更未涉及图片引用/资源更新）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->