### PR TITLE
docs(sandbox): 新增「为 Sandbox 中的 Agent 挂载 Skill」中英文文档

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Mount Skills for Agents in a Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Mount Skills for Agents in a Sandbox.md
@@ -31,7 +31,7 @@ Skill root directories for common Agents:
 | Agent | Global scope | Project / workspace scope | Explicit invocation | Verify loaded |
 |-------|-------------|--------------------------|--------------------|---------------|
 | Claude Code | `/home/user/.claude/skills/<name>/` | `<project>/.claude/skills/<name>/` | `/<name>` | No built-in command; probe with `/<name>` |
-| OpenClaw | `/home/user/.openclaw/skills/<name>/` (Managed) | `/home/user/.openclaw/workspace/skills/<name>/` (Workspace) | `/<name>` | `openclaw skills list` |
+| OpenClaw | `/home/user/.openclaw/skills/<name>/` (Managed) | `/home/user/.openclaw/workspace/skills/<name>/` (Workspace) | `/skill <name>` | `openclaw skills list` |
 
 Other Agents (such as Codex CLI, Cursor CLI, or the neutral `.agents/skills/` convention of the `AGENTS.md` ecosystem) integrate in exactly the same way. Skill discovery and loading are handled by the Agent itself — it scans its own conventional directory at startup, while FC Agent Sandbox only places the files there and does not parse them. Integrating any Agent therefore requires no change to the write logic, only two things to confirm:
 
@@ -50,7 +50,7 @@ Images do not preload custom Skills; Skills are written by the SDK at runtime. T
 
 ### Take the Union of frontmatter Fields
 
-Agents differ in what `SKILL.md` frontmatter they require: Claude Code only requires `description`, while OpenClaw also requires `name` and `user-invocable`. If the same Skill needs to serve multiple Agents, take the union of the fields to satisfy all of them at once:
+Agents differ in what `SKILL.md` frontmatter they require: Claude Code only requires `description`, while OpenClaw requires `name` and `description`. `user-invocable` is optional for OpenClaw and defaults to `true`. If the same Skill needs to serve multiple Agents, take the union of the fields to satisfy all of them at once:
 
 ```markdown
 ---
@@ -162,7 +162,7 @@ After writing, confirm that the Agent recognizes the Skill before running the ac
 print(sandbox.commands.run("openclaw skills list").stdout)
 
 result = sandbox.commands.run(
-    'openclaw agent --local --agent main --message "/summarize-changes"',
+    'openclaw agent --local --agent main --message "/skill summarize-changes"',
     timeout=0,
 )
 print(result.stdout)
@@ -178,19 +178,59 @@ result = sandbox.commands.run(
 print(result.stdout)
 ```
 
-Both support writing `/<name>` in the prompt for explicit invocation, or simply describing the task and letting the model load the Skill based on `description`.
+Claude Code uses `/<name>` in the prompt for explicit invocation; OpenClaw uses the always-available `/skill <name>`. You can also describe the task and let the model load the Skill based on `description`.
 
 ### Complete Example
 
-Skills do not persist with the image. When the sandbox is created and destroyed with the task, every creation repeats the write-then-invoke cycle:
+Skills do not persist with the image. When the sandbox is created and destroyed with the task, every creation repeats the write-then-invoke cycle. Inject the model API Key via `envs` when creating the sandbox, using the same configuration as [Claude Code Template](../04.Features/02.Templates/07.Other%20Templates/04.Claude%20Code%20Template.md).
+
+**China: Bailian DashScope**
 
 ```python
+from e2b_code_interpreter import Sandbox
+
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
+    envs={
+        "ANTHROPIC_AUTH_TOKEN": "<your-bailian-api-key>",
+        "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
+        "ANTHROPIC_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-max",
+    },
     timeout=3600,
-    envs={"ANTHROPIC_AUTH_TOKEN": "<your-model-api-key>"},
     **OPTS,
 )
+
+# You must initialize `~/.claude.json` before the first run, otherwise a corrupted config error may occur.
+sandbox.commands.run("echo '{}' > /home/user/.claude.json")
+
+upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
+
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null -p "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+
+**International: Anthropic direct connection**
+
+```python
+from e2b_code_interpreter import Sandbox
+
+sandbox = Sandbox.create(
+    template=TEMPLATE_NAME,
+    envs={"ANTHROPIC_API_KEY": "<your-anthropic-api-key>"},
+    timeout=3600,
+    **OPTS,
+)
+
+# You must initialize `~/.claude.json` before the first run, otherwise a corrupted config error may occur.
+sandbox.commands.run("echo '{}' > /home/user/.claude.json")
 
 upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
 
@@ -225,7 +265,7 @@ With the Skill watcher on (the default), an existing session may still load the 
 | Issue | Solution |
 |------|----------|
 | Skill has no effect | Verify that the write path matches the Agent's convention; the home directory inside a sandbox is `/home/user`, so replace `~/` from official docs |
-| Explicit invocation does not respond | Verify the syntax is `/<name>`, and that `<name>` matches both the directory name and the `name` in frontmatter |
+| Explicit invocation does not respond | Verify Claude Code uses `/<name>` and OpenClaw uses `/skill <name>`, and that `<name>` matches both the directory name and the `name` in frontmatter |
 | Model never selects the Skill automatically | `description` does not state the trigger scenario; add a `Use when ...` clause |
 | Skill still runs with the old content after an overwrite | The current session is still on its original snapshot; start a new session by passing a new `--session-id` or sending a standalone `/new` or `/reset` |
 | Listed in `openclaw skills list` but the session cannot use it | Same cause — takes effect once a new session starts |

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Mount Skills for Agents in a Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Mount Skills for Agents in a Sandbox.md
@@ -207,14 +207,14 @@ sandbox.kill()
 
 ## When an Overwritten Skill Takes Effect
 
-The Skill list is snapshotted **when a session starts**, and every subsequent turn in that session reuses the snapshot. After overwriting an existing Skill, start a new session for the change to take effect.
+The Skill list is snapshotted **when a session starts**. Later turns in the same session typically reuse that snapshot.
 
-**OpenClaw** starts a new session differently depending on how it is used:
+**OpenClaw** enables a Skill watcher by default. After you add, overwrite, or update a `SKILL.md`, the current session usually refreshes the snapshot on the next turn. To make the change take effect immediately, start a new session or reset the current one:
 
 - **CLI**: pass a new `--session-id`
-- **Gateway / chat UI**: send a standalone `/new` or `/reset` as its own message, not combined with the task
+- **Gateway / chat UI**: send `/new` or `/reset` as its own message, not combined with the task. `/new` creates a session and switches to it; `/reset` keeps the current session key but generates a new sessionId and context
 
-An existing session keeps running against the snapshot taken when it started, including the default session resumed after a Gateway restart — it is restored as-is from the on-disk session store; repeated `openclaw agent --local` calls likewise share one default session. Also note that `openclaw skills list` scans the disk while the current session reads its own snapshot, so being listed does not mean the current session can use it.
+With the Skill watcher on (the default), an existing session may still load the updated Skill on the next turn. If the watcher is off, a change is not detected, or you need a deterministic refresh, use `/new` or `/reset`. Sessions are stored in SQLite on the sandbox filesystem, so a process restart still resumes the default session and its old snapshot. Also note that `openclaw skills list` scans Skill directories on the sandbox disk, while the current session reads its own snapshot. Being listed does not mean the current session is already using it.
 
 **Claude Code** starts a new process and a new session on every `claude -p` invocation, so an overwrite takes effect on the next invocation.
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Mount Skills for Agents in a Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Mount Skills for Agents in a Sandbox.md
@@ -1,0 +1,241 @@
+# Mount Skills for Agents in a Sandbox
+
+A Skill is the capability extension unit of an Agent: a directory plus a `SKILL.md`. Mounting a Skill for an Agent inside FC Agent Sandbox always works the same way — write the Skill directory to the path that the Agent expects, and the Agent scans it at startup. Agents differ only in **path** and **invocation syntax**; the way you write files is identical.
+
+This article covers the general integration steps, the cross-Agent path mapping, and the rules that determine when an overwritten Skill takes effect. For complete scenario tutorials for a single Agent, see [Use Claude Code Sandbox](05.Use%20Claude%20Code%20Sandbox.md) and [Use OpenClaw Sandbox](06.Use%20OpenClaw%20Sandbox.md).
+
+If this is your first time, complete the prerequisites, API key creation, and SDK setup in [Use FC Agent Sandbox with the SDK](../01.Getting%20Started/03.Quickstarts/01.Use%20FC%20Agent%20Sandbox%20with%20the%20SDK.md).
+
+---
+
+## Prerequisites
+
+- Completed [SDK integration](../01.Getting%20Started/03.Quickstarts/01.Use%20FC%20Agent%20Sandbox%20with%20the%20SDK.md) (E2B API Key, `api_url`, `domain`)
+- Built an Agent Template with status `ready` and created a `sandbox`
+  - For Claude Code, see [Claude Code Template](../04.Features/02.Templates/07.Other%20Templates/04.Claude%20Code%20Template.md)
+  - For OpenClaw, see [OpenClaw Template](../04.Features/02.Templates/07.Other%20Templates/05.OpenClaw%20Template.md)
+  - For other Agents, see [Build Custom Image Templates](../04.Features/02.Templates/03.Build%20Custom%20Image%20Templates.md)
+- Prepared a Skill source directory on your local machine, for example:
+
+```text
+./my-skills/summarize-changes/SKILL.md
+./my-skills/summarize-changes/scripts/collect.sh
+```
+
+---
+
+## Step 1: Identify the Skill Path of the Target Agent
+
+Skill root directories for common Agents:
+
+| Agent | Global scope | Project / workspace scope | Explicit invocation | Verify loaded |
+|-------|-------------|--------------------------|--------------------|---------------|
+| Claude Code | `/home/user/.claude/skills/<name>/` | `<project>/.claude/skills/<name>/` | `/<name>` | No built-in command; probe with `/<name>` |
+| OpenClaw | `/home/user/.openclaw/skills/<name>/` (Managed) | `/home/user/.openclaw/workspace/skills/<name>/` (Workspace) | `/<name>` | `openclaw skills list` |
+
+Other Agents (such as Codex CLI, Cursor CLI, or the neutral `.agents/skills/` convention of the `AGENTS.md` ecosystem) integrate in exactly the same way. Skill discovery and loading are handled by the Agent itself — it scans its own conventional directory at startup, while FC Agent Sandbox only places the files there and does not parse them. Integrating any Agent therefore requires no change to the write logic, only two things to confirm:
+
+1. **The Skill root directory of that Agent**: check the Skills section of its official documentation, or run the skills-related subcommand of its CLI inside the sandbox. Note that the default user inside a sandbox is `user` and the home directory is `/home/user`, so replace `~/` from official docs with `/home/user/`.
+2. **The frontmatter requirements of `SKILL.md`**: required fields differ across Agents; see Step 2.
+
+Once confirmed, replace the target path in the next step with that Agent's root directory. The write code stays the same.
+
+---
+
+## Step 2: Write the Skill
+
+Images do not preload custom Skills; Skills are written by the SDK at runtime. The write must happen **after the sandbox is created and before the Agent starts** — the Agent scans the Skill directory when its process starts, and anything written afterwards is not picked up by that process.
+
+> **About Template.copy**: Prefilling files with `.copy("local-dir", "/home/user/.claude/skills/...")` during `Template.build` is **not supported** yet. Use the runtime write approaches below for custom Skills.
+
+### Take the Union of frontmatter Fields
+
+Agents differ in what `SKILL.md` frontmatter they require: Claude Code only requires `description`, while OpenClaw also requires `name` and `user-invocable`. If the same Skill needs to serve multiple Agents, take the union of the fields to satisfy all of them at once:
+
+```markdown
+---
+name: summarize-changes
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+user-invocable: true
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+```
+
+`description` determines whether the model can select the Skill without an explicit invocation, so state both **what it does** and **when to use it**, as in `Use when reviewing diffs or writing commit messages.` above.
+
+### Single-File Skill
+
+When there is only a `SKILL.md`, write it directly:
+
+```python
+sandbox.files.write(
+    "/home/user/.claude/skills/summarize-changes/SKILL.md",
+    """---
+name: summarize-changes
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+user-invocable: true
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+""",
+)
+```
+
+### Multi-File Skill Directory
+
+When a Skill includes accompanying files such as `scripts/` or `references/`, use `files.write_files` to write them in one batch instead of calling `files.write` for each file:
+
+```python
+from pathlib import Path
+
+def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
+    local = Path(local_dir).resolve()
+    entries = []
+    for path in local.rglob("*"):
+        if path.is_file():
+            rel = path.relative_to(local).as_posix()
+            entries.append({
+                "path": f"{remote_root.rstrip('/')}/{rel}",
+                "data": path.read_bytes(),
+            })
+    sandbox.files.write_files(entries)
+
+upload_skill_dir(
+    sandbox,
+    "./my-skills/summarize-changes",
+    "/home/user/.claude/skills/summarize-changes",
+)
+```
+
+To switch Agents, replace `remote_root` only — for the OpenClaw Managed scope, use `/home/user/.openclaw/skills/summarize-changes`.
+
+### One Source Directory, Multiple Mount Points
+
+When the same Skill must serve multiple Agents inside a sandbox, list the mount points in an array and still make a single `write_files` call:
+
+```python
+from pathlib import Path
+
+# Skill root directories per Agent; add or remove as needed
+MOUNTS = [
+    "/home/user/.claude/skills",     # Claude Code
+    "/home/user/.openclaw/skills",   # OpenClaw Managed
+]
+
+def upload_skill(sandbox, local_dir: str, mounts: list[str]) -> None:
+    local = Path(local_dir).resolve()
+    name = local.name
+    entries = []
+    for path in local.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(local).as_posix()
+        data = path.read_bytes()
+        for mount in mounts:
+            entries.append({
+                "path": f"{mount.rstrip('/')}/{name}/{rel}",
+                "data": data,
+            })
+    sandbox.files.write_files(entries)
+
+upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
+```
+
+Maintain one Skill source directory locally, and every Agent in the sandbox gets its own copy. To add an Agent, append its root directory to `MOUNTS`.
+
+---
+
+## Step 3: Invoke and Verify Loading
+
+After writing, confirm that the Agent recognizes the Skill before running the actual task.
+
+**OpenClaw** can list loaded Skills directly:
+
+```python
+print(sandbox.commands.run("openclaw skills list").stdout)
+
+result = sandbox.commands.run(
+    'openclaw agent --local --agent main --message "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**Claude Code** has no equivalent list command, so use an explicit invocation as the probe:
+
+```python
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null -p "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+Both support writing `/<name>` in the prompt for explicit invocation, or simply describing the task and letting the model load the Skill based on `description`.
+
+---
+
+## When an Overwritten Skill Takes Effect
+
+The Skill directory is scanned only when the Agent process starts. Whether an overwritten Skill takes effect immediately therefore depends on whether the Agent runs once per invocation or stays resident.
+
+| Run mode | Typical command | Scan timing | After overwriting a Skill |
+|----------|----------------|-------------|--------------------------|
+| One-shot execution | `claude -p "..."`, `openclaw agent --local` | Every invocation is a new process and rescans | Effective on the next invocation |
+| Resident process | `openclaw gateway` | Scans only at process startup | Effective after restarting the process |
+
+**One-shot execution**: the sandbox is usually created and destroyed with the task, so the Skill must be written again on every creation.
+
+```python
+sandbox = Sandbox.create(
+    template=TEMPLATE_NAME,
+    timeout=3600,
+    envs={"ANTHROPIC_AUTH_TOKEN": "<your-model-api-key>"},
+    **OPTS,
+)
+
+upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
+
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null -p "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+
+**Resident process**: the Gateway scans the Skill directory at startup, so the order is **write the Skill first, then start the Gateway**. If you write or overwrite a Skill while the Gateway is already running, restarting the Gateway ensures a rescan; for the restart procedure, see [Use OpenClaw Sandbox](06.Use%20OpenClaw%20Sandbox.md).
+
+---
+
+## FAQ
+
+| Issue | Solution |
+|------|----------|
+| Skill has no effect | Verify that the write path matches the Agent's convention; the home directory inside a sandbox is `/home/user`, so replace `~/` from official docs |
+| Skill missing from `openclaw skills list` | Frontmatter is missing `name` or `user-invocable: true` |
+| Explicit invocation does not respond | Verify the syntax is `/<name>`, and that `<name>` matches both the directory name and the `name` in frontmatter |
+| Model never selects the Skill automatically | `description` does not state the trigger scenario; add a `Use when ...` clause |
+| Overwriting a Skill while the Gateway runs has no effect | Restart the Gateway to rescan the Skill directory |
+| `Template.copy` fails to prefill a Skill | Prefilling at build time is not supported; use the runtime `files.write` / `files.write_files` instead |
+| Other SDK / build issues | See [Template Management](../08.FAQ/05.Template%20Management.md) |
+
+---
+
+## References
+
+- [Use Claude Code Sandbox](05.Use%20Claude%20Code%20Sandbox.md) (clone repositories, MCP, Skills, structured output, and other scenario tutorials)
+- [Use OpenClaw Sandbox](06.Use%20OpenClaw%20Sandbox.md) (deploy Gateway, Agent CLI, security mode, Skill extension)
+- [Claude Code Template](../04.Features/02.Templates/07.Other%20Templates/04.Claude%20Code%20Template.md) (image addresses, build Template, MCP and Skill capability notes)
+- [OpenClaw Template](../04.Features/02.Templates/07.Other%20Templates/05.OpenClaw%20Template.md) (image addresses, build Template, Gateway parameters, Skill capability notes)
+- [Build Custom Image Templates](../04.Features/02.Templates/03.Build%20Custom%20Image%20Templates.md)
+- [Extend Claude with skills](https://code.claude.com/docs/en/skills)
+- [OpenClaw Skills](https://docs.openclaw.ai/tools/skills)

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Mount Skills for Agents in a Sandbox.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Mount Skills for Agents in a Sandbox.md
@@ -11,9 +11,9 @@ If this is your first time, complete the prerequisites, API key creation, and SD
 ## Prerequisites
 
 - Completed [SDK integration](../01.Getting%20Started/03.Quickstarts/01.Use%20FC%20Agent%20Sandbox%20with%20the%20SDK.md) (E2B API Key, `api_url`, `domain`)
-- Built an Agent Template with status `ready` and created a `sandbox`
+- Built an Agent Template with status `ready`, created a `sandbox`, and confirmed the Agent responds
   - For Claude Code, see [Claude Code Template](../04.Features/02.Templates/07.Other%20Templates/04.Claude%20Code%20Template.md)
-  - For OpenClaw, see [OpenClaw Template](../04.Features/02.Templates/07.Other%20Templates/05.OpenClaw%20Template.md)
+  - For OpenClaw, see [OpenClaw Template](../04.Features/02.Templates/07.Other%20Templates/05.OpenClaw%20Template.md); after creating the sandbox, OpenClaw additionally requires `onboard` and a default model, see [Use OpenClaw Sandbox](06.Use%20OpenClaw%20Sandbox.md)
   - For other Agents, see [Build Custom Image Templates](../04.Features/02.Templates/03.Build%20Custom%20Image%20Templates.md)
 - Prepared a Skill source directory on your local machine, for example:
 
@@ -44,7 +44,7 @@ Once confirmed, replace the target path in the next step with that Agent's root 
 
 ## Step 2: Write the Skill
 
-Images do not preload custom Skills; Skills are written by the SDK at runtime. The write must happen **after the sandbox is created and before the Agent starts** — the Agent scans the Skill directory when its process starts, and anything written afterwards is not picked up by that process.
+Images do not preload custom Skills; Skills are written by the SDK at runtime. The write must happen **after the sandbox is created and before the target session starts** — the Agent snapshots the Skill list when a session starts, and anything written afterwards is not picked up by a session already under way. See "When an Overwritten Skill Takes Effect" below.
 
 > **About Template.copy**: Prefilling files with `.copy("local-dir", "/home/user/.claude/skills/...")` during `Template.build` is **not supported** yet. Use the runtime write approaches below for custom Skills.
 
@@ -180,18 +180,9 @@ print(result.stdout)
 
 Both support writing `/<name>` in the prompt for explicit invocation, or simply describing the task and letting the model load the Skill based on `description`.
 
----
+### Complete Example
 
-## When an Overwritten Skill Takes Effect
-
-The Skill directory is scanned only when the Agent process starts. Whether an overwritten Skill takes effect immediately therefore depends on whether the Agent runs once per invocation or stays resident.
-
-| Run mode | Typical command | Scan timing | After overwriting a Skill |
-|----------|----------------|-------------|--------------------------|
-| One-shot execution | `claude -p "..."`, `openclaw agent --local` | Every invocation is a new process and rescans | Effective on the next invocation |
-| Resident process | `openclaw gateway` | Scans only at process startup | Effective after restarting the process |
-
-**One-shot execution**: the sandbox is usually created and destroyed with the task, so the Skill must be written again on every creation.
+Skills do not persist with the image. When the sandbox is created and destroyed with the task, every creation repeats the write-then-invoke cycle:
 
 ```python
 sandbox = Sandbox.create(
@@ -212,7 +203,20 @@ print(result.stdout)
 sandbox.kill()
 ```
 
-**Resident process**: the Gateway scans the Skill directory at startup, so the order is **write the Skill first, then start the Gateway**. If you write or overwrite a Skill while the Gateway is already running, restarting the Gateway ensures a rescan; for the restart procedure, see [Use OpenClaw Sandbox](06.Use%20OpenClaw%20Sandbox.md).
+---
+
+## When an Overwritten Skill Takes Effect
+
+The Skill list is snapshotted **when a session starts**, and every subsequent turn in that session reuses the snapshot. After overwriting an existing Skill, start a new session for the change to take effect.
+
+**OpenClaw** starts a new session differently depending on how it is used:
+
+- **CLI**: pass a new `--session-id`
+- **Gateway / chat UI**: send a standalone `/new` or `/reset` as its own message, not combined with the task
+
+An existing session keeps running against the snapshot taken when it started, including the default session resumed after a Gateway restart — it is restored as-is from the on-disk session store; repeated `openclaw agent --local` calls likewise share one default session. Also note that `openclaw skills list` scans the disk while the current session reads its own snapshot, so being listed does not mean the current session can use it.
+
+**Claude Code** starts a new process and a new session on every `claude -p` invocation, so an overwrite takes effect on the next invocation.
 
 ---
 
@@ -221,10 +225,10 @@ sandbox.kill()
 | Issue | Solution |
 |------|----------|
 | Skill has no effect | Verify that the write path matches the Agent's convention; the home directory inside a sandbox is `/home/user`, so replace `~/` from official docs |
-| Skill missing from `openclaw skills list` | Frontmatter is missing `name` or `user-invocable: true` |
 | Explicit invocation does not respond | Verify the syntax is `/<name>`, and that `<name>` matches both the directory name and the `name` in frontmatter |
 | Model never selects the Skill automatically | `description` does not state the trigger scenario; add a `Use when ...` clause |
-| Overwriting a Skill while the Gateway runs has no effect | Restart the Gateway to rescan the Skill directory |
+| Skill still runs with the old content after an overwrite | The current session is still on its original snapshot; start a new session by passing a new `--session-id` or sending a standalone `/new` or `/reset` |
+| Listed in `openclaw skills list` but the session cannot use it | Same cause — takes effect once a new session starts |
 | `Template.copy` fails to prefill a Skill | Prefilling at build time is not supported; use the runtime `files.write` / `files.write_files` instead |
 | Other SDK / build issues | See [Template Management](../08.FAQ/05.Template%20Management.md) |
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.为 Sandbox 中的 Agent 挂载 Skill.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.为 Sandbox 中的 Agent 挂载 Skill.md
@@ -207,14 +207,14 @@ sandbox.kill()
 
 ## 覆盖 Skill 后何时生效
 
-Skill 列表在**会话开始时**被快照，同一会话的后续每一轮都复用这份快照。因此覆盖已有 Skill 后，需要开启新会话才会生效。
+Skill 列表在**会话开始时**被快照，同一会话的后续轮次通常复用这份快照。
 
-**OpenClaw** 按使用方式开启新会话：
+**OpenClaw** OpenClaw 默认启用 Skill watcher；新增、覆盖或更新 SKILL.md 后，当前会话通常会在下一轮刷新快照。若要确保立即生效，建议开启新会话或重置当前会话：
 
 - **CLI**：指定一个新的 `--session-id`
-- **Gateway / 聊天界面**：发送独立的 `/new` 或 `/reset`，单独作为一条 message，不要和任务写在一起
+- **Gateway / 聊天界面**：单独发送 /new 或 /reset，不要和任务写在同一条消息中；/new 创建并切换到新会话，/reset 保留当前 session key，但生成新的 sessionId 和上下文
 
-沿用已有会话则继续按会话开始时的快照执行，包括 Gateway 重启后续用的默认会话 —— 它会从磁盘上的会话库原样恢复；`openclaw agent --local` 连续调用多次也同属一个默认会话。另外 `openclaw skills list` 扫描的是磁盘，当前会话读的是自己那份快照，列表里有不代表当前会话用得上。
+默认启用 Skill watcher 时，沿用已有会话也可能在下一轮加载更新后的 Skill；如果 watcher 被关闭、没有检测到变化或需要确定性刷新，则使用 /new 或 /reset。会话存在沙箱文件系统的 SQLite 中，进程重启后仍续用默认会话及其旧快照。另外：`openclaw skills list` 扫的是沙箱里的 Skill 目录；当前会话读的是自己那份快照。列表里有，不代表当前会话已经在用。
 
 **Claude Code** 每次 `claude -p` 调用都是新进程、新会话，覆盖后下次调用即生效。
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.为 Sandbox 中的 Agent 挂载 Skill.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.为 Sandbox 中的 Agent 挂载 Skill.md
@@ -11,9 +11,9 @@ Skill 是 Agent 的能力扩展单元：一个目录加一个 `SKILL.md`。在�
 ## 前置条件
 
 - 已完成 [SDK 接入](../01.开始使用/03.快速入门/01.通过%20SDK%20使用云沙箱.md)（E2B API Key、`api_url`、`domain`）
-- 已构建出状态为 `ready` 的 Agent 模板并创建 `sandbox`
+- 已构建出状态为 `ready` 的 Agent 模板并创建 `sandbox`，且该 Agent 已能正常应答
   - Claude Code 见 [Claude Code 模板](../04.功能说明/02.模板/07.其他模板/04.Claude%20Code%20模板.md)
-  - OpenClaw 见 [OpenClaw 模板](../04.功能说明/02.模板/07.其他模板/05.OpenClaw%20模板.md)
+  - OpenClaw 见 [OpenClaw 模板](../04.功能说明/02.模板/07.其他模板/05.OpenClaw%20模板.md)；创建沙箱后还需完成 `onboard` 与默认模型配置，见[使用 OpenClaw Sandbox](06.使用%20OpenClaw%20Sandbox.md)
   - 其他 Agent 见[构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)
 - 本机已准备 Skill 源目录，例如：
 
@@ -44,7 +44,7 @@ Skill 是 Agent 的能力扩展单元：一个目录加一个 `SKILL.md`。在�
 
 ## 步骤二：写入 Skill
 
-镜像不预装自定义 Skill，Skill 由 SDK 在运行时写入。写入必须发生在**沙箱创建之后、Agent 启动之前** —— Agent 在进程启动时扫描 Skill 目录，之后再写入的内容不会被当次进程识别。
+镜像不预装自定义 Skill，Skill 由 SDK 在运行时写入。写入要发生在**沙箱创建之后、目标会话开始之前** —— Agent 在会话开始时快照当前的 Skill 列表，之后再写入的内容不会被已开始的会话识别，详见下文「覆盖 Skill 后何时生效」。
 
 > **关于 Template.copy**：**暂不支持** `Template.build` 时用 `.copy("local-dir", "/home/user/.claude/skills/...")` 预置文件。自定义 Skill 请使用下方运行时写入方式。
 
@@ -180,18 +180,9 @@ print(result.stdout)
 
 两者都支持在提示词中写 `/<name>` 显式调用，也可以只描述任务、由模型依据 `description` 自动加载。
 
----
+### 完整示例
 
-## 覆盖 Skill 后何时生效
-
-Skill 目录仅在 Agent 进程启动时扫描，因此覆盖已有 Skill 后能否立即生效，取决于该 Agent 是一次性执行还是常驻运行。
-
-| 运行方式 | 典型命令 | 扫描时机 | 覆盖 Skill 后 |
-|---------|---------|---------|-------------|
-| 一次性执行 | `claude -p "..."`、`openclaw agent --local` | 每次调用都是新进程，重新扫描 | 下次调用即生效 |
-| 常驻运行 | `openclaw gateway` | 仅进程启动时扫描 | 重启进程后生效 |
-
-**一次性执行**：沙箱通常随任务创建和销毁，每次创建都要重新写入 Skill。
+Skill 不随镜像持久化，沙箱随任务创建和销毁时，每次创建都要重新走一遍「写入 — 调用」：
 
 ```python
 sandbox = Sandbox.create(
@@ -212,7 +203,20 @@ print(result.stdout)
 sandbox.kill()
 ```
 
-**常驻运行**：Gateway 在启动时扫描 Skill 目录，因此顺序是**先写入 Skill、再启动 Gateway**。若在 Gateway 运行期间才写入或覆盖 Skill，重启 Gateway 可确保重新扫描，重启流程见[使用 OpenClaw Sandbox](06.使用%20OpenClaw%20Sandbox.md)。
+---
+
+## 覆盖 Skill 后何时生效
+
+Skill 列表在**会话开始时**被快照，同一会话的后续每一轮都复用这份快照。因此覆盖已有 Skill 后，需要开启新会话才会生效。
+
+**OpenClaw** 按使用方式开启新会话：
+
+- **CLI**：指定一个新的 `--session-id`
+- **Gateway / 聊天界面**：发送独立的 `/new` 或 `/reset`，单独作为一条 message，不要和任务写在一起
+
+沿用已有会话则继续按会话开始时的快照执行，包括 Gateway 重启后续用的默认会话 —— 它会从磁盘上的会话库原样恢复；`openclaw agent --local` 连续调用多次也同属一个默认会话。另外 `openclaw skills list` 扫描的是磁盘，当前会话读的是自己那份快照，列表里有不代表当前会话用得上。
+
+**Claude Code** 每次 `claude -p` 调用都是新进程、新会话，覆盖后下次调用即生效。
 
 ---
 
@@ -221,10 +225,10 @@ sandbox.kill()
 | 现象 | 处理 |
 |------|------|
 | Skill 未生效 | 确认写入路径与该 Agent 的约定一致；沙箱内家目录为 `/home/user`，官方文档中的 `~/` 需替换 |
-| `openclaw skills list` 看不到 | frontmatter 缺 `name` 或 `user-invocable: true` |
 | 显式调用无响应 | 确认调用语法为 `/<name>`，且 `<name>` 与目录名、frontmatter 中的 `name` 一致 |
 | 模型不自动调用 | `description` 未写明触发场景，补充 `Use when ...` 描述 |
-| Gateway 运行中覆盖 Skill 不生效 | 重启 Gateway 重新扫描 Skill 目录 |
+| 覆盖 Skill 后仍按旧内容执行 | 当前会话仍在用开始时的快照，需开新会话：换新的 `--session-id`，或发送独立的 `/new`、`/reset` |
+| `openclaw skills list` 里有，但会话调用不到 | 同上，开新会话后生效 |
 | `Template.copy` 预置 Skill 失败 | 暂不支持构建时预置，改用运行时 `files.write` / `files.write_files` |
 | 其他 SDK / 构建问题 | 见[模板管理](../08.常见问题/05.模板管理.md) |
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.为 Sandbox 中的 Agent 挂载 Skill.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.为 Sandbox 中的 Agent 挂载 Skill.md
@@ -31,7 +31,7 @@ Skill 是 Agent 的能力扩展单元：一个目录加一个 `SKILL.md`。在�
 | Agent | 全局作用域 | 项目 / 工作区作用域 | 显式调用 | 确认已加载 |
 |-------|-----------|-------------------|---------|-----------|
 | Claude Code | `/home/user/.claude/skills/<name>/` | `<项目>/.claude/skills/<name>/` | `/<name>` | 无内置命令，用 `/<name>` 探针 |
-| OpenClaw | `/home/user/.openclaw/skills/<name>/`（Managed） | `/home/user/.openclaw/workspace/skills/<name>/`（Workspace） | `/<name>` | `openclaw skills list` |
+| OpenClaw | `/home/user/.openclaw/skills/<name>/`（Managed） | `/home/user/.openclaw/workspace/skills/<name>/`（Workspace） | `/skill <name>` | `openclaw skills list` |
 
 其他 Agent（如 Codex CLI、Cursor CLI，或 `AGENTS.md` 生态的 `.agents/skills/` 中立约定）接入方式完全相同。Skill 的发现与加载由 Agent 自身完成 —— 它在启动时扫描自己约定的目录；云沙箱只负责把文件放到该目录下，不参与解析。因此接入任意 Agent 都不需要改写入逻辑，只需确认两件事：
 
@@ -50,7 +50,7 @@ Skill 是 Agent 的能力扩展单元：一个目录加一个 `SKILL.md`。在�
 
 ### frontmatter 取并集
 
-各 Agent 对 `SKILL.md` 的 frontmatter 要求不同：Claude Code 只要求 `description`，OpenClaw 还需要 `name` 与 `user-invocable`。若同一份 Skill 要供多个 Agent 使用，取字段并集即可同时满足：
+各 Agent 对 `SKILL.md` 的 frontmatter 要求不同：Claude Code 只要求 `description`，OpenClaw 要求 `name` 与 `description`。`user-invocable` 为 OpenClaw 可选字段，默认 `true`。若同一份 Skill 要供多个 Agent 使用，取字段并集即可同时满足：
 
 ```markdown
 ---
@@ -162,7 +162,7 @@ upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
 print(sandbox.commands.run("openclaw skills list").stdout)
 
 result = sandbox.commands.run(
-    'openclaw agent --local --agent main --message "/summarize-changes"',
+    'openclaw agent --local --agent main --message "/skill summarize-changes"',
     timeout=0,
 )
 print(result.stdout)
@@ -178,19 +178,34 @@ result = sandbox.commands.run(
 print(result.stdout)
 ```
 
-两者都支持在提示词中写 `/<name>` 显式调用，也可以只描述任务、由模型依据 `description` 自动加载。
+Claude Code 在提示词中写 `/<name>` 显式调用；OpenClaw 使用始终可用的 `/skill <name>`。也可以只描述任务、由模型依据 `description` 自动加载。
 
 ### 完整示例
 
-Skill 不随镜像持久化，沙箱随任务创建和销毁时，每次创建都要重新走一遍「写入 — 调用」：
+Skill 不随镜像持久化，沙箱随任务创建和销毁时，每次创建都要重新走一遍「写入 — 调用」。创建沙箱时通过 `envs` 注入模型 API Key，写法与 [Claude Code 模板](../04.功能说明/02.模板/07.其他模板/04.Claude%20Code%20模板.md) 一致。
+
+<!-- @props:china -->
+**中国站：百炼 DashScope**
 
 ```python
+from e2b_code_interpreter import Sandbox
+
 sandbox = Sandbox.create(
     template=TEMPLATE_NAME,
+    envs={
+        "ANTHROPIC_AUTH_TOKEN": "<your-bailian-api-key>",
+        "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
+        "ANTHROPIC_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.7-max",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen3.7-max",
+    },
     timeout=3600,
-    envs={"ANTHROPIC_AUTH_TOKEN": "<你的模型 API Key>"},
     **OPTS,
 )
+
+# 首次运行前须初始化 `~/.claude.json`，否则可能报配置损坏。
+sandbox.commands.run("echo '{}' > /home/user/.claude.json")
 
 upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
 
@@ -202,6 +217,35 @@ print(result.stdout)
 
 sandbox.kill()
 ```
+<!-- @/props -->
+
+<!-- @props:intl -->
+**国际站：Anthropic 直连**
+
+```python
+from e2b_code_interpreter import Sandbox
+
+sandbox = Sandbox.create(
+    template=TEMPLATE_NAME,
+    envs={"ANTHROPIC_API_KEY": "<your-anthropic-api-key>"},
+    timeout=3600,
+    **OPTS,
+)
+
+# 首次运行前须初始化 `~/.claude.json`，否则可能报配置损坏。
+sandbox.commands.run("echo '{}' > /home/user/.claude.json")
+
+upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
+
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null -p "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+<!-- @/props -->
 
 ---
 
@@ -225,7 +269,7 @@ Skill 列表在**会话开始时**被快照，同一会话的后续轮次通常�
 | 现象 | 处理 |
 |------|------|
 | Skill 未生效 | 确认写入路径与该 Agent 的约定一致；沙箱内家目录为 `/home/user`，官方文档中的 `~/` 需替换 |
-| 显式调用无响应 | 确认调用语法为 `/<name>`，且 `<name>` 与目录名、frontmatter 中的 `name` 一致 |
+| 显式调用无响应 | 确认 Claude Code 使用 `/<name>`、OpenClaw 使用 `/skill <name>`，且 `<name>` 与目录名、frontmatter 中的 `name` 一致 |
 | 模型不自动调用 | `description` 未写明触发场景，补充 `Use when ...` 描述 |
 | 覆盖 Skill 后仍按旧内容执行 | 当前会话仍在用开始时的快照，需开新会话：换新的 `--session-id`，或发送独立的 `/new`、`/reset` |
 | `openclaw skills list` 里有，但会话调用不到 | 同上，开新会话后生效 |

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.为 Sandbox 中的 Agent 挂载 Skill.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.为 Sandbox 中的 Agent 挂载 Skill.md
@@ -1,0 +1,241 @@
+# 为 Sandbox 中的 Agent 挂载 Skill
+
+Skill 是 Agent 的能力扩展单元：一个目录加一个 `SKILL.md`。在云沙箱里给 Agent 挂载 Skill 的方法是统一的 —— 把 Skill 目录写进沙箱内该 Agent 约定的路径，Agent 启动时自动扫描。不同 Agent 的差异只在**路径**与**调用语法**，写入方式完全相同。
+
+本文说明通用接入步骤、跨 Agent 路径映射，以及覆盖 Skill 后的生效规则。单个 Agent 的完整场景教程见[使用 Claude Code Sandbox](05.使用%20Claude%20Code%20Sandbox.md)与[使用 OpenClaw Sandbox](06.使用%20OpenClaw%20Sandbox.md)。
+
+首次使用请先完成[通过 SDK 使用云沙箱](../01.开始使用/03.快速入门/01.通过%20SDK%20使用云沙箱.md)中的前置准备、API Key 创建和 SDK 配置。
+
+---
+
+## 前置条件
+
+- 已完成 [SDK 接入](../01.开始使用/03.快速入门/01.通过%20SDK%20使用云沙箱.md)（E2B API Key、`api_url`、`domain`）
+- 已构建出状态为 `ready` 的 Agent 模板并创建 `sandbox`
+  - Claude Code 见 [Claude Code 模板](../04.功能说明/02.模板/07.其他模板/04.Claude%20Code%20模板.md)
+  - OpenClaw 见 [OpenClaw 模板](../04.功能说明/02.模板/07.其他模板/05.OpenClaw%20模板.md)
+  - 其他 Agent 见[构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)
+- 本机已准备 Skill 源目录，例如：
+
+```text
+./my-skills/summarize-changes/SKILL.md
+./my-skills/summarize-changes/scripts/collect.sh
+```
+
+---
+
+## 步骤一：确认目标 Agent 的 Skill 路径
+
+常见 Agent 的 Skill 根目录：
+
+| Agent | 全局作用域 | 项目 / 工作区作用域 | 显式调用 | 确认已加载 |
+|-------|-----------|-------------------|---------|-----------|
+| Claude Code | `/home/user/.claude/skills/<name>/` | `<项目>/.claude/skills/<name>/` | `/<name>` | 无内置命令，用 `/<name>` 探针 |
+| OpenClaw | `/home/user/.openclaw/skills/<name>/`（Managed） | `/home/user/.openclaw/workspace/skills/<name>/`（Workspace） | `/<name>` | `openclaw skills list` |
+
+其他 Agent（如 Codex CLI、Cursor CLI，或 `AGENTS.md` 生态的 `.agents/skills/` 中立约定）接入方式完全相同。Skill 的发现与加载由 Agent 自身完成 —— 它在启动时扫描自己约定的目录；云沙箱只负责把文件放到该目录下，不参与解析。因此接入任意 Agent 都不需要改写入逻辑，只需确认两件事：
+
+1. **该 Agent 的 Skill 根目录**：查阅其官方文档的 Skills 章节，或在沙箱内运行其 CLI 的 skills 相关子命令查看。注意沙箱内默认用户为 `user`，家目录为 `/home/user`，官方文档中的 `~/` 需替换为 `/home/user/`。
+2. **`SKILL.md` 的 frontmatter 要求**：不同 Agent 的必填字段不同，见步骤二。
+
+确认后，把下一步中的目标路径换成该 Agent 的根目录即可，写入代码无需改动。
+
+---
+
+## 步骤二：写入 Skill
+
+镜像不预装自定义 Skill，Skill 由 SDK 在运行时写入。写入必须发生在**沙箱创建之后、Agent 启动之前** —— Agent 在进程启动时扫描 Skill 目录，之后再写入的内容不会被当次进程识别。
+
+> **关于 Template.copy**：**暂不支持** `Template.build` 时用 `.copy("local-dir", "/home/user/.claude/skills/...")` 预置文件。自定义 Skill 请使用下方运行时写入方式。
+
+### frontmatter 取并集
+
+各 Agent 对 `SKILL.md` 的 frontmatter 要求不同：Claude Code 只要求 `description`，OpenClaw 还需要 `name` 与 `user-invocable`。若同一份 Skill 要供多个 Agent 使用，取字段并集即可同时满足：
+
+```markdown
+---
+name: summarize-changes
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+user-invocable: true
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+```
+
+`description` 决定模型能否在未显式调用时自动命中该 Skill，需写清**做什么**与**何时用**，如上例的 `Use when reviewing diffs or writing commit messages.`。
+
+### 单文件 Skill
+
+只有 `SKILL.md` 时直接写入：
+
+```python
+sandbox.files.write(
+    "/home/user/.claude/skills/summarize-changes/SKILL.md",
+    """---
+name: summarize-changes
+description: Summarizes uncommitted changes and flags risks. Use when reviewing diffs or writing commit messages.
+user-invocable: true
+---
+
+## Instructions
+1. Run `git diff HEAD` and summarize changes in 2–3 bullets.
+2. List risks such as missing error handling or hardcoded values.
+3. If the diff is empty, say there are no uncommitted changes.
+""",
+)
+```
+
+### 多文件 Skill 目录
+
+Skill 含 `scripts/`、`references/` 等附属文件时，用 `files.write_files` 一次批量写入，不必逐文件调用 `files.write`：
+
+```python
+from pathlib import Path
+
+def upload_skill_dir(sandbox, local_dir: str, remote_root: str) -> None:
+    local = Path(local_dir).resolve()
+    entries = []
+    for path in local.rglob("*"):
+        if path.is_file():
+            rel = path.relative_to(local).as_posix()
+            entries.append({
+                "path": f"{remote_root.rstrip('/')}/{rel}",
+                "data": path.read_bytes(),
+            })
+    sandbox.files.write_files(entries)
+
+upload_skill_dir(
+    sandbox,
+    "./my-skills/summarize-changes",
+    "/home/user/.claude/skills/summarize-changes",
+)
+```
+
+换 Agent 只需替换 `remote_root`，例如 OpenClaw Managed 作用域用 `/home/user/.openclaw/skills/summarize-changes`。
+
+### 一份源目录，多处挂载
+
+同一份 Skill 要供沙箱内多个 Agent 使用时，把挂载点列成数组，仍然只调用一次 `write_files`：
+
+```python
+from pathlib import Path
+
+# 各 Agent 的 Skill 根目录，按需增减
+MOUNTS = [
+    "/home/user/.claude/skills",     # Claude Code
+    "/home/user/.openclaw/skills",   # OpenClaw Managed
+]
+
+def upload_skill(sandbox, local_dir: str, mounts: list[str]) -> None:
+    local = Path(local_dir).resolve()
+    name = local.name
+    entries = []
+    for path in local.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(local).as_posix()
+        data = path.read_bytes()
+        for mount in mounts:
+            entries.append({
+                "path": f"{mount.rstrip('/')}/{name}/{rel}",
+                "data": data,
+            })
+    sandbox.files.write_files(entries)
+
+upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
+```
+
+本机维护一份 Skill 源目录，沙箱内各 Agent 各得一份副本。新增 Agent 时只需向 `MOUNTS` 追加其根目录。
+
+---
+
+## 步骤三：调用与确认加载
+
+写入后先确认 Agent 已识别该 Skill，再执行任务。
+
+**OpenClaw** 可直接列出已加载 Skill：
+
+```python
+print(sandbox.commands.run("openclaw skills list").stdout)
+
+result = sandbox.commands.run(
+    'openclaw agent --local --agent main --message "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+**Claude Code** 没有对应的列出命令，直接用显式调用作为探针：
+
+```python
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null -p "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+两者都支持在提示词中写 `/<name>` 显式调用，也可以只描述任务、由模型依据 `description` 自动加载。
+
+---
+
+## 覆盖 Skill 后何时生效
+
+Skill 目录仅在 Agent 进程启动时扫描，因此覆盖已有 Skill 后能否立即生效，取决于该 Agent 是一次性执行还是常驻运行。
+
+| 运行方式 | 典型命令 | 扫描时机 | 覆盖 Skill 后 |
+|---------|---------|---------|-------------|
+| 一次性执行 | `claude -p "..."`、`openclaw agent --local` | 每次调用都是新进程，重新扫描 | 下次调用即生效 |
+| 常驻运行 | `openclaw gateway` | 仅进程启动时扫描 | 重启进程后生效 |
+
+**一次性执行**：沙箱通常随任务创建和销毁，每次创建都要重新写入 Skill。
+
+```python
+sandbox = Sandbox.create(
+    template=TEMPLATE_NAME,
+    timeout=3600,
+    envs={"ANTHROPIC_AUTH_TOKEN": "<你的模型 API Key>"},
+    **OPTS,
+)
+
+upload_skill(sandbox, "./my-skills/summarize-changes", MOUNTS)
+
+result = sandbox.commands.run(
+    'claude --dangerously-skip-permissions < /dev/null -p "/summarize-changes"',
+    timeout=0,
+)
+print(result.stdout)
+
+sandbox.kill()
+```
+
+**常驻运行**：Gateway 在启动时扫描 Skill 目录，因此顺序是**先写入 Skill、再启动 Gateway**。若在 Gateway 运行期间才写入或覆盖 Skill，重启 Gateway 可确保重新扫描，重启流程见[使用 OpenClaw Sandbox](06.使用%20OpenClaw%20Sandbox.md)。
+
+---
+
+## 常见问题
+
+| 现象 | 处理 |
+|------|------|
+| Skill 未生效 | 确认写入路径与该 Agent 的约定一致；沙箱内家目录为 `/home/user`，官方文档中的 `~/` 需替换 |
+| `openclaw skills list` 看不到 | frontmatter 缺 `name` 或 `user-invocable: true` |
+| 显式调用无响应 | 确认调用语法为 `/<name>`，且 `<name>` 与目录名、frontmatter 中的 `name` 一致 |
+| 模型不自动调用 | `description` 未写明触发场景，补充 `Use when ...` 描述 |
+| Gateway 运行中覆盖 Skill 不生效 | 重启 Gateway 重新扫描 Skill 目录 |
+| `Template.copy` 预置 Skill 失败 | 暂不支持构建时预置，改用运行时 `files.write` / `files.write_files` |
+| 其他 SDK / 构建问题 | 见[模板管理](../08.常见问题/05.模板管理.md) |
+
+---
+
+## 参考
+
+- [使用 Claude Code Sandbox](05.使用%20Claude%20Code%20Sandbox.md)（克隆仓库、MCP、Skill、结构化输出等场景教程）
+- [使用 OpenClaw Sandbox](06.使用%20OpenClaw%20Sandbox.md)（部署 Gateway、Agent CLI、安全模式、Skill 扩展）
+- [Claude Code 模板](../04.功能说明/02.模板/07.其他模板/04.Claude%20Code%20模板.md)（镜像地址、构建 Template、MCP 与 Skill 能力约定）
+- [OpenClaw 模板](../04.功能说明/02.模板/07.其他模板/05.OpenClaw%20模板.md)（镜像地址、构建 Template、Gateway 参数、Skill 能力约定）
+- [构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)
+- [Extend Claude with skills](https://code.claude.com/docs/zh-CN/skills)
+- [OpenClaw Skills](https://docs.openclaw.ai/tools/skills)


### PR DESCRIPTION
## Summary

新增一篇跨 Agent 的 Skill 挂载指南（中英文各一篇），补齐现有文档的空白：`05.使用 Claude Code Sandbox` 和 `06.使用 OpenClaw Sandbox` 各自都有「使用 Skill 扩展能力」小节，但读者无法从中得知同一份 Skill 如何同时服务多个 Agent，也没有一个与具体 Agent 无关的通用接入说明。

- 按操作步骤组织：确认路径 → 写入 Skill → 调用与确认加载 → 覆盖后的生效规则，而非按 Agent 罗列，避免与 05、06 重复
- 给出跨 Agent 路径速查表（Claude Code、OpenClaw），并说明其他 Agent（Codex CLI、Cursor CLI、`.agents/skills` 中立约定）的通用接入方法：Skill 的发现与加载由 Agent 自身完成，云沙箱只负责放置文件，因此换 Agent 只需替换目标路径
- 新增「一份源目录，多处挂载」示例，一次 `write_files` 调用把同一份 Skill 铺到多个 Agent 的根目录
- 说明 `SKILL.md` frontmatter 取并集的写法（Claude Code 只需 `description`，OpenClaw 还需 `name` 与 `user-invocable`）
- 明确写入的顺序约束：必须在沙箱创建之后、Agent 启动之前；并区分一次性执行与常驻进程下覆盖 Skill 的生效时机

单 Agent 的深入用法仍链接回 05、06，不做搬运。

## Test plan

- [x] `make check-docs` 通过：705 篇 Markdown、所有本地引用有效
- [x] `make test` 通过（13 项）
- [x] `mkdocs build --strict` 通过
- [x] 中英文两篇章节结构逐节对应，英文版链接已对齐 en-US 目录实际文件名

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
本 PR 更新函数计算（FC）Agent Sandbox 文档。

- 在“最佳实践”章节新增中英文两篇“为 Sandbox 中的 Agent 挂载 Skill”页面。
- 新增 Skill 挂载流程、路径配置、`frontmatter`、加载验证及覆盖后的生效规则。
- 覆盖 Claude Code、OpenClaw 和其他 Agent 的接入方法。
- 新增单文件、多文件 Skill 及多 Agent 挂载示例。
- 未删除页面。
- 未新增或修改图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->