### PR TITLE
docs(browser): 补充窗口与屏幕尺寸环境变量说明

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/01.Browser Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/01.Browser Template.md
@@ -244,7 +244,7 @@ Since browser image v0.0.37, the browser window and virtual screen size are cont
 | `BROWSER_WINDOW_SIZE` | Chrome startup window size (`--window-size`) | Width and height from `RESOLUTION` |
 | `VNC_CLIP` | Clipping area of the VNC live stream | Same as the window size |
 
-The `envs` parameter of `Sandbox.create` is only injected into command-execution processes inside the sandbox and does not affect the browser stack; template builds also do not support Dockerfile steps. To change the window size, bake the environment variables into a custom image with a Dockerfile, push it to an image registry, and then build the template with `from_image`:
+The `envs` parameter of `Sandbox.create` is only injected into command-execution processes inside the sandbox and does not affect the browser stack. To change the window size, bake the environment variables into a custom image with a Dockerfile, push it to an image registry, and then build the template with `from_image`:
 
 ```dockerfile
 FROM fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.39

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/01.Browser Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/01.Browser Template.md
@@ -234,6 +234,28 @@ After returning `101 Switching Protocols`, the server continues sending WebSocke
 
 > **Note**: The browser WebSocket API cannot set custom headers during the handshake, so pure-browser clients such as noVNC cannot send `X-Access-Token` and will receive `403` on a direct connection. Use a WebSocket client that supports custom headers (such as `wscat` or Python `websockets`) to send `X-Access-Token` and complete the RFB handshake. If you only need to view the result, connect over CDP and call `page.screenshot()`.
 
+## Window and screen size
+
+Since browser image v0.0.37, the browser window and virtual screen size are controlled by three environment variables in the image:
+
+| **Environment variable** | **Purpose** | **Default** |
+| --- | --- | --- |
+| `RESOLUTION` | Xvfb virtual screen resolution (WxHxdepth) | `1680x1050x24` |
+| `BROWSER_WINDOW_SIZE` | Chrome startup window size (`--window-size`) | Width and height from `RESOLUTION` |
+| `VNC_CLIP` | Clipping area of the VNC live stream | Same as the window size |
+
+The `envs` parameter of `Sandbox.create` is only injected into command-execution processes inside the sandbox and does not affect the browser stack; template builds also do not support Dockerfile steps. To change the window size, bake the environment variables into a custom image with a Dockerfile, push it to an image registry, and then build the template with `from_image`:
+
+```dockerfile
+FROM fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.39
+
+ENV RESOLUTION=1920x1080x24
+ENV BROWSER_WINDOW_SIZE=1920x1080
+ENV VNC_CLIP=1920x1080
+```
+
+Then replace `FROM_IMAGE` with this custom image address when building the template; for other regions, replace the region in the image address with your sandbox region. The window size also determines the VNC live-stream area; the in-page viewport is still set by the client (Puppeteer, Playwright, and so on) over CDP.
+
 ## Limitations
 
 | **Item** | **Constraint** |

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/01.browser-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/01.browser-模板.md
@@ -234,6 +234,28 @@ curl -sS -m 4 -i \
 
 > **说明**：浏览器 WebSocket API 不支持在握手时设置自定义请求头，因此 noVNC 等纯浏览器客户端无法携带 `X-Access-Token`，直接连接会返回 `403`。需使用支持自定义请求头的 WebSocket 客户端（如 `wscat`、Python `websockets`）携带 `X-Access-Token` 完成 RFB 握手。如果只需查看结果，可通过 CDP 连接后调用 `page.screenshot()` 截图。
 
+## 窗口与屏幕尺寸
+
+browser 镜像 v0.0.37 起，浏览器窗口与虚拟屏幕尺寸由镜像中的三个环境变量控制：
+
+| **环境变量** | **作用** | **默认值** |
+| --- | --- | --- |
+| `RESOLUTION` | Xvfb 虚拟屏幕分辨率（宽x高x色深） | `1680x1050x24` |
+| `BROWSER_WINDOW_SIZE` | Chrome 启动窗口大小（`--window-size`） | 取 `RESOLUTION` 的宽高 |
+| `VNC_CLIP` | VNC 实时流的画面裁剪区域 | 与窗口大小一致 |
+
+`Sandbox.create` 的 `envs` 参数只注入沙箱内的命令执行进程，不会影响浏览器栈；模板构建也不支持 Dockerfile 步骤。因此调整窗口尺寸需要先用 Dockerfile 把环境变量烤进自定义镜像，推送到镜像仓库后再通过 `from_image` 构建模板：
+
+```dockerfile
+FROM fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.39
+
+ENV RESOLUTION=1920x1080x24
+ENV BROWSER_WINDOW_SIZE=1920x1080
+ENV VNC_CLIP=1920x1080
+```
+
+构建模板时将 `FROM_IMAGE` 替换为该自定义镜像地址即可，其他地域请将镜像地址中的地域替换为云沙箱接入地域。窗口尺寸同时决定 VNC 实时流的画面范围；页面内视口仍由 Puppeteer、Playwright 等客户端通过 CDP 自行设置。
+
 ## 使用限制
 
 | **限制项** | **约束** |

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/01.browser-模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/01.browser-模板.md
@@ -244,7 +244,7 @@ browser 镜像 v0.0.37 起，浏览器窗口与虚拟屏幕尺寸由镜像中的
 | `BROWSER_WINDOW_SIZE` | Chrome 启动窗口大小（`--window-size`） | 取 `RESOLUTION` 的宽高 |
 | `VNC_CLIP` | VNC 实时流的画面裁剪区域 | 与窗口大小一致 |
 
-`Sandbox.create` 的 `envs` 参数只注入沙箱内的命令执行进程，不会影响浏览器栈；模板构建也不支持 Dockerfile 步骤。因此调整窗口尺寸需要先用 Dockerfile 把环境变量烤进自定义镜像，推送到镜像仓库后再通过 `from_image` 构建模板：
+`Sandbox.create` 的 `envs` 参数只注入沙箱内的命令执行进程，不会影响浏览器栈。因此调整窗口尺寸需要先用 Dockerfile 把环境变量烤进自定义镜像，推送到镜像仓库后再通过 `from_image` 构建模板：
 
 ```dockerfile
 FROM fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/browser:v0.0.39


### PR DESCRIPTION
## Summary

- browser 模板文档（中英文）各新增「窗口与屏幕尺寸 / Window and screen size」章节
- 说明 browser 镜像 v0.0.37 起支持 `RESOLUTION`（Xvfb 虚拟屏，默认 1680x1050x24）、`BROWSER_WINDOW_SIZE`（Chrome --window-size，默认取 RESOLUTION 宽高）、`VNC_CLIP`（VNC 画面裁剪，默认同窗口）三个环境变量
- 说明 `Sandbox.create` 的 envs 不影响浏览器栈，需将变量烤进自定义镜像后通过 from_image 构建模板，并给出 1920x1080 的 Dockerfile 示例

## 验证

- 杭州生产（149）实测：默认 browser:v0.0.42 窗口 1680x1050；烤入三个 ENV 的自制镜像 Chrome `--window-size=1920x1080`、Xvfb `screen 0 1920x1080x24`、VNC `clip 1920x1080`、页面 screen 1920x1080，全部生效
- e2b-runtime 源码核对：三个变量自 v0.0.37（commit 900a9b8）引入 start-browsertool.sh，v0.0.39/v0.0.42 行为一致
- `make build`（mkdocs --strict）通过

## Test plan

- [ ] 评审确认章节位置与措辞
- [ ] 确认默认镜像版本（文档当前 v0.0.39）与该说明匹配

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 更新函数计算云沙箱的 browser 模板文档，涉及中文和英文两个版本：

- 中文文档：`01.browser-模板.md`
- 英文文档：`01.Browser Template.md`
- 章节范围：模板 > 其他模板 > Browser 模板
- 新增“窗口与屏幕尺寸 / Window and screen size”章节。
- 说明 `RESOLUTION`、`BROWSER_WINDOW_SIZE` 和 `VNC_CLIP` 的用途及默认值。
- 说明 `Sandbox.create` 的 `envs` 不影响浏览器栈。
- 补充通过 Dockerfile 构建自定义镜像，并使用 `from_image` 构建模板的示例。
- 说明浏览器窗口尺寸与 VNC 区域、CDP 页面视口之间的关系。

本次改动未新增页面，未删除页面，也未修改图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->