### PR TITLE
docs(sandbox): add Java and Go SDK guides

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/07.Developer Reference/05.E2B SDK for Java and Go.md
+++ b/docs/en-US/01.FC Agent Sandbox/07.Developer Reference/05.E2B SDK for Java and Go.md
@@ -1,0 +1,182 @@
+# E2B SDK for Java and Go
+
+E2B officially provides only Python and TypeScript SDKs. To make it easier for Java and Go developers to connect to FC Agent Sandbox, the Alibaba Cloud Function Compute team maintains the following E2B data-plane-compatible SDKs.
+
+- Java SDK: [aliyun-fc/e2b-java-sdk](https://github.com/aliyun-fc/e2b-java-sdk)
+- Go SDK: [aliyun-fc/e2b-go-sdk](https://github.com/aliyun-fc/e2b-go-sdk)
+
+This topic first describes the connection settings shared by both SDKs, and then provides separate Java and Go quickstarts. For exact interfaces, parameter names, and defaults, refer to the source code and type definitions in each repository.
+
+## Prerequisites and common connection configuration
+
+- You have an Alibaba Cloud account and the required permissions to use Function Compute.
+- You have [created an API key](../01.Getting%20Started/02.Create%20an%20API%20Key.md) in the Function Compute console.
+- You have confirmed that FC Agent Sandbox is available in the target region and that your local network can access the service endpoint in that region.
+
+Pass the API key, API URL, and domain through environment variables. Do not hard-code them in source code.
+
+```bash
+export E2B_API_KEY="<your-api-key>"
+export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+```
+
+Replace `<region>` with the region where FC Agent Sandbox is deployed. Supported values are `cn-beijing`, `cn-shanghai`, `cn-hangzhou`, `cn-shenzhen`, `cn-hongkong`, `ap-southeast-1`, `us-east-1`, and `us-west-1`. The API URL, domain, template, and sandbox must be in the same region.
+
+## Java SDK
+
+### Availability and installation
+
+The Java SDK is currently available as source code. Version `2.1.0` has not been published to Maven Central or another public Maven repository. Clone the repository and install the SDK in your local Maven repository:
+
+```bash
+git clone https://github.com/aliyun-fc/e2b-java-sdk.git
+cd e2b-java-sdk
+mvn clean install -DskipTests
+```
+
+For a Maven project, add the dependency:
+
+```xml
+<dependency>
+    <groupId>com.alibaba.serverless</groupId>
+    <artifactId>e2b-java-sdk</artifactId>
+    <version>2.1.0</version>
+</dependency>
+```
+
+For a Gradle project, enable the local Maven repository before adding the dependency:
+
+```groovy
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.alibaba.serverless:e2b-java-sdk:2.1.0'
+}
+```
+
+The SDK requires Java 8 or later. Its main packages are:
+
+| Package | Description |
+|----|------|
+| `dev.e2b.sdk` | `Sandbox` entry class. |
+| `dev.e2b.sdk.client` | Connection configuration such as `ConnectionConfig`. |
+| `dev.e2b.sdk.model` | Data models such as `CommandResult`. |
+
+### Create and run a sandbox
+
+```java
+import dev.e2b.sdk.Sandbox;
+import dev.e2b.sdk.client.ConnectionConfig;
+import dev.e2b.sdk.model.CommandResult;
+
+public class Quickstart {
+    public static void main(String[] args) throws Exception {
+        ConnectionConfig config = ConnectionConfig.builder()
+                .apiKey(System.getenv("E2B_API_KEY"))
+                .apiUrl(System.getenv("E2B_API_URL"))
+                .domain(System.getenv("E2B_DOMAIN"))
+                .build();
+
+        try (Sandbox sandbox = Sandbox.create("code-interpreter-v1", config)) {
+            CommandResult result = sandbox.getCommands().run(
+                    "python3 -c \"print('hello from sandbox')\""
+            );
+            System.out.println(result.getStdout().trim());
+        }
+    }
+}
+```
+
+`Sandbox` implements `AutoCloseable`. Leaving the `try` block calls `kill()` and releases the sandbox. For finer lifecycle control, set an explicit sandbox timeout and call `sandbox.kill()` when the task finishes.
+
+## Go SDK
+
+### Availability and installation
+
+The Go SDK is currently available as source code and requires Go 1.22 or later. Its `go.mod` still declares the legacy module path `github.com/e2b-dev/e2b-go-sdk`, which is no longer resolvable. Clone the SDK next to your Go project and replace the legacy module with the local directory.
+
+The following example assumes that your project is in `myapp/`:
+
+```bash
+# Run from the directory that contains myapp/.
+git clone https://github.com/aliyun-fc/e2b-go-sdk.git
+cd myapp
+go mod init myapp  # Skip this command if go.mod already exists.
+go mod edit -replace=github.com/e2b-dev/e2b-go-sdk=../e2b-go-sdk
+```
+
+Keep the legacy module path in imports because it matches the SDK's current `go.mod` declaration:
+
+```go
+import e2b "github.com/e2b-dev/e2b-go-sdk"
+```
+
+### Create and run a sandbox
+
+Save the following example as `main.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	e2b "github.com/e2b-dev/e2b-go-sdk"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := e2b.NewClient(
+		e2b.WithAPIKey(os.Getenv("E2B_API_KEY")),
+		e2b.WithAPIURL(os.Getenv("E2B_API_URL")),
+		e2b.WithDomain(os.Getenv("E2B_DOMAIN")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sandbox, err := client.CreateSandbox(
+		ctx,
+		e2b.WithTemplate("code-interpreter-v1"),
+		e2b.WithTimeout(900),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sandbox.Kill(context.Background())
+
+	result, err := sandbox.Commands.Run(
+		ctx,
+		"python3 -c \"print('hello from sandbox')\"",
+		e2b.WithCommandTimeout(60*time.Second),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(strings.TrimSpace(result.Stdout))
+}
+```
+
+Resolve the local replacement and run the example:
+
+```bash
+go mod tidy
+go run .
+```
+
+`defer sandbox.Kill(...)` releases the sandbox when the function exits. In production code, set an explicit timeout and release the sandbox when the task finishes.
+
+## Related documentation
+
+- Both SDKs implement the E2B data-plane protocol, but their interfaces and defaults differ from the Python and TypeScript SDKs. Check the version notes in each SDK repository before integrating.
+- For the full capability boundary, see [E2B SDK-compatible API List](01.E2B%20SDK-compatible%20API%20List.md).

--- a/docs/zh-CN/01.云沙箱/07.开发参考/05.E2B SDK（Java 与 Go）.md
+++ b/docs/zh-CN/01.云沙箱/07.开发参考/05.E2B SDK（Java 与 Go）.md
@@ -1,0 +1,182 @@
+# E2B SDK（Java 与 Go）
+
+E2B 官方目前只提供 Python 和 TypeScript SDK。为了方便 Java 和 Go 开发者接入云沙箱，阿里云函数计算团队在以下仓库维护了兼容 E2B 数据面协议的 SDK：
+
+- Java SDK：[aliyun-fc/e2b-java-sdk](https://github.com/aliyun-fc/e2b-java-sdk)
+- Go SDK：[aliyun-fc/e2b-go-sdk](https://github.com/aliyun-fc/e2b-go-sdk)
+
+本文先说明两个 SDK 共用的连接配置，再分别提供 Java 和 Go 快速入门。具体接口、参数名称和默认值以对应仓库的源码和类型定义为准。
+
+## 前置条件与通用连接配置
+
+- 已拥有阿里云账号，并具备函数计算相关操作权限。
+- 已在函数计算控制台[创建 API Key](../01.开始使用/02.创建%20API%20Key.md)。
+- 已确认目标地域支持云沙箱，并且本机网络可访问该地域的服务端点。
+
+通过环境变量传入 API Key、API URL 和域名，不要在代码中硬编码：
+
+```bash
+export E2B_API_KEY="<your-api-key>"
+export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+```
+
+将 `<region>` 替换为云沙箱所在地域。当前支持 `cn-beijing`、`cn-shanghai`、`cn-hangzhou`、`cn-shenzhen`、`cn-hongkong`、`ap-southeast-1`、`us-east-1` 和 `us-west-1`。API URL、域名、模板和 Sandbox 必须属于同一地域。
+
+## Java SDK
+
+### 可用状态与安装方式
+
+Java SDK 目前以源码形式提供。版本 `2.1.0` 尚未发布到 Maven Central 或其他公共 Maven 仓库，需要先克隆仓库并安装到本地 Maven 仓库：
+
+```bash
+git clone https://github.com/aliyun-fc/e2b-java-sdk.git
+cd e2b-java-sdk
+mvn clean install -DskipTests
+```
+
+Maven 项目添加以下依赖：
+
+```xml
+<dependency>
+    <groupId>com.alibaba.serverless</groupId>
+    <artifactId>e2b-java-sdk</artifactId>
+    <version>2.1.0</version>
+</dependency>
+```
+
+Gradle 项目需要先启用本地 Maven 仓库，再添加依赖：
+
+```groovy
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.alibaba.serverless:e2b-java-sdk:2.1.0'
+}
+```
+
+SDK 要求 Java 8 或更高版本，主要包如下：
+
+| 包 | 说明 |
+|----|------|
+| `dev.e2b.sdk` | `Sandbox` 入口类。 |
+| `dev.e2b.sdk.client` | `ConnectionConfig` 等连接配置。 |
+| `dev.e2b.sdk.model` | `CommandResult` 等数据模型。 |
+
+### 创建并运行 Sandbox
+
+```java
+import dev.e2b.sdk.Sandbox;
+import dev.e2b.sdk.client.ConnectionConfig;
+import dev.e2b.sdk.model.CommandResult;
+
+public class Quickstart {
+    public static void main(String[] args) throws Exception {
+        ConnectionConfig config = ConnectionConfig.builder()
+                .apiKey(System.getenv("E2B_API_KEY"))
+                .apiUrl(System.getenv("E2B_API_URL"))
+                .domain(System.getenv("E2B_DOMAIN"))
+                .build();
+
+        try (Sandbox sandbox = Sandbox.create("code-interpreter-v1", config)) {
+            CommandResult result = sandbox.getCommands().run(
+                    "python3 -c \"print('hello from sandbox')\""
+            );
+            System.out.println(result.getStdout().trim());
+        }
+    }
+}
+```
+
+`Sandbox` 实现了 `AutoCloseable`。退出 `try` 块时会调用 `kill()` 并释放 Sandbox。如需更细粒度的生命周期控制，请显式设置 Sandbox 超时时间，并在任务完成后调用 `sandbox.kill()`。
+
+## Go SDK
+
+### 可用状态与安装方式
+
+Go SDK 目前以源码形式提供，要求 Go 1.22 或更高版本。其 `go.mod` 仍声明旧模块路径 `github.com/e2b-dev/e2b-go-sdk`，但该路径已无法获取。请将 SDK 克隆到 Go 项目的同级目录，并将旧模块路径替换为本地目录。
+
+以下命令假设 Go 项目位于 `myapp/`：
+
+```bash
+# 在包含 myapp/ 的目录中执行。
+git clone https://github.com/aliyun-fc/e2b-go-sdk.git
+cd myapp
+go mod init myapp  # 如果已有 go.mod，请跳过此命令。
+go mod edit -replace=github.com/e2b-dev/e2b-go-sdk=../e2b-go-sdk
+```
+
+导入时继续使用旧模块路径，使其与 SDK 当前的 `go.mod` 声明一致：
+
+```go
+import e2b "github.com/e2b-dev/e2b-go-sdk"
+```
+
+### 创建并运行 Sandbox
+
+将以下示例保存为 `main.go`：
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	e2b "github.com/e2b-dev/e2b-go-sdk"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := e2b.NewClient(
+		e2b.WithAPIKey(os.Getenv("E2B_API_KEY")),
+		e2b.WithAPIURL(os.Getenv("E2B_API_URL")),
+		e2b.WithDomain(os.Getenv("E2B_DOMAIN")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sandbox, err := client.CreateSandbox(
+		ctx,
+		e2b.WithTemplate("code-interpreter-v1"),
+		e2b.WithTimeout(900),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sandbox.Kill(context.Background())
+
+	result, err := sandbox.Commands.Run(
+		ctx,
+		"python3 -c \"print('hello from sandbox')\"",
+		e2b.WithCommandTimeout(60*time.Second),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(strings.TrimSpace(result.Stdout))
+}
+```
+
+解析本地替换并运行示例：
+
+```bash
+go mod tidy
+go run .
+```
+
+`defer sandbox.Kill(...)` 会在函数退出时释放 Sandbox。生产代码应显式设置超时时间，并在任务完成后释放 Sandbox。
+
+## 相关文档
+
+- 两个 SDK 均实现 E2B 数据面协议，但接口和默认值与 Python、TypeScript SDK 不完全相同。接入前请查看对应 SDK 仓库的版本说明。
+- 完整能力边界参见 [E2B SDK 兼容 API 清单](./01.E2B%20SDK%20兼容%20API%20清单.md)。


### PR DESCRIPTION
Document source-based installation and minimal sandbox examples for both SDKs. Separate shared connection settings from the language-specific workflows.

## 变更说明

请说明本次修改涉及的产品、章节和问题。

## 变更类型

- [ ] 修正文档内容
- [ ] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [ ] 已运行 `make check`
- [ ] 已检查新增或修改的链接和图片
- [ ] 未提交真实凭证或敏感信息

## 相关 Issue

如有，请填写 Issue 链接。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 为函数计算云沙箱新增 Java 与 Go SDK 开发参考文档，覆盖连接配置、安装方式、快速入门示例、超时设置及 Sandbox 生命周期管理。

- 产品范围：云沙箱（FC Agent Sandbox）
- 章节范围：开发参考
- 页面变更：新增中文和英文各 1 个文档页面，共 2 个；未删除页面
- 图片资源：未新增或修改图片资源

<!-- end of auto-generated comment: release notes by coderabbit.ai -->