### PR TITLE
docs(sandbox): 使用 GitHub Actions 发布 Sandbox 模板

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/09.Publish a Sandbox Template with GitHub Actions.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/09.Publish a Sandbox Template with GitHub Actions.md
@@ -1,0 +1,117 @@
+# Publish a Sandbox Template with GitHub Actions
+
+FC Agent Sandbox provides an official GitHub template repository, [aliyun-fc/fce2b-template-builder](https://github.com/aliyun-fc/fce2b-template-builder). After you create your own repository from this template, you only need to maintain a `Dockerfile`. GitHub Actions automatically builds a `linux/amd64` image and pushes it to your private GHCR package, builds a Sandbox template from that image, creates a Sandbox to run a smoke test, and finally outputs a ready-to-use Template ID.
+
+[Build a Sandbox Template from a GHCR Custom Image](./07.Build%20a%20Sandbox%20Template%20from%20a%20GHCR%20Custom%20Image.md) requires you to push the image to GHCR yourself and then call the SDK to build the template. This document integrates template publishing into GitHub Actions, which fits scenarios where you want to manage the template definition in Git and publish a new template version with every code commit.
+
+## Use cases
+
+- The template definition (Dockerfile and dependencies) is version-controlled together with your business code, and every commit automatically publishes a new template version.
+- Team members do not need to install Docker or the SDK locally; publishing is done by committing code or by a manual trigger on GitHub.
+- Images are stored in a private GHCR package that cannot be pulled anonymously, and all build artifacts are governed by your own GitHub account.
+
+## Supported regions
+
+| Region | Region ID |
+| --- | --- |
+| China (Hong Kong) | `cn-hongkong` |
+| Singapore | `ap-southeast-1` |
+| US (Virginia) | `us-east-1` |
+| US (Silicon Valley) | `us-west-1` |
+
+API Keys are isolated per region, and each publish targets a single region.
+
+## Prerequisites
+
+- FC Agent Sandbox is enabled, and you have the API Key for the target region.
+- You have a GitHub account with permission to create repositories.
+
+## Step 1: Create your repository
+
+On the [aliyun-fc/fce2b-template-builder](https://github.com/aliyun-fc/fce2b-template-builder) repository page, click **Use this template** in the upper-right corner and select **Create a new repository**.
+
+After the repository is created, modify the `Dockerfile` in the root directory as needed. Before you commit, make sure the Dockerfile can build a `linux/amd64` image.
+
+## Step 2: Create a GitHub token
+
+Create a GitHub Personal Access Token (classic) with the following scopes:
+
+- `read:packages`
+- `write:packages`
+
+The user that owns the token must have read and write access to the repository and its private GHCR package. If the organization has SSO enabled, you must also authorize the token for the organization.
+
+## Step 3: Configure GitHub Actions credentials
+
+Go to **Settings → Secrets and variables → Actions** of your repository.
+
+Add the following **Secrets**:
+
+| Name | Description |
+| --- | --- |
+| `FCE2B_API_KEY` | The FC Agent Sandbox API Key for the target region. |
+| `GHCR_TOKEN` | The GitHub token created in the previous step. |
+
+Add the following **Variables**:
+
+| Name | Example | Description |
+| --- | --- | --- |
+| `FCE2B_REGION` | `us-west-1` | The target region where the template is created. |
+
+When you change `FCE2B_REGION`, you must also replace `FCE2B_API_KEY` with the API Key of that region.
+
+## Step 4: Publish the template
+
+Trigger a publish in either of the following ways:
+
+- Modify and commit the `Dockerfile`, dependency files, or files under the `landing` directory to the `master` branch;
+- Go to **Actions → Build fce2b template → Run workflow** and trigger it manually.
+
+A full run usually takes about 1 to 3 minutes, depending on the region and the image size.
+
+## Step 5: Get the result
+
+After a successful run, check the corresponding GitHub Actions run:
+
+- **Summary**: the Template ID, Build ID, Sandbox ID, image address, and verification result;
+- **Artifacts → landing-result**: download the complete `landing.json`.
+
+Save the Template ID. You can then use the E2B SDK to create Sandboxes from this template.
+
+## Update the template
+
+After you modify the Dockerfile or dependencies, trigger the workflow again. Every successful publish generates a new Template ID and never overwrites previous templates; to roll back, keep using the old Template ID.
+
+You can also publish a versioned image with a Git tag:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+Pushing the tag automatically builds a `linux/amd64` image and publishes it to:
+
+```text
+ghcr.io/<owner>/<repository>:v1.0.0
+```
+
+A version tag does not overwrite `latest`. To publish a new version, create a new Git tag.
+
+## Credential maintenance
+
+- Do not write `FCE2B_API_KEY` or `GHCR_TOKEN` into repository files, the Dockerfile, or Action logs.
+- Keep `GHCR_TOKEN` valid so that FC Agent Sandbox can continue to pull your private GHCR image.
+- After rotating the token, update `GHCR_TOKEN` and publish the template again.
+- After rotating the API Key or switching regions, update `FCE2B_API_KEY` and publish the template again.
+
+## FAQ
+
+- **GHCR login or push returns 401/403**: Check that `GHCR_TOKEN` has the `read:packages` and `write:packages` scopes, and that the token owner can access the repository. If the repository belongs to an organization, also check SSO authorization.
+- **The API Key is rejected**: Check that the API Key is valid for the target region and matches `FCE2B_REGION`.
+- **The workflow does not run automatically**: Automatic triggers only watch Dockerfile, dependency, workflow, and `landing` files on the `master` branch. You can also run it manually from the Actions page.
+- **The template is created but the image cannot be pulled later**: Check that the GHCR package stays private, that `GHCR_TOKEN` has not expired, and that the token owner still has read access to the package; then update the token and publish the template again.
+
+## Related features
+
+- [Build a Sandbox Template from a GHCR Custom Image](./07.Build%20a%20Sandbox%20Template%20from%20a%20GHCR%20Custom%20Image.md)
+- [Build Custom Image Templates](../04.Features/02.Templates/03.Build%20Custom%20Image%20Templates.md)

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/09.使用 GitHub Actions 发布 Sandbox 模板.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/09.使用 GitHub Actions 发布 Sandbox 模板.md
@@ -1,0 +1,117 @@
+# 使用 GitHub Actions 发布 Sandbox 模板
+
+云沙箱提供了官方 GitHub 模板仓库 [aliyun-fc/fce2b-template-builder](https://github.com/aliyun-fc/fce2b-template-builder)。从该模板创建自己的仓库后，只需要维护一个 `Dockerfile`，GitHub Actions 会自动完成：构建 `linux/amd64` 镜像并推送到你仓库的私有 GHCR、从该镜像构建 Sandbox 模板、创建 Sandbox 做冒烟校验，最后输出可直接使用的 Template ID。
+
+与[使用 GHCR 自定义镜像构建 Sandbox 模板](./07.使用%20GHCR%20自定义镜像构建%20Sandbox%20模板.md)相比，后者需要自己把镜像推送到 GHCR 再调用 SDK 构建模板；本文的方式把模板发布集成进 GitHub Actions，适合希望把模板定义纳入 Git 流程、随代码提交自动发布新模板版本的场景。
+
+## 业务场景
+
+- 模板定义（Dockerfile 和依赖）与业务代码一起版本化管理，每次提交自动发布新的模板版本。
+- 团队成员不需要在本地安装 Docker 或 SDK，通过提交代码或在 GitHub 上手工触发即可完成发布。
+- 镜像保存在私有 GHCR 仓库，不允许匿名拉取，构建产物由自己的 GitHub 账号管控。
+
+## 支持的地域
+
+| 地域 | Region |
+| --- | --- |
+| 中国香港 | `cn-hongkong` |
+| 新加坡 | `ap-southeast-1` |
+| 美国（弗吉尼亚） | `us-east-1` |
+| 美国（硅谷） | `us-west-1` |
+
+API Key 按地域隔离，一次发布只面向一个地域。
+
+## 前置条件
+
+- 已开通云沙箱，并获取目标地域的 API Key。
+- 拥有 GitHub 账号，且具备创建仓库的权限。
+
+## 步骤一：创建自己的仓库
+
+在 [aliyun-fc/fce2b-template-builder](https://github.com/aliyun-fc/fce2b-template-builder) 仓库页面右上角点击 **Use this template**，选择 **Create a new repository**。
+
+创建仓库后，根据需要修改根目录的 `Dockerfile`。提交代码前，请确保 Dockerfile 可以构建 `linux/amd64` 镜像。
+
+## 步骤二：创建 GitHub Token
+
+创建一个 GitHub Personal Access Token (classic)，并授予以下权限：
+
+- `read:packages`
+- `write:packages`
+
+Token 所属用户必须对当前仓库及其 private GHCR package 具有读写权限。如果组织启用了 SSO，还需要为该 Token 完成组织授权。
+
+## 步骤三：配置 GitHub Actions 凭据
+
+进入仓库的 **Settings → Secrets and variables → Actions**。
+
+在 **Secrets** 中添加：
+
+| 名称 | 说明 |
+| --- | --- |
+| `FCE2B_API_KEY` | 目标地域的云沙箱 API Key。 |
+| `GHCR_TOKEN` | 上一步创建的 GitHub Token。 |
+
+在 **Variables** 中添加：
+
+| 名称 | 示例 | 说明 |
+| --- | --- | --- |
+| `FCE2B_REGION` | `us-west-1` | 创建模板的目标地域。 |
+
+修改 `FCE2B_REGION` 时，必须同时把 `FCE2B_API_KEY` 替换为该地域的 API Key。
+
+## 步骤四：发布模板
+
+使用以下任一方式触发发布：
+
+- 修改并提交 `Dockerfile`、依赖文件或 `landing` 目录中的文件到 `master` 分支；
+- 进入 **Actions → Build fce2b template → Run workflow** 手工触发。
+
+一次完整执行通常需要约 1～3 分钟，实际时间取决于地域和镜像大小。
+
+## 步骤五：获取发布结果
+
+执行成功后，在对应的 GitHub Actions run 中查看：
+
+- **Summary**：Template ID、Build ID、Sandbox ID、镜像地址和验证结果；
+- **Artifacts → landing-result**：下载完整的 `landing.json`。
+
+保存输出的 Template ID，后续即可使用 E2B SDK 通过该模板创建 Sandbox。
+
+## 更新模板
+
+修改 Dockerfile 或依赖后重新触发 workflow。每次成功发布都会生成新的 Template ID，不会覆盖之前的模板；需要回滚时继续使用旧的 Template ID 即可。
+
+也可以通过 Git tag 发布带版本号的镜像：
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+tag 推送后会自动构建 `linux/amd64` 镜像并发布到：
+
+```text
+ghcr.io/<owner>/<repository>:v1.0.0
+```
+
+版本 tag 不会同时覆盖 `latest`。如需发布新版本，请创建新的 Git tag。
+
+## 凭据维护
+
+- 不要把 `FCE2B_API_KEY` 或 `GHCR_TOKEN` 写入仓库文件、Dockerfile 或 Action 日志。
+- `GHCR_TOKEN` 必须保持有效，确保云沙箱能够继续读取你的私有 GHCR 镜像。
+- Token 轮换后，更新 `GHCR_TOKEN` 并重新发布模板。
+- API Key 轮换或切换地域后，更新 `FCE2B_API_KEY` 并重新发布模板。
+
+## 常见问题
+
+- **GHCR 登录或推送返回 401/403**：检查 `GHCR_TOKEN` 是否具有 `read:packages`、`write:packages` 权限，以及 Token 所属用户是否能访问当前仓库。如果仓库属于组织，还需检查 SSO 授权。
+- **API Key 被拒绝**：检查 API Key 是否为目标地域的有效 Key，并确认它与 `FCE2B_REGION` 对应。
+- **workflow 没有自动运行**：自动触发仅监听 `master` 分支中的 Dockerfile、依赖、workflow 和 `landing` 相关文件，也可以在 Actions 页面手工运行。
+- **模板创建成功但后续无法拉取镜像**：检查 GHCR package 是否保持 private、`GHCR_TOKEN` 是否过期，以及 Token 所属用户是否仍有 package 读取权限；更新 Token 后重新发布模板。
+
+## 相关功能
+
+- [使用 GHCR 自定义镜像构建 Sandbox 模板](./07.使用%20GHCR%20自定义镜像构建%20Sandbox%20模板.md)
+- [构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)


### PR DESCRIPTION
## Summary

- 新增中英文最佳实践《使用 GitHub Actions 发布 Sandbox 模板》/《Publish a Sandbox Template with GitHub Actions》（`05.最佳实践/09`），介绍官方 GitHub 模板仓库 `aliyun-fc/fce2b-template-builder`：用户 `Use this template` 创建仓库后只维护 Dockerfile，GitHub Actions 自动完成私有 GHCR 推送、Template Build、Sandbox 冒烟验证并输出 Template ID。
- 内容覆盖支持地域、GitHub Token 与 Actions Secrets/Variables 配置、发布与结果获取、Git tag 版本化镜像、凭据维护和常见问题；与既有《使用 GHCR 自定义镜像构建 Sandbox 模板》互链，职责不重复。

## 验证

- `python3 scripts/prepare-mkdocs.py` 通过，新页面已进入生成 nav。
- `mkdocs build -f mkdocs.generated.yml` 通过。
- 新文件 fence 闭合、相对链接无断链；未使用 `@props` 条件标记，不影响国际站格式。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 文档范围

- 产品：FC Agent Sandbox。
- 章节：中英文“最佳实践”章节。
- 新增页面：
  - 中文：《使用 GitHub Actions 发布 Sandbox 模板》
  - 英文：《Publish a Sandbox Template with GitHub Actions》
- 页面内容包括 GitHub Actions 发布流程、私有 GHCR 镜像推送、Template Build、Sandbox 冒烟验证、Template ID 获取、版本管理、凭据维护和常见问题。
- 未删除页面。
- 未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->