### PR TITLE
docs: 更新云沙箱休眠与恢复 FAQ（中英文）

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/08.FAQ/08.Hibernation and Resume.md
+++ b/docs/en-US/01.FC Agent Sandbox/08.FAQ/08.Hibernation and Resume.md
@@ -4,7 +4,7 @@
 
 The active state means the sandbox is running. It is suitable for continuous command execution, keeping service ports open, handling interactive tasks, or carrying longrun workloads.
 
-Light hibernation preserves sandbox state while reducing resource usage. Under the current billing rules, it is available only on the Pro plan, and memory and disk usage are still billed.
+Light hibernation preserves sandbox state while reducing resource usage. When a sandbox is idle (CPU usage below 0.01 core, network traffic below 1,000 Bytes/s, or no incoming requests), it enters light hibernation automatically. Do not rely on these thresholds to design precise state transitions. Light hibernation is available only on the Pro plan and requires no allowlist application. During light hibernation, vCPU charges stop and only memory and disk usage are billed.
 
 Deep hibernation preserves sandbox state at a lower resource cost. It does not incur vCPU or memory charges, but deep-hibernation disk usage is still billed.
 
@@ -14,7 +14,7 @@ They reduce repeated initialization and idle resource usage while preserving san
 
 If every task recreates a sandbox from scratch, developers repeatedly wait for environment preparation, dependency loading, service startup, and context restoration. Hibernation and resume allow a sandbox to return to an available state while preserving its runtime context, which reduces repeated initialization.
 
-The E2B-compatible SDK currently exposes `sandbox.pause()`. A sandbox enters the `paused` state, which corresponds to deep hibernation, and can later be resumed through `Sandbox.connect(sandboxId)`. Pause and resume are currently available only to allowlisted accounts. The SDK does not provide an application API for choosing light hibernation. Availability of light hibernation depends on the current plan and console capabilities.
+The E2B-compatible SDK currently exposes `sandbox.pause()`. A sandbox enters the `paused` state, which corresponds to deep hibernation, and can later be resumed through `Sandbox.connect(sandboxId)`. Pause and resume are currently available only to allowlisted accounts. The SDK does not provide an application API for choosing light hibernation; the system triggers it automatically when the sandbox is idle.
 
 ## How long does resume take?
 
@@ -30,10 +30,50 @@ For billing differences and plan restrictions, see [Pay-as-you-go](../03.Pricing
 
 When using the E2B-compatible SDK, call `pause()` for work that must preserve state, and later resume it through `Sandbox.connect()`. If the task is complete and its state is no longer needed, terminate the sandbox and release its resources.
 
-To use light hibernation, first confirm that the account plan and console provide an entry point. Then test actual resume latency and cost before deciding whether it suits the workload.
+Light hibernation is triggered automatically by the system when the sandbox is idle and requires no allowlist application.
 
 ## What should be recorded when using hibernation and resume?
 
 At a minimum, record the `sandboxId`, task ID, template version, current phase, key file paths, and key process or port information.
 
 After resume, it is recommended to run a lightweight health check, such as confirming that the command channel is available, key files exist, and service ports are reachable. This makes hibernation and resume part of a stable business state machine instead of relying only on the result of a single SDK call.
+
+## Is a sandbox destroyed automatically after `sandbox.kill()` is called?
+
+Yes. `sandbox.kill()` is an explicit destroy operation. After the call succeeds, the sandbox is destroyed permanently and cannot be resumed through `Sandbox.connect(sandboxId)`.
+
+If you still need to resume the sandbox later, pause it instead of calling `sandbox.kill()`.
+
+## How long without requests before a sandbox enters light hibernation?
+
+Light hibernation is not triggered by the time since the last request alone. The system uses request awareness to decide whether a sandbox is idle: when CPU usage is below 0.01 core, network traffic is below 1,000 Bytes/s, or no requests arrive, the sandbox enters light hibernation automatically. During light hibernation, vCPU charges stop and only memory and disk usage are billed.
+
+Do not rely on these thresholds to design precise state transitions. Light hibernation is available only on the Pro plan and requires no allowlist application.
+
+## Does the `timeout` timer pause or reset while a sandbox is executing code or commands?
+
+No. The `timeout` counts continuously from sandbox creation. Executing code or commands does not pause or reset the timer.
+
+When the timeout is reached, the action configured in `lifecycle.on_timeout` runs even if the sandbox is still executing code or commands. If it is configured as `pause`, the sandbox enters deep hibernation. If it is configured as `kill`, the sandbox is destroyed permanently.
+
+## Is the `timeout` extended automatically while a sandbox is in active use?
+
+No. Running code, executing commands, or sending requests does not extend the sandbox's timeout automatically. To extend it, call the SDK's `set_timeout` method explicitly before the timeout is reached.
+
+`set_timeout` accepts the new timeout in seconds and restarts the countdown from the time of the call. For example, after you call `sandbox.set_timeout(600)`, the sandbox counts down 600 seconds from that call. This behavior matches the official E2B SDK.
+
+## Can I set the retention duration of a paused sandbox through `reserve-paused-sandbox-duration`?
+
+No. `e2b.agents.kruise.io/reserve-paused-sandbox-duration` is not a configuration supported by this service. It is a metadata parameter used by other platforms and cannot set the retention duration of a paused sandbox.
+
+This service manages sandbox timeouts only through the `timeout` parameter. Do not rely on that metadata to keep a paused sandbox for 48 hours.
+
+Different plans provide different retention durations for deep-hibernated sandboxes. Refer to the service description of your plan for the exact duration.
+
+## Can I customize the retention duration of a deep-hibernated sandbox and have it deleted automatically when the duration expires?
+
+Not yet. You cannot currently customize the retention duration of a deep-hibernated sandbox or configure automatic deletion after a specified time. This capability is being planned.
+
+## Can a paused sandbox resume automatically?
+
+Yes. When you create a sandbox, enable automatic resume through the `lifecycle` configuration, for example `lifecycle={"on_timeout": "pause", "auto_resume": True}` (requires `on_timeout` to be set to `pause`). Pause and resume require allowlist enablement. With this option enabled, subsequent activity — incoming requests or SDK operations — wakes a paused sandbox directly, without calling `Sandbox.connect(sandboxId)` first. Even without automatic resume enabled, reconnecting through `Sandbox.connect(sandboxId)` resumes a paused sandbox.

--- a/docs/zh-CN/01.云沙箱/08.常见问题/08.休眠与恢复.md
+++ b/docs/zh-CN/01.云沙箱/08.常见问题/08.休眠与恢复.md
@@ -4,7 +4,7 @@
 
 活跃状态表示 Sandbox 正在运行，适合持续执行命令、保持服务端口、处理交互式任务或承载 longrun 任务。
 
-浅休眠用于在保留 Sandbox 现场的同时降低资源占用。按当前计费规则，它仅对 Pro 计划开放，且仍收取内存和磁盘费用。
+浅休眠用于在保留 Sandbox 现场的同时降低资源占用。当 Sandbox 空闲（CPU 消耗低于 0.01 core、网络流量低于 1,000 Bytes/s 或无请求）时，会自动进入浅休眠。不建议依赖上述阈值设计精确的状态切换逻辑。浅休眠仅 Pro 计划支持，无需申请白名单，浅休眠期间不收取 vCPU 费用，仅收取内存和磁盘费用。
 
 深休眠用于在更低资源成本下保留 Sandbox 状态。它不收取 vCPU 和内存费用，但仍收取深休眠磁盘费用。
 
@@ -14,7 +14,7 @@
 
 如果每次任务都重新创建 Sandbox，开发者需要反复等待环境准备、依赖加载、服务启动和上下文恢复。休眠/恢复让 Sandbox 可以在保留现场的基础上重新进入可用状态，减少重复初始化。
 
-当前 E2B 兼容 SDK 对外提供的是 `sandbox.pause()`：Sandbox 会进入 `paused`（深休眠）状态，之后可通过 `Sandbox.connect(sandboxId)` 恢复。暂停与恢复功能当前仅对已开通白名单的账号可用。SDK 文档未提供由应用选择浅休眠的接口；是否可使用浅休眠以当前计划和控制台开通能力为准。
+当前 E2B 兼容 SDK 对外提供的是 `sandbox.pause()`：Sandbox 会进入 `paused`（深休眠）状态，之后可通过 `Sandbox.connect(sandboxId)` 恢复。暂停与恢复功能当前仅对已开通白名单的账号可用。SDK 文档未提供由应用选择浅休眠的接口，浅休眠由系统在 Sandbox 空闲时自动触发。
 
 ## 恢复需要多长时间？
 
@@ -30,10 +30,50 @@ E2B 的 `pause()` 用于暂停一个 Sandbox，后续再连接同一个 Sandbox 
 
 使用 E2B 兼容 SDK 时，需要保留现场的任务调用 `pause()`，之后通过 `Sandbox.connect()` 恢复。任务已经完成、不再需要恢复现场时，应终止 Sandbox，释放资源。
 
-如需使用浅休眠，应先确认账号计划和控制台是否已提供对应入口，再根据实际恢复时延和成本测试决定。
+浅休眠由系统在 Sandbox 空闲时自动触发，无需申请白名单。
 
 ## 使用休眠/恢复时需要记录什么？
 
 至少记录 `sandboxId`、任务 ID、模板版本、当前阶段、关键文件路径、关键进程或端口信息。
 
 恢复后建议做一次轻量健康检查，例如确认命令通道可用、关键文件存在、服务端口可访问。这样可以把休眠/恢复纳入稳定的业务状态机，而不是只依赖一次 SDK 调用结果。
+
+## 调用 `sandbox.kill()` 后，Sandbox 是否会自动销毁？
+
+会。`sandbox.kill()` 是显式销毁操作。调用成功后，Sandbox 将被永久销毁，无法再通过 `Sandbox.connect(sandboxId)` 恢复。
+
+如果后续仍需恢复 Sandbox，请使用暂停操作，不要调用 `sandbox.kill()`。
+
+## Sandbox 在多久没有请求后会进入浅休眠？
+
+浅休眠不是单纯按距离上次请求的时间触发的。系统基于请求感知判断 Sandbox 是否空闲：当 CPU 消耗低于 0.01 core、网络流量低于 1,000 Bytes/s 或无请求时，Sandbox 会自动进入浅休眠，浅休眠期间不收取 vCPU 费用，仅收取内存和磁盘费用。
+
+不建议依赖上述阈值设计精确的状态切换逻辑。浅休眠仅 Pro 计划支持，无需申请白名单。
+
+## Sandbox 正在执行代码或命令时，`timeout` 计时器是否会暂停或重置？
+
+不会。`timeout` 从 Sandbox 创建后连续计时，执行代码或命令不会暂停或重置计时器。
+
+到达超时时间后，即使 Sandbox 仍在执行代码或命令，也会触发 `lifecycle.on_timeout` 配置的行为：配置为 `pause` 时，Sandbox 进入深休眠状态；配置为 `kill` 时，Sandbox 被永久销毁。
+
+## Sandbox 活跃使用期间是否会自动续期 `timeout`？
+
+不会。运行代码、执行命令或发送请求均不会自动延长 Sandbox 的超时时间。如需续期，需在超时前显式调用 SDK 的 `set_timeout` 方法。
+
+`set_timeout` 接收以秒为单位的新超时时长，并从调用时刻重新开始倒计时。例如，调用 `sandbox.set_timeout(600)` 后，Sandbox 将从本次调用开始重新倒计时 600 秒。该行为与 E2B 官方 SDK 一致。
+
+## 能否通过 `reserve-paused-sandbox-duration` 配置暂停后保留时长？
+
+不能。`e2b.agents.kruise.io/reserve-paused-sandbox-duration` 不是当前服务支持的配置，而是其他平台使用的 Metadata 参数，不能用于设置暂停后的 Sandbox 保留时长。
+
+当前服务仅支持通过 `timeout` 参数管理 Sandbox 的超时时间。不要依赖上述 Metadata 实现暂停后保留 48 小时的机制。
+
+不同的 Plan 提供不同的深休眠 Sandbox 保存时长，具体时长请以对应 Plan 的服务说明为准。
+
+## 是否支持自定义深休眠 Sandbox 的保存时长，并在到期后自动删除？
+
+暂不支持。目前用户无法自定义深休眠 Sandbox 的保存时长，也无法配置在指定时间后自动删除。该能力正在规划中。
+
+## 是否支持自动恢复已暂停的 Sandbox？
+
+支持。创建 Sandbox 时，可以通过 `lifecycle` 配置开启自动恢复，例如 `lifecycle={"on_timeout": "pause", "auto_resume": True}`（要求 `on_timeout` 设置为 `pause`）。暂停与恢复功能需要先开通白名单。开启后，后续对 Sandbox 的请求或 SDK 操作会直接唤醒已暂停的 Sandbox，无需先调用 `Sandbox.connect(sandboxId)`。未开启自动恢复时，通过 `Sandbox.connect(sandboxId)` 重连也会恢复已暂停的 Sandbox。


### PR DESCRIPTION
## 背景

产品侧提供了新版《休眠与恢复》FAQ 内容，需要同步更新中英文文档，并统一浅休眠的触发定义与计费口径。

## 变更内容

### FAQ（zh-CN `08.休眠与恢复.md` / en-US `08.Hibernation and Resume.md`）

- **新增 7 个问答**：
  - `sandbox.kill()` 后 Sandbox 是否自动销毁
  - Sandbox 多久没有请求后进入浅休眠
  - `timeout` 计时器在执行代码/命令时是否暂停或重置
  - 活跃使用期间是否自动续期 `timeout`（`set_timeout` 说明）
  - `reserve-paused-sandbox-duration` 不受支持的说明
  - 是否支持自定义深休眠保存时长并到期自动删除
  - 是否支持收到请求时自动恢复（`auto_resume=True`）
- **浅休眠表述更新**：
  - 触发机制统一为请求感知空闲定义：CPU 消耗 < 0.01 core 或网络流量 < 1,000 Bytes/s 或无请求，由系统自动触发
  - 标注浅休眠无需申请白名单
  - 计费口径与按量付费文档保持一致：不收取 vCPU 费用，仅收取内存和磁盘费用

### 计划差异文档（en-US `03.FC Agent Sandbox Plan Features by Tier.md`）

- 浅休眠注释中的 `shallow sleep` 术语统一为 `light hibernation`，与全站术语一致

## 未改动说明

- 按量付费文档（中英文）计费规则、示例表格保持原文，作为计费口径基准
- 计划能力矩阵（浅休眠仅 Pro 计划）保持原样，FAQ 中计划限制继续引用按量付费文档
- 中文版计划差异文档注释本身已是请求感知空闲定义，无需改动

## 测试计划

- [x] `make check-docs` 通过（699 个 Markdown 文件、682 个资源、全部本地引用）
- [x] `make test` 通过（13 个测试）
- [x] 全局扫描确认无残留旧口径表述（"只收取内存费用"、"CPU 负载 3%" 等）
- [ ] TODO: 审阅浅休眠触发定义与计费口径是否符合最新产品行为
- [ ] TODO: 确认新增 FAQ 中 `auto_resume`、`lifecycle.on_timeout`、`set_timeout` 等 SDK 行为描述准确

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 更新阿里云函数计算的云沙箱文档，涉及以下章节：

- 英文“按计划查看云沙箱功能”章节：将 `shallow sleep` 统一为 `light hibernation`，并明确内存和磁盘按标准费率计费。
- 中英文“休眠与恢复”FAQ 章节：补充休眠触发条件、计费规则、`sandbox.kill()`、`timeout`、保留时长及 `auto_resume=True` 等说明。

本 PR 未新增或删除文档页面，仅修改现有的 3 个页面。

本 PR 未修改图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->