### PR TITLE
docs: 英文 envd 教程对齐中文权威版本

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/10.envd Integration Tutorial - Turn Your Own Image into an e2b Sandbox Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/10.envd Integration Tutorial - Turn Your Own Image into an e2b Sandbox Template.md
@@ -102,7 +102,7 @@ flowchart TD
     C2 -->|No| F2["Sandbox can be created<br/>but envd requests return nginx 404"]
     C2 -->|Yes| C3{"③ Is envd running and listening on 49983?"}
     C3 -->|No| F3["Requests pass through nginx<br/>then 502 / connection refused"]
-    C3 -->|Yes| OK["✅ SDK methods are usable"]
+    C3 -->|Yes| OK["✅ envd reachable, SDK transport works"]
 
     style OK stroke-width:3px
 ```
@@ -111,6 +111,8 @@ Of the three conditions, **only ③ is what this tutorial adds**; ① and ② de
 
 - Built on AgentRun's official `sandbox-all-in-one` series: ① and ② are usually already satisfied
 - Using **your own image**: ① and ② are likely both missing, so you need to add an nginx/openresty layer yourself; see [Section 6](#porting)
+
+> These three conditions get envd **reachable**; they do not by themselves make every `commands.run` succeed. If the SDK call omits `user=`, it drops privileges to a default `user` account (uid 1000) that must exist in the image—a fourth condition, orthogonal to the three above: all three can be green and a call still fails with `unknown user`. Official images ship this account; custom images usually have to add it. See [Section 6.1 ③](#porting).
 
 ---
 
@@ -412,8 +414,8 @@ flowchart LR
 ```mermaid
 flowchart TD
     A["Your image"] --> B{"Does it have process-compose?"}
-    B -->|Yes| B1["Add process-compose.envd.yaml<br/>fork entrypoint, add one line"]
-    B -->|"No<br/>(custom entrypoint)"| B2["supervisord manages envd<br/>autorestart=true"]
+    B -->|Yes| B1["Add process-compose.envd.yaml<br/>register via existing startup<br/>(official image: fork entrypoint)"]
+    B -->|"No<br/>(custom entrypoint)"| B2["supervisord manages envd<br/>autorestart=true + startretries huge"]
     B1 --> C{"Is a process listening on 5000?"}
     B2 --> C
     C -->|Has nginx/openresty| C1{"Does it do multi-port forwarding?"}
@@ -458,7 +460,7 @@ An image built from scratch (the sample uses `debian:bookworm-slim`) means addin
 | What to add | The one thing you must remember | Full config |
 |---|---|---|
 | **① Keep envd resident**<br/>supervisord instead of process-compose | If envd dies, all sandbox SDK capabilities are lost. `autorestart=true` **is not enough**: supervisord defaults to `startretries=3`, so after 3 rapid failures it enters **FATAL and never restarts again** → "fine for the first few minutes, then all SDK calls 502". You must raise `startretries` to a huge value | [`supervisor-envd.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/supervisor-envd.conf) · [`supervisord.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/supervisord.conf) |
-| **② Multi-port reverse proxy on 5000**<br/>install openresty yourself | Must be openresty, not nginx (multi-port routing needs `rewrite_by_lua`, and Debian's `nginx` package has no lua). It also needs `rewrite_by_lua_no_postpone on;`, otherwise envd's `/health` gets answered by your own `location = /health` | [`nginx.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx.conf) · [`nginx-multiport-http.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-http.conf) · [`nginx-multiport-routes.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-routes.conf) |
+| **② Multi-port reverse proxy on 5000**<br/>install openresty yourself | You need nginx **with a Lua module**—multi-port routing relies on `rewrite_by_lua`. The example uses openresty; on Debian you can instead add [`libnginx-mod-http-lua`](https://packages.debian.org/bookworm/libnginx-mod-http-lua) to stock nginx. Either way, set `rewrite_by_lua_no_postpone on;`, or envd's `/health` gets answered by your own `location = /health` | [`nginx.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx.conf) · [`nginx-multiport-http.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-http.conf) · [`nginx-multiport-routes.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-routes.conf) |
 | **③ SDK default user `user`**<br/>the 4th condition beyond the three in [2.3](#three-conditions) | Without `user=`, every `commands.run` drops privileges to the `user` account; without that account → `AuthenticationException: unknown user`. Yet the sandbox is created, envd is running, and `/health` returns 204 — all three necessary conditions green, making this the easiest to misdiagnose | [`Dockerfile`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/Dockerfile) (`useradd --uid 1000`) |
 | **④ China-region build + runtime guardrails** | Four "builds fine, blows up only at runtime" traps: `deb.debian.org` unreachable in China, `python3-minimal` missing stdlib keeps the business port at 502 forever, slim has no `ss`, and bookworm mirror swaps must use deb822. General fix: for anything like this, add an assertion into `RUN` | [`Dockerfile`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/Dockerfile) |
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/10.envd Integration Tutorial - Turn Your Own Image into an e2b Sandbox Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/10.envd Integration Tutorial - Turn Your Own Image into an e2b Sandbox Template.md
@@ -3,7 +3,7 @@
 This guide uses the `sandbox-all-in-one` image in AgentRun as an example to walk through the full process of turning an ordinary container image into a working e2b sandbox template.
 **The example is just a vehicle—what matters is understanding the principles**: as long as the three necessary conditions in this guide are met, any image can be adapted the same way.
 
-In addition to the three envd-specific conditions, the image must also satisfy the platform's hard requirements listed in [Build Custom Image Templates](../04.Features/02.Templates/03.Build Custom Image Templates.md): `linux/amd64` architecture, ACR image acceleration disabled, writable `/etc/passwd` and `/etc/group`, and a fixed `/bin/bash` path for `commands.run` and PTY.
+In addition to the three envd-specific conditions, the image must also satisfy the platform's hard requirements listed in [Build Custom Image Templates](../04.Features/02.Templates/03.Build Custom Image Templates.md): `linux/amd64` architecture, ACR EE image acceleration disabled, writable `/etc/passwd` and `/etc/group`, and a fixed `/bin/bash` path for `commands.run` and PTY.
 
 - Target readers: You have your own container image and want e2b SDK capabilities such as `commands.run` and `files` to work inside it.
 - Prerequisites: You can `docker build` / `docker push` to ACR, and you have an e2b `API_KEY` / `API_URL` / `DOMAIN`.
@@ -29,6 +29,8 @@ fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/base:v0.0.44  →  /.fce2b/e
 ```
 
 It listens on `0.0.0.0:49983` and returns `204` for `GET /health`.
+
+> **The envd here can also be a fully custom implementation of your own.**
 
 ---
 
@@ -107,21 +109,22 @@ flowchart TD
 
 Of the three conditions, **only ③ is what this tutorial adds**; ① and ② depend on what your image already looks like:
 
-- Based on an official `sandbox-*` image: ① and ② are usually already satisfied (**exception**: the standalone `sandbox-browser-tool` image satisfies neither)
-- Using **your own image**: ① and ② are likely both missing. You will need to add an nginx/openresty layer yourself; see [Section 6](#porting)
+- Built on AgentRun's official `sandbox-all-in-one` series: ① and ② are usually already satisfied
+- Using **your own image**: ① and ② are likely both missing, so you need to add an nginx/openresty layer yourself; see [Section 6](#porting)
 
 ---
 
 ## 3. Hands-on: Using all-in-one as an example
 
-You only need three files in the directory (full version in `case3-all-in-one/`):
+Put just these files in the directory:
 
 ```
-case3-all-in-one/
+case-all-in-one/
 ├── Dockerfile
-├── process-compose.envd.yaml
-├── build.py     # docker build → push → e2b template build
-└── run.py       # create sandbox and verify envd
+├── process-compose.envd.yaml   # envd process definition
+├── entrypoint.sh               # a fork of the vendor original, with only the two envd lines added
+├── build.py                    # docker build → push → e2b template build
+└── run.py                      # create sandbox and verify envd
 ```
 
 ### Step 1: Write the process-compose config for envd
@@ -234,55 +237,73 @@ RUN set -eu; \
     rm -f /tmp/entrypoint.vendor.sh /tmp/entrypoint.diff
 ```
 
-The checks after `diff` are **not decorative; they are build-time guards**. Please copy this habit:
+`ENTRYPOINT` / `CMD` both use what the image ships with—no change needed.
+
+**That `RUN` guard is not decoration; it is the precondition that makes this whole approach viable.**
+The cost of forking is "you now own this file, and you won't know when upstream bumps a version"—the guard turns that cost into a single build failure:
 
 | Check | What it catches |
 |---|---|
-| `grep -c '^<' = 0` | You deleted or altered vendor lines, usually because upstream changed after you forked |
-| `grep -c '^>' = 2` | Your copy does not contain exactly the two expected added lines |
-| `grep -q '^> # \[envd\]'` / `grep -qE '^> +-f …envd\.yaml \\$'` | The two added lines are not the expected comment and `-f` line |
-| `bash -n` | Syntax errors such as broken line continuations or quotes |
-| `rm` cleanup | Prevents the diff artifacts from ending up in the image layer |
+| `^<` count is 0 | Lines in vendor but not in your copy → upstream added a prep step / env-var default / config file and you are still carrying the old script |
+| `^>` count is 2 | You added something extra, or upstream deleted a line (e.g. dropped some `-f`) |
+| The two `grep`s | Those 2 lines really are envd's comment and `-f`, not some other change |
+| `bash -n` | A fork transcribed or edited by hand broke the syntax (line continuations, quotes), so the container exits on start |
 
-**Why this pedantry is worth it**: you are patching a script inside someone else's image; upstream changes can silently break an in-place `sed`. An exact-diff guard fails the build immediately when the fork is stale or the edit is wrong, which is much cheaper than debugging after push, template build, and sandbox creation.
+Four upstream-drift scenarios were tested; the guard caught all of them:
 
-> Concrete pitfall: in-place `sed` can insert the envd config path as a shell command if the anchor pattern accidentally matches an existence-check loop. That path is valid shell syntax, so `bash -n` does not catch it. Only a structural or exact-diff assertion catches the damage.
+| Simulated upstream change | Guard result |
+|---|---|
+| Normal case | PASS |
+| Upstream adds a process-compose config file | FAIL: `^<` is not 0 |
+| Upstream adds an env-var default | FAIL: `^<` is not 0 |
+| Upstream deletes two lines | FAIL: `^>` is not 2 |
+
+> **Don't want to fork?** There is another path: leave the script alone and change `CMD`. The v0.10.1 `entrypoint.sh` leaves an escape hatch **after** all the prep work (tmpfs dirs, 20+ env-var defaults, `trap`):
+> ```bash
+> if [ $# -gt 0 ] && [ "$1" != "process-compose" ]; then exec "$@"; fi
+> [ "$1" = "process-compose" ] && shift
+> ```
+> So `CMD ["bash","-c","exec process-compose up -f …envd.yaml -f …base.yaml … --tui=false --no-server"]` gets all the prep work for free. **But the first argument must never be `process-compose`**—it would hit the `shift` above, your arguments would be dropped, the vendor's hard-coded list would still run, and it would silently do nothing. This path was also tested and works; the cost is one duplicated config list, plus readers having to understand the escape hatch first.
+>
+> The one thing you should **not** do is replace `entrypoint.sh` with a script written from scratch: you would have to copy all 100 lines of prep work, and you would never know when upstream changes.
 
 ### Step 3: Local validation (the cheapest round) {#local-validation}
 
 Push and template builds are slow; **validate everything you can locally first**. Use the same specs as the template (the example uses 4C8G):
 
+In `-p 15000:5000`, the left side is the **host** port and the right side is the **in-container** port: nginx inside the container listens only on 5000 (and the gateway only recognizes 5000). Which host port you map to is arbitrary; 15000 just avoids colliding with a 5000 already taken on your machine. So below, on the host you `curl 127.0.0.1:15000`, while inside the container via `docker exec` it is `localhost:5000`.
+
 ```bash
 docker build --platform linux/amd64 -t my-envd-image:local .
 docker run -d --name t --cpus 4 --memory 8g -p 15000:5000 my-envd-image:local
 
-# ① Check that envd is running and that 49983 and 5000 are listening
+# ① Is envd running, and are 49983 and 5000 listening?
 docker exec t ps -ef | grep -E 'process-compose|envd'
 docker exec t ss -ltn
 
 # ② Direct connection to envd inside the sandbox (expect 204)
 docker exec t curl -s -o /dev/null -w '%{http_code}\n' http://localhost:49983/health
 
-# ③ Simulate the gateway: send Host-with-port-prefix traffic to 5000 and see if it reaches envd (expect 204)
-curl -s -o /dev/null -w '%{http_code}\n' \
-     -H 'Host: 49983-x.cn-beijing.e2b.fc.aliyuncs.com' http://127.0.0.1:15000/health
+# ③ Simulate the gateway: put the target port in the X-Sandbox-Port header, send it to 5000, and see if it reaches envd
+#    Expect envd's own plaintext "404 page not found", not openresty's 404 HTML
+curl -s -H 'X-Sandbox-Port: 49983' http://127.0.0.1:15000/__nope
 
-# ④ Unknown paths should return envd's own 404 text, not nginx's 404 HTML
-curl -s -H 'Host: 49983-x.cn-beijing.e2b.fc.aliyuncs.com' http://127.0.0.1:15000/__nope
-
-# ⑤ Without the port prefix, your existing business routes should be unaffected
+# ④ Without any port info, your existing business routes are unaffected
 curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:15000/health
 ```
 
-Step ③ is the most valuable: it locally verifies all three conditions from [2.3](#three-conditions) at once.
+Step ③ is the most valuable: it locally verifies conditions ①, ②, and ③ from [2.3](#three-conditions) in one shot.
+
+> **Why does ③ use `/__nope` and not `/health`?**
+> The nginx that ships with all-in-one has `location = /health { return 200 … }`, and it does **not** enable `rewrite_by_lua_no_postpone on`, so a `/health` request carrying port info gets answered early by that exact location—it actually returns **200 (the vendor's), not 204 (envd's)**, so using it as the criterion would mislead you. Pick a path the vendor does not define (`/__nope`) and the response body is envd's plaintext `404 page not found`.
 
 ### Step 4: Push and build the template
 
-Note that **the push address and the template pull address are different**: push goes over the public network, while the template build service pulls the image inside the VPC. The registry endpoints must be in the **same region and same Alibaba Cloud account** as the template build service.
+Note that **the push address and the template pull address are different**: push goes over the public network, while the template build service pulls the image inside the VPC.
 
 ```python
-REGISTRY     = "<your-public-acr-endpoint>.cr.aliyuncs.com"      # for push; same region/account as template build
-REGISTRY_VPC = "<your-vpc-acr-endpoint>.cr.aliyuncs.com"         # for from_image; same region/account as REGISTRY
+REGISTRY     = "<your-public-acr-ee-endpoint>.cr.aliyuncs.com"   # for push; same account/region as the template build service
+REGISTRY_VPC = "<your-vpc-acr-ee-endpoint>.cr.aliyuncs.com"      # for from_image; same account/region as REGISTRY
 REPO, TAG = "runtime/envd-all-in-one", "v2"
 
 IMAGE      = f"{REGISTRY}/{REPO}:{TAG}"
@@ -296,7 +317,7 @@ build = Template.build(
     name="envd-all-in-one-4c8g-v2",
     cpu_count=4,
     memory_mb=8192,
-    skip_cache=False,                                    # backend does not support force
+    skip_cache=False,
     on_build_logs=default_build_logger(),
     headers={"X-E2B-Template-Build-Mode": "direct"},
     api_key=API_KEY, api_url=API_URL, domain=DOMAIN,
@@ -307,19 +328,20 @@ build = Template.build(
 
 | Limit | Error | Workaround |
 |---|---|---|
-| ACR tag cannot be overwritten | `tag[v1] is already existed` | Change tag: v1 → v2 → v3 |
+| ACR EE tag, if configured as immutable | `tag[v1] is already existed` | Change tag: v1 → v2 → v3 |
 | A template name can only be built once | `409 … only a single build` | Change template name |
-| force is not supported | `400: force is not supported` | Keep `skip_cache=False` |
 
 ### Step 5: Create a sandbox and verify
 
 ```python
 sbx = Sandbox.create(template="envd-all-in-one-4c8g-v2", timeout=900, api_key=..., api_url=..., domain=...)
 try:
-    # After create returns, envd may not yet be routed by the gateway (larger images cold-start slower), so retry the first command
+    # After create returns, envd may not yet be routed by the gateway (larger images cold-start slower), so retry the first command.
+    # Probe with `echo` rather than `true`: it also verifies stdout comes back —
+    # if envd can fork the process but the output stream is broken, a command with no output would still pass
     for i in range(12):
         try:
-            sbx.commands.run("true")
+            assert sbx.commands.run("echo envd-ok").stdout.strip() == "envd-ok"
             break
         except Exception as exc:
             print(f"waiting for envd ({i + 1}/12): {type(exc).__name__}")
@@ -334,8 +356,8 @@ finally:
 Expected output (actual):
 
 ```
-sandbox_id: sbx-c64b949e-2647-42ec-a796-83c2c9a7ab53
-OK   envd reachable (attempt 1)
+sandbox_id: sbx-4ef4c439-6cda-4f40-908b-293ad543ad68
+OK   envd reachable, stdout comes back (attempt 1)
 root  1  0  process-compose up -f …process-compose.envd.yaml -f …base.yaml -f …gui.yaml …
 root 21  1  /usr/local/bin/envd
 OK   envd process running
@@ -352,17 +374,17 @@ The first line showing `envd.yaml` in the `process-compose up` arguments, and th
 ```mermaid
 flowchart LR
     A["docker build<br/>self-checks pass"] --> B["local run<br/>5000/49983 listening"]
-    B --> C["local curl<br/>Host port prefix → 204"]
+    B --> C["local curl<br/>port info → hits envd"]
     C --> D["push + template build"]
     D --> E["Sandbox.create<br/>returns in seconds"]
     E --> F["commands.run<br/>usable"]
 ```
 
-- [ ] The exact-diff guard in `RUN` passes: exactly two expected lines added relative to the vendor entrypoint (and `nginx -t` if applicable)
+- [ ] Exact diff / `bash -n` (and `nginx -t` when applicable) live in `RUN`, so the build fails outright when the patch or fork breaks
 - [ ] `docker exec … ss -ltn` shows `0.0.0.0:5000` and `*:49983`
 - [ ] Inside the sandbox `curl localhost:49983/health` → 204
-- [ ] Locally `-H 'Host: 49983-x.<domain>'` to 5000 → 204 (**this is the most important one**)
-- [ ] Without the port prefix, existing business routes behave the same as before
+- [ ] Locally `-H 'X-Sandbox-Port: 49983'` to an undefined path on 5000 → envd's plaintext 404 (**this is the most important one**)
+- [ ] Without any port info, existing business routes behave the same as before
 - [ ] `Sandbox.create` returns in seconds (**not** hanging for ~121s then erroring)
 - [ ] The first `commands.run` retries and eventually succeeds
 - [ ] `finally` calls `sbx.kill()`; don't leave the sandbox running
@@ -375,19 +397,13 @@ flowchart LR
 |---|---|---|
 | `Sandbox.create` hangs for ~120s then `StreamReset` / empty response; the sandbox is not found in `GET /sandboxes` | No process in the container is listening on **5000**; the gateway disconnects before readiness | Make nginx (or any reverse proxy) `listen 0.0.0.0:5000` |
 | Sandbox is created, but SDK requests return **openresty 404 HTML** | nginx lacks **multi-port routing**; the 49983 request is not forwarded | Add the multi-port config from [Section 6](#porting) |
-| Requests pass through nginx then return **502 / connection refused** | envd is not running | `ps -ef` to check envd; verify the entrypoint patch took effect |
-| The entrypoint `-f` list **does not** contain `envd.yaml` | The fork is based on an old vendor script, or the change did not land in the config list that actually runs | Re-fork from the vendor original as in [Step 2](#fork-entrypoint) and keep the exact-diff guard in `RUN` |
-| Container exits immediately with `syntax error near unexpected token` | Entrypoint syntax was broken (usually a broken line continuation) | `bash -n` to locate; re-fork from the vendor original instead of hand-editing |
-| `docker push` fails with `tag is already existed` | ACR tag cannot be overwritten | Change tag |
+| Requests pass through nginx then return **502 / connection refused** | envd is not running | `ps -ef` to check envd; then verify the entrypoint patch took effect |
+| The entrypoint `-f` list **does not** contain `envd.yaml` | The fork is based on an old script, or the change did not land in the config list that actually runs | Re-fork from the vendor original as in [Step 2](#fork-entrypoint), and add the exact-diff guard into `RUN` |
+| Container exits on start with `syntax error near unexpected token` | Entrypoint syntax was broken (usually a broken line continuation) | `bash -n` to locate; re-fork from the vendor original |
+| `docker push` fails with `tag is already existed` | ACR EE tag cannot be overwritten | Change tag |
 | Template build fails with `409 … only a single build` | A template name can only be built once | Change template name |
-| `run_code` returns 502 but `commands.run` works | Gateway routing issue for the business process (5001), **not envd-related** | Self-check with `curl localhost:5001/health` inside the sandbox; troubleshoot on the business side |
 
-**Recommended troubleshooting order**: reproduce locally with `docker run` first. Most symptoms above can be reproduced locally—only suspect the platform side if you cannot reproduce locally.
-
-> One lesson learned: case2 (browser-tool) was once misdiagnosed as "image too large causing cold-start timeout".
-> We flattened the image (8.33GB → 5.51GB) — **completely ineffective**.
-> The actual counterexample: the working computer-use image (6.51GB) was larger than the failing browser-tool (5.51GB).
-> The real cause was that nginx was not listening on 5000. **Don't guess by intuition; do controlled experiments: compare a working image and the failing image item by item.**
+**Recommended troubleshooting order**: reproduce locally with `docker run` first. Most symptoms above can be reproduced locally—only suspect the platform side when you cannot.
 
 ---
 
@@ -396,134 +412,81 @@ flowchart LR
 ```mermaid
 flowchart TD
     A["Your image"] --> B{"Does it have process-compose?"}
-    B -->|Yes| B1["Add process-compose.envd.yaml<br/>register via mechanism A/B/C"]
-    B -->|No<br/>(custom entrypoint)| B2["Start envd in the background from entrypoint<br/>or use supervisord to manage it"]
-    B1 --> C{"Is there a process listening on 5000 in the container?"}
+    B -->|Yes| B1["Add process-compose.envd.yaml<br/>fork entrypoint, add one line"]
+    B -->|"No<br/>(custom entrypoint)"| B2["supervisord manages envd<br/>autorestart=true"]
+    B1 --> C{"Is a process listening on 5000?"}
     B2 --> C
     C -->|Has nginx/openresty| C1{"Does it do multi-port forwarding?"}
-    C -->|No| C2["Add an openresty layer<br/>listen 5000 + multi-port routing"]
-    C1 -->|Yes| D["✅ Just integrate envd"]
+    C -->|"No"| C2["Add an openresty layer<br/>listen 5000 + multi-port routing"]
+    C1 -->|Yes| D{"Is there an SDK default user 'user'?"}
     C1 -->|No| C3["Add multi-port routing config"]
     C2 --> D
     C3 --> D
+    D -->|Yes| OK["✅ Works"]
+    D -->|"No<br/>(common for custom images)"| D1["Create a uid 1000 'user' account"]
+    D1 --> OK
+
+    style OK stroke-width:3px
 ```
 
-### 6.1 No process-compose: run envd directly in the entrypoint
+**Every conclusion in this section was verified on the standalone sample project [`e2b-custom-image`](https://github.com/aliyun-fc/fc-e2b-samples/tree/main/e2b-custom-image)** (clone and run it directly): starting from `debian:bookworm-slim`, you install openresty, write the multi-port routing, and manage envd with supervisord yourself. The full path works end to end: build → local validation → push → template build → sandbox creation → `commands.run` / `files`. The final image is **235MB** (versus 2.34GB–6.51GB for the vendor-image-based variants).
 
-You don't have to introduce process-compose just for envd. The minimal change for an image with its own `entrypoint.sh`:
-
-```dockerfile
-COPY --from=envd-extract /.fce2b/envd /usr/local/bin/envd
+```
+e2b-custom-image/
+├── Dockerfile                    # debian-slim + openresty + supervisor + envd + user account
+├── nginx.conf                    # ① listen 0.0.0.0:5000
+├── nginx-multiport-http.conf     # ② http level: map + rewrite_by_lua_no_postpone
+├── nginx-multiport-routes.conf   # ② server level: multi-port routing
+├── nginx-app-routes.conf         # business routes (incl. location = /health, the intentional early-answer trap)
+├── supervisord.conf              # ③ main config: nodaemon + socket + include conf.d
+├── supervisor-envd.conf          # ③ envd — the one file you can copy wholesale into your image
+├── supervisor-openresty.conf     # reverse proxy (daemon off + stopsignal=QUIT)
+├── supervisor-app.conf           # example business process
+├── entrypoint.sh                 # only prepares dirs + exec supervisord
+├── app.py                        # example business process (127.0.0.1:8000)
+├── verify-local.sh               # Step 3 local validation, ①–⑦ seven assertion groups
+├── build.py                      # docker build → push → template build
+├── run.py                        # create sandbox and verify envd / supervisord status / user / files
+├── requirements.txt              # e2b SDK + python-dotenv
+└── env.example                   # E2B_API_KEY / _API_URL / _DOMAIN, copy to .env
 ```
 
-Add a daemon loop before your business process in your own entrypoint:
+An image built from scratch (the sample uses `debian:bookworm-slim`) means adding the four things below yourself, versus AgentRun's official `sandbox-*` images that ship with them. **The full config, build-time guardrails, and observed failure output for each live in the project.** See the project [README](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/README.md) §1–§4 for the per-file design rationale; here we keep only "the one thing you must remember" and the corresponding file.
 
-```bash
-# Auto-restart envd when it crashes (equivalent to process-compose restart: always)
-( while true; do /usr/local/bin/envd; echo "envd exited($?), restarting" >&2; sleep 2; done ) &
-```
+### 6.1 Four things to add
 
-For production, prefer a process manager such as supervisord / s6; the semantics only need to align with `restart: always`.
-The key point is: **envd must stay resident and be restarted automatically when it crashes**—if it dies, all SDK capabilities of the sandbox disappear.
+| What to add | The one thing you must remember | Full config |
+|---|---|---|
+| **① Keep envd resident**<br/>supervisord instead of process-compose | If envd dies, all sandbox SDK capabilities are lost. `autorestart=true` **is not enough**: supervisord defaults to `startretries=3`, so after 3 rapid failures it enters **FATAL and never restarts again** → "fine for the first few minutes, then all SDK calls 502". You must raise `startretries` to a huge value | [`supervisor-envd.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/supervisor-envd.conf) · [`supervisord.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/supervisord.conf) |
+| **② Multi-port reverse proxy on 5000**<br/>install openresty yourself | Must be openresty, not nginx (multi-port routing needs `rewrite_by_lua`, and Debian's `nginx` package has no lua). It also needs `rewrite_by_lua_no_postpone on;`, otherwise envd's `/health` gets answered by your own `location = /health` | [`nginx.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx.conf) · [`nginx-multiport-http.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-http.conf) · [`nginx-multiport-routes.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-routes.conf) |
+| **③ SDK default user `user`**<br/>the 4th condition beyond the three in [2.3](#three-conditions) | Without `user=`, every `commands.run` drops privileges to the `user` account; without that account → `AuthenticationException: unknown user`. Yet the sandbox is created, envd is running, and `/health` returns 204 — all three necessary conditions green, making this the easiest to misdiagnose | [`Dockerfile`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/Dockerfile) (`useradd --uid 1000`) |
+| **④ China-region build + runtime guardrails** | Four "builds fine, blows up only at runtime" traps: `deb.debian.org` unreachable in China, `python3-minimal` missing stdlib keeps the business port at 502 forever, slim has no `ss`, and bookworm mirror swaps must use deb822. General fix: for anything like this, add an assertion into `RUN` | [`Dockerfile`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/Dockerfile) |
 
-### 6.2 No multi-port reverse proxy on 5000: add an openresty layer
+> **Acceptance must verify "it recovers after a crash", not just "it's running now".** Item ⑦ in the project's [`verify-local.sh`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/verify-local.sh): after `pkill -9 envd`, port 49983 is listening again within 6s **and** `supervisorctl status envd` returns to **RUNNING** (before entering FATAL, supervisord also restarts a few times, so checking only the port misses it; `STARTING`/`BACKOFF` are transient states, so poll rather than sample once). Also, `files` and `commands` go through different envd interfaces, so [`run.py`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/run.py) does a `files.write` / `files.read` round-trip in addition to `whoami`.
 
-This config was verified on `sandbox-browser-tool` and can be reused directly (it requires openresty because it uses lua).
-
-`nginx.conf` server block:
-
-```nginx
-server {
-    listen 0.0.0.0:5000;      # ① The gateway only recognizes 5000
-    server_name _;
-    include conf.d/*.conf;    # multi-port routing + your own business routes
-}
-```
-
-`http` block level (place in `http.d/00-multiport.conf` or similar, included into the http block):
-
-```nginx
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    '' close;
-}
-
-# Let rewrite_by_lua run before ngx_rewrite's return/rewrite,
-# otherwise envd's /health will be answered early by your own `location = /health { return 200 ... }`
-rewrite_by_lua_no_postpone on;
-```
-
-`server` block level (place in `conf.d/00-multiport-routes.conf`; the `00-` prefix ensures it is included first):
-
-```nginx
-set $target_port "";
-
-# Placed at server level → inherited by all locations → port-prefixed requests can be hijacked
-# before exact/prefix locations like location = /health or location ~ ^/api/
-rewrite_by_lua_block {
-    local port = ngx.var.http_x_sandbox_port
-    if not port or port == "" then
-        port = string.match(ngx.var.host or "", "^(%d+)%-")
-    end
-    if not port then return end
-    local port_num = tonumber(port)
-    -- Tighten the lower bound as needed to avoid exposing internal ports to the public internet
-    if not port_num or port_num <= 2999 or port_num > 65535 then return end
-    ngx.var.target_port = port
-    ngx.exec("@multiport")
-}
-
-location @multiport {
-    # Must override the inherited server-level rewrite_by_lua_block,
-    # otherwise the internal redirect re-enters ngx.exec → redirect loop
-    rewrite_by_lua_block { return }
-
-    proxy_pass http://127.0.0.1:$target_port;
-    proxy_set_header Host localhost:$target_port;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
-    proxy_connect_timeout 7d;
-    proxy_send_timeout 7d;
-    proxy_read_timeout 7d;
-
-    # envd uses the connect protocol and requires HTTP/1.1 with buffering off
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_buffering off;
-    proxy_request_buffering off;
-}
-```
-
-When adding it to the Dockerfile, include the same build-time self-checks:
-
-```dockerfile
-COPY nginx-multiport-http.conf   /etc/nginx/http.d/00-multiport.conf
-COPY nginx-multiport-routes.conf /etc/nginx/conf.d/00-multiport-routes.conf
-RUN nginx -t
-```
-
-> Scope note: this config was verified on vendor images that already have openresty.
-> If your image has no nginx at all, the same config should work in principle, but you need to install openresty into the image yourself.
-> That path has not been tested—be sure to verify locally with Step ③ from [Step 3](#local-validation) before pushing.
-
-### 6.3 Porting Checklist
+### 6.2 Porting Checklist
 
 | Item | Official `sandbox-*` images | Your own image |
 |---|---|---|
-| envd binary | `COPY --from=base:v0.0.44 /.fce2b/envd` | Same |
-| envd residency | Add `process-compose.envd.yaml` + register | process-compose / supervisord / entrypoint daemon loop |
-| 5000 listener | Usually present (browser-tool exception) | Add reverse proxy yourself |
-| Multi-port routing | Usually present (browser-tool exception) | Add yourself (see 6.2) |
-| Build-time self-checks | `grep -c` + `bash -n` + `nginx -t` | Same |
+| envd binary | `COPY --from=base:v0.0.44 /.fce2b/envd` | Same (statically linked, works across distros) |
+| envd residency | Add `process-compose.envd.yaml` + register | supervisord-managed + raise `startretries` |
+| 5000 listener | Usually present (browser-tool exception) | Install openresty yourself |
+| Multi-port routing | Usually present (browser-tool exception) | Write the lua route yourself |
+| `user` account | Built in | **Must create it yourself** |
+| Build-time self-checks | Exact diff vs vendor original + `bash -n` + `nginx -t` | `openresty -t` + semantic `grep` + `id user` + dependency `import` |
+
+> Full source and per-item design rationale: standalone project [`e2b-custom-image`](https://github.com/aliyun-fc/fc-e2b-samples/tree/main/e2b-custom-image); clone it to reproduce the whole flow.
 
 ---
 
 ## 7. One-Sentence Summary
 
-**envd integration = place the binary + keep it running + make the reverse proxy on 5000 forward port-49983 traffic to it based on the Host port prefix.**
+**envd integration = place the binary + keep it running + make the reverse proxy on 5000 forward port-49983 traffic to it based on the Host port prefix (or the `X-Sandbox-Port` header).**
 
-The first two steps are the same for every image; the third depends on what your image's reverse proxy looks like, and it is the source of almost all hard-to-diagnose failures.
-A single local command `curl -H 'Host: 49983-x.<domain>' http://127.0.0.1:15000/health` expecting `204` is the single criterion for whether all three steps were done correctly.
+The first two steps are the same for every image; the third depends on what that reverse-proxy layer in your image looks like, and it is the source of almost all hard-to-diagnose failures.
+
+After starting the container locally (`-p 15000:5000`), a single command is the one criterion for all three—pick a path your business **does not** define, or your own `location` will answer it early (see [Step 3](#local-validation)):
+
+```bash
+curl -s -H 'X-Sandbox-Port: 49983' http://127.0.0.1:15000/__nope   # expect envd's plaintext 404 page not found
+```

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/10.envd 集成教程：把你自己的镜像变成 e2b 沙箱模板.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/10.envd 集成教程：把你自己的镜像变成 e2b 沙箱模板.md
@@ -103,7 +103,7 @@ flowchart TD
     C2 -->|否| F2["沙箱能创建<br/>但 envd 请求被 nginx 直接 404"]
     C2 -->|是| C3{"③ envd 进程是否在跑<br/>并监听 49983？"}
     C3 -->|否| F3["请求穿过 nginx 后<br/>502 / 连接被拒"]
-    C3 -->|是| OK["✅ SDK 相关方法可用"]
+    C3 -->|是| OK["✅ envd 可达，SDK 传输打通"]
 
     style OK stroke-width:3px
 ```
@@ -112,6 +112,8 @@ flowchart TD
 
 - 用 AgentRun 官方 `sandbox-all-in-one` 系列镜像做基础：① ② 通常已满足
 - 用**你自己的镜像**：① ② 大概率都不满足，需要自己补一个 nginx/openresty 层，见 [第六节](#porting)
+
+> 这三条只保证 envd **可达**，并不等于每条 `commands.run` 都能成功：调用时若不传 `user=`，SDK 会把命令降权到镜像里 uid 1000 的 `user` 账号执行——这是与上面三条正交的第 ④ 个条件，三条全绿时缺它照样会 `unknown user`。官方镜像自带，自定义镜像通常要自己建，详见 [6.1 ③](#porting)。
 
 ---
 
@@ -426,8 +428,8 @@ flowchart LR
 ```mermaid
 flowchart TD
     A["你的镜像"] --> B{"有 process-compose 吗？"}
-    B -->|有| B1["加一份 process-compose.envd.yaml<br/>fork entrypoint 加一行"]
-    B -->|"没有<br/>（自己的 entrypoint）"| B2["supervisord 托管 envd<br/>autorestart=true"]
+    B -->|有| B1["加一份 process-compose.envd.yaml<br/>用现有启动机制注册<br/>（官方镜像：fork entrypoint 加一行）"]
+    B -->|"没有<br/>（自己的 entrypoint）"| B2["supervisord 托管 envd<br/>autorestart=true + startretries 调大"]
     B1 --> C{"容器内有进程监听 5000 吗？"}
     B2 --> C
     C -->|有 nginx/openresty| C1{"它做多端口转发吗？"}
@@ -478,7 +480,7 @@ e2b-custom-image/
 | 要补什么 | 必须记住的那一条 | 完整配置 |
 |---|---|---|
 | **① 让 envd 常驻**<br/>supervisord 托管，替代 process-compose | envd 一挂，沙箱 SDK 能力全失。`autorestart=true` **不够**：supervisord 默认 `startretries=3`，快速失败 3 次即进 **FATAL 永不再拉起** → 「前几分钟正常、之后所有 SDK 调用 502」。必须把 `startretries` 调到极大值 | [`supervisor-envd.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/supervisor-envd.conf) · [`supervisord.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/supervisord.conf) |
-| **② 5000 上的多端口反代**<br/>自己装 openresty | 必须 openresty 不是 nginx（多端口路由要 `rewrite_by_lua`，Debian 的 `nginx` 包没 lua）。且要 `rewrite_by_lua_no_postpone on;`，否则 envd 的 `/health` 会被业务的 `location = /health` 抢答 | [`nginx.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx.conf) · [`nginx-multiport-http.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-http.conf) · [`nginx-multiport-routes.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-routes.conf) |
+| **② 5000 上的多端口反代**<br/>自己装 openresty | 要 nginx **带 Lua 模块**——多端口路由靠 `rewrite_by_lua`。示例用 openresty；Debian 上也可给原生 nginx 装 [`libnginx-mod-http-lua`](https://packages.debian.org/bookworm/libnginx-mod-http-lua)。无论哪种都要 `rewrite_by_lua_no_postpone on;`，否则 envd 的 `/health` 会被业务的 `location = /health` 抢答 | [`nginx.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx.conf) · [`nginx-multiport-http.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-http.conf) · [`nginx-multiport-routes.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-routes.conf) |
 | **③ SDK 默认用户 `user`**<br/>[2.3](#three-conditions) 的第 ④ 个条件 | 不指定 `user=` 时每条 `commands.run` 都降权到 `user` 账号执行；缺它 → `AuthenticationException: unknown user`。而此时沙箱创建成功、envd 在跑、`/health` 也是 204，三个必要条件全绿，最易误判 | [`Dockerfile`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/Dockerfile)（`useradd --uid 1000`） |
 | **④ 国内构建 + 运行期护栏** | 四个「构建能过、运行期才炸」的坑：`deb.debian.org` 国内不可用、`python3-minimal` 缺标准库致业务端口一直 502、slim 无 `ss`、bookworm 换源要用 deb822。通解：凡此类都往 `RUN` 里塞一条断言 | [`Dockerfile`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/Dockerfile) |
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/10.envd 集成教程：把你自己的镜像变成 e2b 沙箱模板.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/10.envd 集成教程：把你自己的镜像变成 e2b 沙箱模板.md
@@ -427,121 +427,78 @@ flowchart LR
 flowchart TD
     A["你的镜像"] --> B{"有 process-compose 吗？"}
     B -->|有| B1["加一份 process-compose.envd.yaml<br/>fork entrypoint 加一行"]
-    B -->|"没有<br/>（自己的 entrypoint）"| B2["entrypoint 里后台起 envd<br/>或用 supervisord 托管"]
+    B -->|"没有<br/>（自己的 entrypoint）"| B2["supervisord 托管 envd<br/>autorestart=true"]
     B1 --> C{"容器内有进程监听 5000 吗？"}
     B2 --> C
     C -->|有 nginx/openresty| C1{"它做多端口转发吗？"}
     C -->|"没有"| C2["加一层 openresty<br/>listen 5000 + 多端口路由"]
-    C1 -->|做| D["✅ 只需集成 envd"]
+    C1 -->|做| D{"有 SDK 默认用户 user 吗？"}
     C1 -->|不做| C3["补多端口路由配置"]
     C2 --> D
     C3 --> D
+    D -->|有| OK["✅ 可用"]
+    D -->|"没有<br/>（多为自定义镜像）"| D1["建 uid 1000 的 user 账号"]
+    D1 --> OK
+
+    style OK stroke-width:3px
 ```
 
-### 6.1 没有 process-compose：直接在 entrypoint 里托管 envd
+**这一节的每条结论都在独立示例工程 [`e2b-custom-image`](https://github.com/aliyun-fc/fc-e2b-samples/tree/main/e2b-custom-image) 上实测过**（源码可直接 clone 跑）：从 `debian:bookworm-slim` 起步，
+自己装 openresty、写多端口路由、用 supervisord 托管 envd，
+完整跑通 build → 本地验证 → push → 模板构建 → 创建沙箱，`commands.run` / `files` 全部可用。
+成品镜像 **235MB**（vendor 镜像方案则是 2.34GB–6.51GB）。
 
-不必为了 envd 引入 process-compose。最小改法（自带 `entrypoint.sh` 的镜像）：
-
-```dockerfile
-COPY --from=envd-extract /.fce2b/envd /usr/local/bin/envd
+```
+e2b-custom-image/
+├── Dockerfile                    # debian-slim + openresty + supervisor + envd + user 账号
+├── nginx.conf                    # ① listen 0.0.0.0:5000
+├── nginx-multiport-http.conf     # ② http 级：map + rewrite_by_lua_no_postpone
+├── nginx-multiport-routes.conf   # ② server 级：多端口路由
+├── nginx-app-routes.conf         # 业务路由（含 location = /health，故意留的抢答陷阱）
+├── supervisord.conf              # ③ 主配置：nodaemon + socket + include conf.d
+├── supervisor-envd.conf          # ③ envd —— 可整份搬到你自己镜像的那一份
+├── supervisor-openresty.conf     # 反代（daemon off + stopsignal=QUIT）
+├── supervisor-app.conf           # 示例业务进程
+├── entrypoint.sh                 # 只做目录准备 + exec supervisord
+├── app.py                        # 示例业务进程（127.0.0.1:8000）
+├── verify-local.sh               # 步骤 3 的本地验证，①–⑦ 七组断言
+├── build.py                      # docker build → push → 模板构建
+├── run.py                        # 创建沙箱并验证 envd / supervisord 状态 / user / files
+├── requirements.txt              # e2b SDK + python-dotenv
+└── env.example                   # E2B_API_KEY / _API_URL / _DOMAIN，复制成 .env
 ```
 
-在你自己的 entrypoint 里，业务进程之前加一段守护循环：
+从零搭的镜像（示例用 `debian:bookworm-slim`）相比 AgentRun 官方 `sandbox-*` 镜像，要自己补齐下面四件事。
+**每件的完整配置、构建期护栏、失败实测输出都在工程里**，逐文件的设计取舍见工程
+[README](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/README_ZH-CN.md) §1–§4；
+这里只留「必须记住的那一条」和对应文件。
 
-```bash
-# envd 崩溃自动重启（等价于 process-compose 的 restart: always）
-( while true; do /usr/local/bin/envd; echo "envd exited($?), restarting" >&2; sleep 2; done ) &
-```
+### 6.1 四件要补的事
 
-生产环境更建议交给 supervisord / s6 之类的进程管理器，语义和 `restart: always` 对齐即可。
-关键只有一条：**envd 必须常驻，挂了要自动拉起**——它挂了整个沙箱的 cmd 等相关的 SDK 能力就没了。
+| 要补什么 | 必须记住的那一条 | 完整配置 |
+|---|---|---|
+| **① 让 envd 常驻**<br/>supervisord 托管，替代 process-compose | envd 一挂，沙箱 SDK 能力全失。`autorestart=true` **不够**：supervisord 默认 `startretries=3`，快速失败 3 次即进 **FATAL 永不再拉起** → 「前几分钟正常、之后所有 SDK 调用 502」。必须把 `startretries` 调到极大值 | [`supervisor-envd.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/supervisor-envd.conf) · [`supervisord.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/supervisord.conf) |
+| **② 5000 上的多端口反代**<br/>自己装 openresty | 必须 openresty 不是 nginx（多端口路由要 `rewrite_by_lua`，Debian 的 `nginx` 包没 lua）。且要 `rewrite_by_lua_no_postpone on;`，否则 envd 的 `/health` 会被业务的 `location = /health` 抢答 | [`nginx.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx.conf) · [`nginx-multiport-http.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-http.conf) · [`nginx-multiport-routes.conf`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/nginx-multiport-routes.conf) |
+| **③ SDK 默认用户 `user`**<br/>[2.3](#three-conditions) 的第 ④ 个条件 | 不指定 `user=` 时每条 `commands.run` 都降权到 `user` 账号执行；缺它 → `AuthenticationException: unknown user`。而此时沙箱创建成功、envd 在跑、`/health` 也是 204，三个必要条件全绿，最易误判 | [`Dockerfile`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/Dockerfile)（`useradd --uid 1000`） |
+| **④ 国内构建 + 运行期护栏** | 四个「构建能过、运行期才炸」的坑：`deb.debian.org` 国内不可用、`python3-minimal` 缺标准库致业务端口一直 502、slim 无 `ss`、bookworm 换源要用 deb822。通解：凡此类都往 `RUN` 里塞一条断言 | [`Dockerfile`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/Dockerfile) |
 
-### 6.2 没有 5000 上的多端口反代：加一层 openresty
+> **验收要验「崩了能起来」，不是「现在在跑」。** 工程 [`verify-local.sh`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/verify-local.sh) 第 ⑦ 项：
+> `pkill -9 envd` 后 6 秒内 49983 重新在听、且 `supervisorctl status envd` 回到 **RUNNING**
+> （进 FATAL 前也会重启几次，只看端口会漏判；`STARTING`/`BACKOFF` 是过渡态，要轮询）。
+> 另外 `files` 与 `commands` 走 envd 的不同接口，[`run.py`](https://github.com/aliyun-fc/fc-e2b-samples/blob/main/e2b-custom-image/run.py) 因此在 `whoami` 外还做一次 `files.write` / `files.read` 往返。
 
-`nginx.conf` 的 server 块：
-
-```nginx
-server {
-    listen 0.0.0.0:5000;      # ① 网关只认 5000
-    server_name _;
-    include conf.d/*.conf;    # 多端口路由 + 你自己的业务路由
-}
-```
-
-`http` 块级（放 `http.d/00-multiport.conf` 之类，被 `include` 进 http 块）：
-
-```nginx
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    '' close;
-}
-
-# 让 rewrite_by_lua 先于 ngx_rewrite 的 return/rewrite 执行，
-# 否则 envd 的 /health 会被你自己的 `location = /health { return 200 ... }` 抢先应答
-rewrite_by_lua_no_postpone on;
-```
-
-`server` 块级（放 `conf.d/00-multiport-routes.conf`，注意 `00-` 前缀保证先被 include）：
-
-```nginx
-set $target_port "";
-
-# 放在 server 级 → 所有 location 继承 → 带端口前缀的请求能在
-# location = /health、location ~ ^/api/ 这些精确/前缀路由之前被劫持
-rewrite_by_lua_block {
-    local port = ngx.var.http_x_sandbox_port
-    if not port or port == "" then
-        port = string.match(ngx.var.host or "", "^(%d+)%-")
-    end
-    if not port then return end
-    local port_num = tonumber(port)
-    -- 按需收紧下界，避免把内部端口暴露到公网
-    if not port_num or port_num <= 2999 or port_num > 65535 then return end
-    ngx.var.target_port = port
-    ngx.exec("@multiport")
-}
-
-location @multiport {
-    # 必须覆盖继承来的 server 级 rewrite_by_lua_block，
-    # 否则内部重定向进来后又 ngx.exec 一次 → 重定向死循环
-    rewrite_by_lua_block { return }
-
-    proxy_pass http://127.0.0.1:$target_port;
-    proxy_set_header Host localhost:$target_port;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
-    proxy_connect_timeout 7d;
-    proxy_send_timeout 7d;
-    proxy_read_timeout 7d;
-
-    # envd 用 connect 协议，需要 HTTP/1.1 且关闭缓冲
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_buffering off;
-    proxy_request_buffering off;
-}
-```
-
-把它加进 Dockerfile 时，同样带上构建期自检：
-
-```dockerfile
-COPY nginx-multiport-http.conf   /etc/nginx/http.d/00-multiport.conf
-COPY nginx-multiport-routes.conf /etc/nginx/conf.d/00-multiport-routes.conf
-RUN nginx -t
-```
-
-### 6.3 移植检查表
+### 6.2 移植检查表
 
 | 项 | AgentRun 官方 `sandbox-*` 镜像 | 你自己的镜像 |
 |---|---|---|
-| envd 二进制 | `COPY --from=base:v0.0.44 /.fce2b/envd` | 同左 |
-| envd 常驻 | 加 `process-compose.envd.yaml` + 注册 | process-compose / supervisord / entrypoint 守护循环 |
-| 5000 监听 | 通常已有 | 需要自己加反代 |
-| 多端口路由 | 通常已有 | 需要自己加（见 6.2） |
-| 构建期自检 | 与 vendor 原文件精确 diff + `bash -n` + `nginx -t` | 同左 |
+| envd 二进制 | `COPY --from=base:v0.0.44 /.fce2b/envd` | 同左（静态链接，跨发行版可用） |
+| envd 常驻 | 加 `process-compose.envd.yaml` + 注册 | supervisord 托管 + `startretries` 调大 |
+| 5000 监听 | 通常已有（browser-tool 例外） | 自己装 openresty |
+| 多端口路由 | 通常已有（browser-tool 例外） | 自己写 lua route |
+| `user` 账号 | 自带 | **必须自己建** |
+| 构建期自检 | 与 vendor 原文件精确 diff + `bash -n` + `nginx -t` | `openresty -t` + 语义 `grep` + `id user` + 依赖 `import` |
+
+> 完整源码与逐条设计取舍见独立工程 [`e2b-custom-image`](https://github.com/aliyun-fc/fc-e2b-samples/tree/main/e2b-custom-image)，clone 下来即可复现全流程。
 
 ---
 


### PR DESCRIPTION
## 概述

把英文版 **envd 集成教程** 对齐到作为权威来源的中文文档（中文已演进到更新的验证方法），使中英在内容、示例、验证方式和结构上一致。同时根据评审意见修正了两版共有的若干技术表述。

## 主要改动

**英文版对齐中文（首个提交）**
- **验证方法**：改为 `X-Sandbox-Port` 头 + `/__nope` 探测（原为旧的 `Host` 前缀 + `/health` 204），覆盖 §3 步骤 3、§4 验收清单、§7 总结。
- **§3 步骤 5 探活**：用 `echo envd-ok` 替代 `true`（顺带验证 stdout 回传）。
- **§3 步骤 2**：补充构建期漂移护栏（与 vendor 精确 `diff`、`bash -n`）、漂移场景表，以及「不想 fork？」的 `CMD` 逃生口。
- **§6 移植**：四件要补的事表格、`debian:bookworm-slim` 起点、235MB vs vendor 镜像体积对比。
- 细节：平台要求处 `ACR` → `ACR EE`。

**评审意见修正（第二个提交，中英同步）**
- **[P1] 第四个成功条件**：明确三个条件只保证 envd **可达**，并不等于每条 `commands.run` 都成功；不传 `user=` 时会降权到 uid 1000 的 `user` 账号，该账号必须存在。§2.3 流程图终点由「SDK 可用」改为「envd 可达，传输打通」，并补充说明。
- **[P2] `autorestart=true` 不充分**：§6 流程图 supervisord 节点补上 `startretries 调大`，避免照图实施进入 FATAL。
- **[P2]「必须用 OpenResty」不准确**：改为真实要求「带 Lua 模块的 nginx」，说明示例用 OpenResty，并给出 Debian 的 `libnginx-mod-http-lua` 替代方案。
- **[P2] 不假设存在 vendor entrypoint**：§6 流程图 process-compose 分支改为「用现有启动机制注册」，fork entrypoint 降级为官方镜像示例。

## 说明
- 两处刻意保留的差异：README 链接按语种区分（`README.md` / `README_ZH-CN.md`）、英文 H1 标题保持英文习惯表达，未逐字镜像中文。
- 第二个提交新增一个外链（Debian 包页面，中英同一 URL），并改动了若干 mermaid 节点文案，建议合并前让 CI 重新跑一遍。

## 测试计划
- [ ] 渲染中英两个本地化页面，确认 mermaid 流程图、表格、代码块正常显示。
- [ ] 校验交叉引用/锚点（`#three-conditions`、`#fork-entrypoint`、`#local-validation`、`#porting`）可正常跳转。
- [ ] 确认示例仓库链接（`e2b-custom-image`）按语种指向正确的 README。