### PR TITLE
docs(sandbox): 自定义镜像模板补充镜像加速硬性约束

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -16,6 +16,7 @@ Recommended base images: Ubuntu 20.04, Debian 12 (bookworm) or later (recommende
 | Level | Requirement | Impact if not met |
 | --- | --- | --- |
 | Required | Architecture is `linux/amd64`; for multi-arch images, the manifest list must include the `linux/amd64` variant | Template conversion fails immediately |
+| Required | The image does not have image acceleration enabled | Template conversion fails immediately |
 | Conditional | Fixed path `/bin/bash` exists in the image (not merely resolvable through PATH) | `commands.run` and PTY fail |
 | Required | `/etc/passwd` and `/etc/group` are standard files and writable | gatewayd cannot initialize the default user; container startup fails |
 | Conditional | `python3` or `python` is available in PATH | Python `run_code` is unavailable |

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -16,7 +16,7 @@ Recommended base images: Ubuntu 20.04, Debian 12 (bookworm) or later (recommende
 | Level | Requirement | Impact if not met |
 | --- | --- | --- |
 | Required | Architecture is `linux/amd64`; for multi-arch images, the manifest list must include the `linux/amd64` variant | Template conversion fails immediately |
-| Required | The image does not have image acceleration enabled | Template conversion fails immediately |
+| Required | ACR images should not have the image acceleration option enabled | Template conversion fails immediately |
 | Conditional | Fixed path `/bin/bash` exists in the image (not merely resolvable through PATH) | `commands.run` and PTY fail |
 | Required | `/etc/passwd` and `/etc/group` are standard files and writable | gatewayd cannot initialize the default user; container startup fails |
 | Conditional | `python3` or `python` is available in PATH | Python `run_code` is unavailable |

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
@@ -16,7 +16,7 @@
 | 级别 | 要求 | 不满足时影响 |
 | --- | --- | --- |
 | 硬性 | 架构为 `linux/amd64`；若为多架构镜像，其 manifest 列表必须包含 `linux/amd64` 变体 | Template 转换直接失败 |
-| 硬性 | 镜像未选中（未开启）镜像加速功能 | Template 转换直接失败 |
+| 硬性 | ACR 镜像不应开启镜像加速选项 | Template 转换直接失败 |
 | 条件 | 镜像内存在固定路径 `/bin/bash`（不仅是 PATH 中可找到 Bash） | `commands.run`、PTY 失败 |
 | 硬性 | `/etc/passwd`、`/etc/group` 为标准文件且可写 | gatewayd 无法初始化默认用户，容器启动失败 |
 | 条件 | PATH 中存在 `python3` 或 `python` | Python `run_code` 不可用 |

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
@@ -16,6 +16,7 @@
 | 级别 | 要求 | 不满足时影响 |
 | --- | --- | --- |
 | 硬性 | 架构为 `linux/amd64`；若为多架构镜像，其 manifest 列表必须包含 `linux/amd64` 变体 | Template 转换直接失败 |
+| 硬性 | 镜像未选中（未开启）镜像加速功能 | Template 转换直接失败 |
 | 条件 | 镜像内存在固定路径 `/bin/bash`（不仅是 PATH 中可找到 Bash） | `commands.run`、PTY 失败 |
 | 硬性 | `/etc/passwd`、`/etc/group` 为标准文件且可写 | gatewayd 无法初始化默认用户，容器启动失败 |
 | 条件 | PATH 中存在 `python3` 或 `python` | Python `run_code` 不可用 |


### PR DESCRIPTION
## Summary
- 中英文《构建自定义镜像模板》的镜像要求表新增一行硬性约束：镜像未选中（未开启）镜像加速功能，不满足时 Template 转换直接失败。

## Test plan
- [x] 中英文表格行一致
- [ ] Pages 构建通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 文档范围

- **产品**：FC Agent Sandbox（云沙箱）。
- **章节**：功能说明 > 模板 > 构建自定义镜像模板。
- **语言版本**：中文和英文文档。
- **改动内容**：在镜像要求表中新增约束：ACR 镜像不应开启镜像加速选项，否则 Template 转换将直接失败。
- **页面与资源**：未新增或删除页面。未修改图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->