### PR TITLE
docs(sandbox): pin E2B SDK versions

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/05.Network Access Control.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/05.Network Access Control.md
@@ -29,7 +29,7 @@ export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
 TypeScript (save the example as `demo.ts`):
 
 ```bash
-npm install e2b
+npm install e2b@^2.31.0
 npx tsx demo.ts
 ```
 
@@ -37,11 +37,11 @@ Python (save the example as `demo.py`, **requires Python ≥ 3.10**):
 
 ```bash
 python3 --version        # confirm ≥ 3.10
-pip install "e2b>=2.11" httpx   # httpx is only used by the public auth example
+pip install e2b==2.31.0 httpx   # httpx is only used by the public auth example
 python demo.py
 ```
 
-> **Note**: Runtime updates (`update_network` / `updateNetwork`) require the Python SDK ≥ 2.11, and SDK ≥ 2.11 requires Python ≥ 3.10. Running `pip install e2b` on Python 3.9 will only install the last compatible version (2.10.x), and calling `update_network` will raise `AttributeError: 'Sandbox' object has no attribute 'update_network'`. In that case, upgrade to Python ≥ 3.10 and reinstall, or use the REST endpoint `PUT /sandboxes/{id}/network`.
+> **Note**: Runtime updates (`update_network` / `updateNetwork`) require the Python SDK ≥ 2.11, and SDK ≥ 2.11 requires Python ≥ 3.10. Installing `e2b` without a version pin on Python 3.9 will only install the last compatible version (2.10.x), and calling `update_network` will raise `AttributeError: 'Sandbox' object has no attribute 'update_network'`. In that case, upgrade to Python ≥ 3.10 and reinstall, or use the REST endpoint `PUT /sandboxes/{id}/network`.
 
 ## Parameter Overview
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/07.Build a Sandbox Template from a GHCR Custom Image.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/07.Build a Sandbox Template from a GHCR Custom Image.md
@@ -22,7 +22,7 @@ This document uses a private image on [GitHub Container Registry (GHCR)](https:/
 - Install the `e2b` SDK:
 
 ```bash
-pip install e2b
+pip install e2b==2.31.0
 ```
 
 ## Registry credentials

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/08.Use Traefik for Canary Traffic Routing.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/08.Use Traefik for Canary Traffic Routing.md
@@ -31,7 +31,7 @@ The Sandbox exposes only **Traefik's entry port** to the outside; Traefik forwar
 - Install the cloud Sandbox Python SDK and an HTTP client, and set the connection parameters as environment variables:
 
   ```bash
-  pip install e2b httpx
+  pip install e2b==2.31.0 httpx
 
   export E2B_API_KEY="<your-e2b-api-key>"
   export E2B_DOMAIN="us-west-1.e2b.fc.aliyuncs.com"

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/05.网络访问控制.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/05.网络访问控制.md
@@ -29,7 +29,7 @@ export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
 TypeScript（将示例保存为 `demo.ts`）：
 
 ```bash
-npm install e2b
+npm install e2b@^2.31.0
 npx tsx demo.ts
 ```
 
@@ -37,11 +37,11 @@ Python（将示例保存为 `demo.py`，**要求 Python ≥ 3.10**）：
 
 ```bash
 python3 --version        # 确认 ≥ 3.10
-pip install "e2b>=2.11" httpx   # httpx 仅公网鉴权示例用到
+pip install e2b==2.31.0 httpx   # httpx 仅公网鉴权示例用到
 python demo.py
 ```
 
-> **注意**：运行时更新（`update_network` / `updateNetwork`）需 Python SDK ≥ 2.11，而 SDK ≥ 2.11 要求 Python ≥ 3.10。在 Python 3.9 上执行 `pip install e2b` 只会装到最后一个兼容版本（2.10.x），调用 `update_network` 会报 `AttributeError: 'Sandbox' object has no attribute 'update_network'`。此时请升级到 Python ≥ 3.10 后重装，或改用 REST `PUT /sandboxes/{id}/network`。
+> **注意**：运行时更新（`update_network` / `updateNetwork`）需 Python SDK ≥ 2.11，而 SDK ≥ 2.11 要求 Python ≥ 3.10。在 Python 3.9 上不指定版本安装 `e2b` 时，只会装到最后一个兼容版本（2.10.x），调用 `update_network` 会报 `AttributeError: 'Sandbox' object has no attribute 'update_network'`。此时请升级到 Python ≥ 3.10 后重装，或改用 REST `PUT /sandboxes/{id}/network`。
 
 ## 参数总览
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/07.使用 GHCR 自定义镜像构建 Sandbox 模板.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/07.使用 GHCR 自定义镜像构建 Sandbox 模板.md
@@ -22,7 +22,7 @@
 - 安装 `e2b` SDK：
 
 ```bash
-pip install e2b
+pip install e2b==2.31.0
 ```
 
 ## 镜像仓库凭据

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/08.使用 Traefik 做服务流量灰度转发.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/08.使用 Traefik 做服务流量灰度转发.md
@@ -32,7 +32,7 @@
 - 安装云沙箱 Python SDK 及 HTTP 客户端，并将连接参数设置为环境变量：
 
   ```bash
-  pip install e2b httpx
+  pip install e2b==2.31.0 httpx
 
   export E2B_API_KEY="<your-e2b-api-key>"
   export E2B_DOMAIN="us-west-1.e2b.fc.aliyuncs.com"


### PR DESCRIPTION
Align Python and Node.js installation examples across the Chinese and English documentation with the supported SDK versions.

## 变更说明

请说明本次修改涉及的产品、章节和问题。

## 变更类型

- [ ] 修正文档内容
- [ ] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [ ] 已运行 `make check`
- [ ] 已检查新增或修改的链接和图片
- [ ] 未提交真实凭证或敏感信息

## 相关 Issue

如有，请填写 Issue 链接。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR 摘要

- **产品范围**：FC Agent Sandbox。
- **文档范围**：
  - 网络访问控制。
  - 使用 GHCR 自定义镜像构建 Sandbox 模板。
  - 使用 Traefik 做服务流量灰度转发。
  - 以上章节同时涉及英文文档和中文文档。
- **主要改动**：
  - 将 TypeScript SDK 固定为 `e2b@^2.31.0`。
  - 将 Python SDK 固定为 `e2b==2.31.0`。
  - 补充 Python 3.9 使用未指定版本安装命令时的兼容性说明。
  - 保留升级 Python、重新安装 SDK 或使用 REST API 的处理建议。
  - 在相关示例中保留 `httpx` 依赖及用途说明。
- **页面和资源**：
  - 未新增页面。
  - 未删除页面。
  - 未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->