### PR TITLE
docs(sandbox): 在文档中添加 AgenticFS Access Point 状态提示

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md
@@ -20,6 +20,8 @@ Before you begin, prepare the following:
 
 - The Alibaba Cloud identity that calls the POP SDK has the `fcsandbox:CreateVolume` permission. Querying Volumes requires `fcsandbox:ListVolumes` and `fcsandbox:GetVolume`, and deleting Volumes requires `fcsandbox:DeleteVolume`.
 
+> Note: Before creating a sandbox, make sure that the AgenticFS Access Point corresponding to `SERVER_ADDR` is in the `active` state.
+
 For how to create a Team and obtain the Team ID, see [Create a Team](../../01.Getting%20Started/02.Create%20a%20Team.md).
 
 ## Permission Configuration

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md
@@ -20,7 +20,7 @@ Before you begin, prepare the following:
 
 - The Alibaba Cloud identity that calls the POP SDK has the `fcsandbox:CreateVolume` permission. Querying Volumes requires `fcsandbox:ListVolumes` and `fcsandbox:GetVolume`, and deleting Volumes requires `fcsandbox:DeleteVolume`.
 
-> Note: Before creating a sandbox, make sure that the AgenticFS Access Point corresponding to `SERVER_ADDR` is in the `active` state.
+> Note: Before creating a sandbox, make sure that the corresponding AgenticFS Access Point is in the `active` state. Otherwise, the `createSandbox` call may time out or fail. To check the status, log on to the [AgenticFS console](https://nasnext.console.aliyun.com/), find the corresponding FileSystem, go to the FileSystem details page, and click **Mount and Use** to view the mount point status.
 
 For how to create a Team and obtain the Team ID, see [Create a Team](../../01.Getting%20Started/02.Create%20a%20Team.md).
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/02.Mount an AgenticFS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/02.Mount an AgenticFS Volume.md
@@ -10,7 +10,7 @@ When creating a sandbox, use `volume_mounts` to mount an existing AgenticFS Volu
 - A function execution RAM Role is ready. The Role has AgenticFS mount and read/write permissions, and its trust policy allows the Function Compute service to assume it.
 - The FC Agent Sandbox API URL, domain, and an available template are ready.
 
-> Note: Before creating a sandbox, make sure that the AgenticFS Access Point corresponding to `SERVER_ADDR` is in the `active` state.
+> Note: Before creating a sandbox, make sure that the corresponding AgenticFS Access Point is in the `active` state. Otherwise, the `createSandbox` call may time out or fail. To check the status, log on to the [AgenticFS console](https://nasnext.console.aliyun.com/), find the corresponding FileSystem, go to the FileSystem details page, and click **Mount and Use** to view the mount point status.
 
 ## Configure permissions
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/02.Mount an AgenticFS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/02.Mount an AgenticFS Volume.md
@@ -10,6 +10,8 @@ When creating a sandbox, use `volume_mounts` to mount an existing AgenticFS Volu
 - A function execution RAM Role is ready. The Role has AgenticFS mount and read/write permissions, and its trust policy allows the Function Compute service to assume it.
 - The FC Agent Sandbox API URL, domain, and an available template are ready.
 
+> Note: Before creating a sandbox, make sure that the AgenticFS Access Point corresponding to `SERVER_ADDR` is in the `active` state.
+
 ## Configure permissions
 
 Attach the following permission policy to the function execution RAM Role:

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md
@@ -20,7 +20,7 @@ AgenticFS 的产品说明参见[什么是 AgenticFS](https://help.aliyun.com/zh/
 
 - 调用 POP SDK 的阿里云身份具备 `fcsandbox:CreateVolume` 权限；查询 Volume 需要 `fcsandbox:ListVolumes` 和 `fcsandbox:GetVolume` 权限；删除 Volume 还需要 `fcsandbox:DeleteVolume` 权限。
 
-> 注意：创建 Sandbox 前，必须确保对应的 AgenticFS Access Point 处于 `active` 状态，否则 createSandbox 会超时或者失败。
+> 注意：创建 Sandbox 前，必须确保对应的 AgenticFS Access Point 处于 `active` 状态，否则 `createSandbox` 调用可能超时或失败。您可以登录 [AgenticFS 控制台](https://nasnext.console.aliyun.com/)，找到对应的 FileSystem，进入 FileSystem 详情页面，然后单击**挂载使用**查看挂载点状态。
 
 Team 的创建和 Team ID 获取方式参见[创建 Team](../../01.开始使用/02.创建%20Team.md)。
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md
@@ -20,6 +20,8 @@ AgenticFS 的产品说明参见[什么是 AgenticFS](https://help.aliyun.com/zh/
 
 - 调用 POP SDK 的阿里云身份具备 `fcsandbox:CreateVolume` 权限；查询 Volume 需要 `fcsandbox:ListVolumes` 和 `fcsandbox:GetVolume` 权限；删除 Volume 还需要 `fcsandbox:DeleteVolume` 权限。
 
+> 注意：创建 Sandbox 前，必须确保对应的 AgenticFS Access Point 处于 `active` 状态，否则 createSandbox 会超时或者失败。
+
 Team 的创建和 Team ID 获取方式参见[创建 Team](../../01.开始使用/02.创建%20Team.md)。
 
 ## 权限配置

--- a/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/02.挂载 AgenticFS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/02.挂载 AgenticFS Volume.md
@@ -10,6 +10,8 @@
 - 已准备函数执行 RAM Role。该 Role 具备 AgenticFS 挂载和读写权限，且信任策略允许函数计算服务扮演。
 - 已准备云沙箱 API URL、Domain 和可用模板。
 
+> 注意：创建 Sandbox 前，必须确保对应的 AgenticFS Access Point 处于 `active` 状态，否则 createSandbox 会超时或者失败。
+
 ## 配置权限
 
 请将以下权限策略授予函数执行 RAM Role：

--- a/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/02.挂载 AgenticFS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/02.挂载 AgenticFS Volume.md
@@ -10,7 +10,7 @@
 - 已准备函数执行 RAM Role。该 Role 具备 AgenticFS 挂载和读写权限，且信任策略允许函数计算服务扮演。
 - 已准备云沙箱 API URL、Domain 和可用模板。
 
-> 注意：创建 Sandbox 前，必须确保对应的 AgenticFS Access Point 处于 `active` 状态，否则 createSandbox 会超时或者失败。
+> 注意：创建 Sandbox 前，必须确保对应的 AgenticFS Access Point 处于 `active` 状态，否则 `createSandbox` 调用可能超时或失败。您可以登录 [AgenticFS 控制台](https://nasnext.console.aliyun.com/)，找到对应的 FileSystem，进入 FileSystem 详情页面，然后单击**挂载使用**查看挂载点状态。
 
 ## 配置权限
 


### PR DESCRIPTION
- 在创建 Sandbox 前提示需确认对应的 AgenticFS Access Point 处于 active 状态
- 补充此提示于创建 AgenticFS Volume 和挂载 AgenticFS Volume 两处文档
- 中英文版本均添加相应注意事项
- 规避了因 Access Point 状态异常导致 createSandbox 超时或失败问题

## 变更说明

请说明本次修改涉及的产品、章节和问题。

## 变更类型

- [x] 修正文档内容
- [ ] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [x] 已运行 `make check`
- [ ] 已检查新增或修改的链接和图片
- [ ] 未提交真实凭证或敏感信息

## 相关 Issue

如有，请填写 Issue 链接。
