### PR TITLE
docs: add docs for network.rules

### DIFF
--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/05.网络访问控制.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/05.网络访问控制.md
@@ -52,10 +52,10 @@ python demo.py
 | `network.allowOut` | 出网**允许**清单，支持 IP / CIDR / 域名 | 支持 | 可（`updateNetwork`） |
 | `network.denyOut` | 出网**拒绝**清单，仅支持 IP / CIDR | 支持 | 可（`updateNetwork`） |
 | `network.egressProxy` | 出网 SOCKS5 代理 | **暂不支持** | — |
-| `network.maskRequestHost` | 改写沙箱请求的 `Host` 头 | **暂不支持** | — |
-| `network.rules` | 按域名对出网请求做转换（如注入 HTTP 头） | **暂不支持** | — |
+| `network.maskRequestHost` | 改写沙箱请求的 `Host` 头 | 支持 | 否（仅创建时可设） |
+| `network.rules` | 按域名对出网请求做转换（如注入 HTTP 头） | 支持 | 可（`updateNetwork`） |
 
-> 传入暂不支持的参数（`egressProxy`、`maskRequestHost`、`rules`）不会生效，请不要依赖其行为。
+> `egressProxy` **暂不支持**，传入不会生效。`network.rules` 的详细用法见 [出网请求头转换](07.出网请求头转换.md)。
 
 ## 公网访问鉴权
 
@@ -483,11 +483,11 @@ finally:
 注意：
 
 - `updateNetwork` 是**整体替换**，不与已有规则合并；传入空对象 `updateNetwork({})` 会清空创建时设置的全部 allow / deny 规则。
-- 仅出网相关的 `allowInternetAccess` / `allowOut` / `denyOut` 可更新。`allowPublicTraffic` 属于**创建时锁定**参数，创建后不可修改。
+- 出网相关的 `allowInternetAccess` / `allowOut` / `denyOut` / `network.rules` 可更新。`allowPublicTraffic` 与 `maskRequestHost` 属于**创建时锁定**参数，创建后不可修改。`network.rules` 的具体配置方式见 [出网请求头转换](07.出网请求头转换.md)。
 
 ## 限制与注意事项
 
-- `egressProxy`、`maskRequestHost`、`network.rules` **暂不支持**，传入不会生效。
+- `egressProxy` **暂不支持**，传入不会生效。
 - `trafficAccessToken` 在 create / connect / resume 时均返回；`getInfo` / `list` 不返回。建议持久化保存以简化使用。
 - `allowPublicTraffic` **仅创建时可设**，创建后不可修改。
 - `denyOut` **仅支持 IP / CIDR**，不支持域名；域名只能写在 `allowOut`。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/07.出网请求头转换.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/07.出网请求头转换.md
@@ -1,0 +1,326 @@
+# 出网请求头转换
+
+`network.rules` 可以在沙箱访问指定域名时，由平台在出站 HTTP/HTTPS 请求上新增、覆盖 Header，或替换 Header 值中的凭据占位符。真实凭据不需要进入沙箱环境变量、文件或代码。
+
+## 选择哪种方式
+
+| 方式 | 适用场景 | 沙箱发出的请求 |
+| --- | --- | --- |
+| 整 Header 注入 | 控制端能确定完整 Header，例如 `Authorization: Bearer ...` | 可以完全不带该 Header |
+| Header 值占位符替换 | 第三方 SDK 或沙箱代码必须动态拼 Header，只需隐藏其中的敏感片段 | 带 Header 结构和非敏感占位符 |
+
+若两者作用于同一个 Header，平台先替换占位符，再执行整 Header 注入，因此最终以整 Header 注入值为准。
+
+## 整 Header 注入
+
+**Node.js**
+
+```typescript
+import { Sandbox } from "e2b";
+
+const token = process.env.API_TOKEN;
+if (!token) throw new Error("API_TOKEN is required");
+
+const sandbox = await Sandbox.create({
+  network: {
+    allowOut: ["api.example.com"],
+    denyOut: ["0.0.0.0/0"],
+    rules: {
+      "api.example.com": [
+        {
+          transform: {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        },
+      ],
+    },
+  },
+});
+console.log(`[create] 沙箱已创建: ${sandbox.sandboxId}`);
+
+// 沙箱内程序请求 https://api.example.com 时，平台会自动注入 Authorization
+// 业务代码不需要再设置该 Header
+```
+
+**Python**
+
+```python
+import os
+
+from e2b import Sandbox
+
+token = os.environ["API_TOKEN"]
+
+sandbox = Sandbox.create(
+    network={
+        "allow_out": ["api.example.com"],
+        "deny_out": ["0.0.0.0/0"],
+        "rules": {
+            "api.example.com": [
+                {
+                    "transform": {
+                        "headers": {"Authorization": f"Bearer {token}"}
+                    }
+                }
+            ]
+        },
+    },
+)
+print(f"[create] 沙箱已创建: {sandbox.sandbox_id}")
+```
+
+沙箱内程序正常请求 `https://api.example.com` 即可，不需要再设置 `Authorization`。目标服务会收到平台注入后的 Header。
+
+## Header 值占位符替换
+
+当前 E2B SDK 未暴露独立的 replacement 字段。FC 云沙箱通过保留 Header 键承载替换规则，value 必须是替换数组的 JSON 字符串：
+
+```text
+fc.sandbox.network.header-value-replacements
+```
+
+该键只用于创建或更新规则，不会作为真实 HTTP Header 发给目标服务。
+
+**Node.js**
+
+```typescript
+import { Sandbox } from "e2b";
+
+const token = process.env.API_TOKEN;
+if (!token) throw new Error("API_TOKEN is required");
+
+const replacements = JSON.stringify([
+  { placeholder: "TOKEN_PLACEHOLDER", value: token },
+]);
+
+const sandbox = await Sandbox.create({
+  network: {
+    allowOut: ["api.example.com"],
+    denyOut: ["0.0.0.0/0"],
+    rules: {
+      "api.example.com": [
+        {
+          transform: {
+            headers: {
+              "fc.sandbox.network.header-value-replacements": replacements,
+            },
+          },
+        },
+      ],
+    },
+  },
+});
+```
+
+沙箱代码或第三方 SDK 发送：
+
+```http
+Authorization: Bearer TOKEN_PLACEHOLDER
+```
+
+目标服务收到：
+
+```http
+Authorization: Bearer real-token
+```
+
+**Python**
+
+```python
+import json
+import os
+
+from e2b import Sandbox
+
+token = os.environ["API_TOKEN"]
+carrier = json.dumps(
+    [{"placeholder": "TOKEN_PLACEHOLDER", "value": token}]
+)
+
+sandbox = Sandbox.create(
+    network={
+        "allow_out": ["api.example.com"],
+        "deny_out": ["0.0.0.0/0"],
+        "rules": {
+            "api.example.com": [
+                {
+                    "transform": {
+                        "headers": {
+                            "fc.sandbox.network.header-value-replacements": carrier
+                        }
+                    }
+                }
+            ]
+        },
+    },
+)
+```
+
+replacement 大小写敏感，会替换同一 Header value 中的所有匹配项。替换只扫描一次，生成的新内容不会继续触发其他 replacement；未命中的占位符会原样发给目标服务。
+
+## 运行时更新
+
+`network.rules` 支持通过 `updateNetwork`（TypeScript）/ `update_network`（Python）在**不重建沙箱**的情况下修改。`PUT /sandboxes/{id}/network` 是**全量替换**，不是 patch。更新时应同时提交最终的 `allowOut`、`denyOut` 和 `rules`。省略 `rules`、传 `null` 或传 `{}` 都会清空已有规则。
+
+更新失败时旧规则继续生效。网络规则不会因 Pause 丢失。沙箱处于 Paused 状态时，您仍可以更新 network.rules；Resume 后，沙箱将以最新的规则生效。
+
+**Node.js**
+
+```typescript
+import { Sandbox } from "e2b";
+
+const sandbox = await Sandbox.create({
+  network: {
+    allowOut: ["api.example.com"],
+    denyOut: ["0.0.0.0/0"],
+  },
+});
+console.log(`[create] 沙箱已创建: ${sandbox.sandboxId}`);
+
+// 后续新增规则
+await sandbox.updateNetwork({
+  allowOut: ["api.example.com"],
+  denyOut: ["0.0.0.0/0"],
+  rules: {
+    "api.example.com": [
+      {
+        transform: {
+          headers: {
+            Authorization: `Bearer ${process.env.API_TOKEN}`,
+          },
+        },
+      },
+    ],
+  },
+});
+console.log("[update] 已下发 network.rules");
+
+// 清空规则
+await sandbox.updateNetwork({
+  allowOut: ["api.example.com"],
+  denyOut: ["0.0.0.0/0"],
+});
+console.log("[update] 已清空 network.rules");
+```
+
+**Python**
+
+```python
+import os
+
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    network={
+        "allow_out": ["api.example.com"],
+        "deny_out": ["0.0.0.0/0"],
+    },
+)
+print(f"[create] 沙箱已创建: {sandbox.sandbox_id}")
+
+# 后续新增规则
+sandbox.update_network({
+    "allow_out": ["api.example.com"],
+    "deny_out": ["0.0.0.0/0"],
+    "rules": {
+        "api.example.com": [
+            {
+                "transform": {
+                    "headers": {
+                        "Authorization": f"Bearer {os.environ['API_TOKEN']}"
+                    }
+                }
+            }
+        ]
+    },
+})
+print("[update] 已下发 network.rules")
+
+# 清空规则
+sandbox.update_network({
+    "allow_out": ["api.example.com"],
+    "deny_out": ["0.0.0.0/0"],
+})
+print("[update] 已清空 network.rules")
+```
+
+通过 `getInfo` 或 `GET /sandboxes/{id}` 查询到的 `network.rules` 会回显当前生效规则，可用于后续更新。其中 replacement 会被重新编码为 carrier，真实 `value` 以明文返回，因此不要把查询响应写入普通日志、工单或前端错误上报。
+
+## 配置限制
+
+| 项目 | 限制 |
+| --- | ---: |
+| 目标域名 | 最多 10 个；仅精确 DNS 域名，精确匹配、不匹配子域，不支持 wildcard、IP、CIDR、URL、端口或路径 |
+| 每个域名 | 必须恰好 1 条 rule |
+| 普通 Header | 每条最多 20 个；name 1..64 bytes；value 最多 2048 bytes |
+| 整体 rules | 序列化后最多 64 KiB |
+| replacement | 每域名最多 16 个；每沙箱最多 64 个 |
+| placeholder | 8..128 bytes；只允许字母、数字、`_`、`.`、`-` |
+| replacement value | 1..2048 bytes |
+
+placeholder 不能等于真实 value，不能重复，也不能互为子串。
+
+以下类型的 Header 不支持配置或不会执行 replacement：`Host`、`Content-Length`、`Transfer-Encoding`、`Connection`、`Upgrade`、代理认证 Header、`x-envoy-*`、`x-forwarded-*` 以及其他路由/帧控制 Header。受限 Header 集合可能随平台版本调整，不要依赖这些 Header 在不同版本中的接受行为。
+
+## 安全建议
+
+- 只在受信任控制端读取和提交真实凭据，不要把密钥写进代码仓库；
+- 使用 Secret 管理、CI Secret 或经过鉴权的短期业务凭据；
+- 优先使用 HTTPS。HTTP 请求离开节点代理后是明文，凭据可能在链路上暴露；
+- 使用短期、最小权限、按租户或会话隔离且可撤销的凭据；
+- 只为实际目标配置精确域名，确认目标不会回显或记录认证 Header；
+- 保护创建、更新和查询接口的身份权限，避免打印完整 `network.rules`；
+- 占位符本身不要包含可用的真实凭据。
+
+## 常见问题
+
+### 为什么配置了 rules 仍无法访问目标？
+
+`rules` 不会放行网络。检查目标是否在 `allowOut` 中，以及 `denyOut` 是否覆盖了它。
+
+### HTTP 正常，HTTPS 报证书错误？
+
+平台需要解密 HTTPS 才能修改 Header，因此会在节点出口代理上执行 TLS inspection，并用平台 CA 为目标域名动态签发证书；同时平台会校验真实上游服务的 HTTPS 证书。
+
+如果沙箱客户端不信任平台 CA，检查证书文件、模板版本和语言 truststore。官方模板及受支持的 Debian/Ubuntu 自定义模板会配置平台 CA，curl、Python requests 和 Node.js 可开箱即用；以下客户端通常需要自行配置信任：
+
+- Java：把 `/usr/local/share/ca-certificates/e2b-ca.crt` 导入 JVM `cacerts` 或应用 truststore；
+- Firefox/NSS；
+- 只读取 OpenSSL CApath 的应用；
+- 非 Debian/Ubuntu 自定义镜像；
+- 使用私有 trust bundle、证书 pinning 或忽略系统环境变量的客户端。
+
+同时请确认使用的模板版本，模板过旧会导致平台 CA 未注入：
+
+- 如果使用官方镜像，请确保版本不低于 `v0.0.44`：
+  - `fc-e2b-registry.${regionId}.cr.aliyuncs.com/runtime/base:v0.0.44`
+  - `fc-e2b-registry.${regionId}.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.44`
+- 如果是自定义镜像，请确保镜像构建发生在 2026-08-15 平台发布完成之后，旧镜像不会自动获得平台 CA。
+
+### 目标服务使用自签证书或私有 CA，为什么请求仍失败？
+
+HTTPS 命中 rule 后，平台出口代理会重新向目标服务建立 TLS，并使用节点侧 trust bundle 校验目标证书。沙箱系统 CA、Python/Node truststore 或用户放入沙箱的私有 CA 不会传递给节点代理；即使沙箱内客户端原本信任该证书，目标 CA 不在节点 trust bundle 中时请求仍会失败。仅把目标 CA 安装进沙箱不能修复这种情况。
+
+当前不支持通过 `rules` 上传自定义上游 CA，也不会跳过目标证书校验。
+
+### 哪些协议或场景不支持？
+
+不支持 ECH、QUIC/HTTP3、显式 CONNECT proxy、要求客户端证书的上游 mTLS、WebSocket/HTTP Upgrade 和非 80/443 端口转换。
+
+### 占位符为什么没有替换？
+
+检查目标是否为精确 host、placeholder 大小写和内容是否完全一致、Header 是否属于 `x-forwarded-*` 等受限集合，以及同一 Header 是否随后被整值注入覆盖。
+
+### 可以替换 Body、URL 或响应吗？
+
+不可以。当前只处理出站 HTTP/HTTPS 请求 Header。
+
+### 沙箱内可以读取真实值吗？
+
+正常情况下不可以。沙箱只能看到自己构造的 Header 和占位符；转换发生在节点出口链路。受信任控制端和 FC 平台执行链路可以看到真实值。
+
+### 如何立即撤销凭据？
+
+更新网络配置清空对应规则，并在凭据系统中撤销/轮换凭据。为了覆盖已有长连接和控制面不确定状态，强撤销场景不能只依赖删除规则。


### PR DESCRIPTION
Change-Id: I51cdd90f2994163b73f1968a2b162322979c5ced
Co-developed-by: Qoder <noreply@qoder.com>

## 变更说明

请说明本次修改涉及的产品、章节和问题。

## 变更类型

- [ ] 修正文档内容
- [ ] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [ ] 已运行 `make check`
- [ ] 已检查新增或修改的链接和图片
- [ ] 未提交真实凭证或敏感信息

## 相关 Issue

如有，请填写 Issue 链接。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 文档范围

- 产品：阿里云函数计算云沙箱。
- 章节：功能说明 > 网络。
- 修改 `05.网络访问控制.md`，补充 `network.rules` 文档链接，并更新网络参数和运行时更新说明。
- 新增 `07.出网请求头转换.md`，介绍使用 `network.rules` 配置出站请求头转换。

## 页面与资源变更

- 新增 1 个文档页面。
- 未删除文档页面。
- 未改动图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->