### PR TITLE
docs(sandbox): add SWE Agent best practice

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Build a SWE Agent.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Build a SWE Agent.md
@@ -618,9 +618,9 @@ Whichever category you use, you need a mapping from `instance_id` (or image tag)
 
 | Category | List file | Lines | Download |
 | --- | --- | --- | --- |
-| 1. Grading criteria verified | `tier-A-images.tsv` | 29,112 | TBD |
-| 2. Metadata complete, grading to be implemented | `tier-B-images.tsv` | 27,837 | TBD |
-| 3. Images only | `tier-C-images.tsv` | 20,755 | TBD |
+| 1. Grading criteria verified | `tier-A-images.tsv` | 29,112 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-A-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-A-images.tsv.gz)) |
+| 2. Metadata complete, grading to be implemented | `tier-B-images.tsv` | 27,837 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-B-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-B-images.tsv.gz)) |
+| 3. Images only | `tier-C-images.tsv` | 20,755 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv.gz)) |
 
 All three files have three columns: `instance_id` / image address / benchmark name, so the third column is enough to slice out a single benchmark.
 
@@ -628,26 +628,25 @@ All three files have three columns: `instance_id` / image address / benchmark na
 
 | Benchmark | List file | Lines | Download |
 | --- | --- | --- | --- |
-| SWE-rebench V2 (whole family) | `swerebenchv2-images.tsv` | 32,074 | TBD |
-| SWE-rebench V2 (python subset) | `swerebenchv2-python-images.tsv` | 7,238 | TBD |
-| SWE-rebench V2 (id → language map) | `swerebenchv2-languages.tsv` | 32,074 | TBD |
-| Scale-SWE | `scaleswe-images.tsv` | 19,473 | TBD |
-| SWE-Gym | `swegym-images.tsv` | 2,401 | TBD |
-| CyberGym | `cybergym-images.tsv` | 1,507 | TBD |
-| SWE-bench Pro | `swebpro-images.tsv` | 731 | TBD |
-| SWE-smith | `swesmith-images.tsv` | 363 | TBD |
-| SEC-bench | `secbench-images.tsv` | 300 | TBD |
-| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | TBD |
-| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | TBD |
+| SWE-rebench V2 (whole family) | `swerebenchv2-images.tsv` | 32,074 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv.gz)) |
+| SWE-rebench V2 (python subset) | `swerebenchv2-python-images.tsv` | 7,238 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv.gz)) |
+| SWE-rebench V2 (id → language map) | `swerebenchv2-languages.tsv` | 32,074 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv.gz)) |
+| Scale-SWE | `scaleswe-images.tsv` | 19,473 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv.gz)) |
+| SWE-Gym | `swegym-images.tsv` | 2,401 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv.gz)) |
+| CyberGym | `cybergym-images.tsv` | 1,507 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/cybergym-images.tsv) |
+| SWE-bench Pro | `swebpro-images.tsv` | 731 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv.gz)) |
+| SWE-smith | `swesmith-images.tsv` | 363 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swesmith-images.tsv) |
+| SEC-bench | `secbench-images.tsv` | 300 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/secbench-images.tsv) |
+| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tb21-images.tsv) |
+| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/sweatlas-images.tsv) |
 
 Companion files:
 
 | File | Content | Download |
 | --- | --- | --- |
-| `all-images.tsv` | All 77,704 images, four columns: `instance_id` / image address / benchmark / category | TBD |
-| `image-registry.json` | Per-benchmark working directory, run-as user, grading method, and metadata source, for a runner to read | TBD |
-| `MANIFEST.tsv` | Line count, byte size, and **sha256** for each file; verifying after download is recommended | TBD |
-| Bundle | An archive of all the files above (about 3 MB), including a README | TBD |
+| `all-images.tsv` | All 77,704 images, four columns: `instance_id` / image address / benchmark / category | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv.gz)) |
+| `image-registry.json` | Per-benchmark working directory, run-as user, grading method, and metadata source, for a runner to read | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/image-registry.json) |
+| `MANIFEST.tsv` | Line count, byte size, and **sha256** for each file; verifying after download is recommended | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/MANIFEST.tsv) |
 
 Lists larger than 200 KB also come as `.gz`, with identical content. Lists are never updated in place: a new batch of images is published to a new directory, and already-published files keep their content.
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Build a SWE Agent.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/11.Build a SWE Agent.md
@@ -1,0 +1,754 @@
+# Build a SWE Agent
+
+A SWE Agent (software engineering agent) automates development tasks such as fixing issues and generating pull requests: give it a defect description for a real repository, and it reads code, edits files, and runs tests inside a sandbox, finally producing a patch. The industry-standard way to evaluate one is to run a benchmark such as SWE-bench—each task provides an image containing the repository at the defect commit, and test cases decide whether the patch actually fixed the problem.
+
+This guide walks through the full loop of "agent fixes → produces a patch → we decide whether it is fixed" on Agent Sandbox, using one real SWE-bench-style task as the example, then extends it to batch evaluation and explains how to onboard images for your own repositories. The code in this guide can be copied and run as-is.
+
+## Scenarios
+
+- You need a reproducible evaluation base to compare different models and prompts on real repository defects under one consistent standard.
+- The agent executes repository code and tests, so it needs strong isolation to avoid affecting your local machine or CI runners.
+- Batch evaluation runs dozens or hundreds of instances at once, so it needs per-instance isolation, immediate teardown, and controllable cost.
+- You want to build a private evaluation set from your own repositories, reusing the same agent and grading pipeline.
+
+## Prerequisites
+
+- Agent Sandbox is enabled and you have an `E2B_API_KEY` for the target region. This guide uses China (Shanghai) as the example, with these endpoints:
+  - `api_url`: `https://api.cn-shanghai.e2b.fc.aliyuncs.com`
+  - `domain`: `cn-shanghai.e2b.fc.aliyuncs.com`
+- A working model API key (this guide uses an OpenAI-compatible endpoint).
+- Python 3.10 or later.
+
+> An API key is bound to its region. Using it against another region returns 401.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph ORCH["Orchestration layer: outside the sandbox · holds credentials · stateless"]
+        direction LR
+        META["① Fetch task<br/>dataset metadata<br/>problem statement / test cases"]
+        RESOLVE["② Resolve<br/>id → image address<br/>id → working dir / grading criteria"]
+        TPL["③ Register template<br/>Template.build (idempotent, ~1-2s cached)"]
+        AGENT["④ Agent loop<br/>agent framework + model<br/>(credentials live only here)"]
+        SUM["⑦ Collect patch　⑩ Grade　⑪ Aggregate<br/>preds / grade / trajectory"]
+        META --> RESOLVE --> TPL --> AGENT --> SUM
+    end
+
+    subgraph SBX["Sandbox layer: no credentials at all"]
+        direction LR
+        WORKER["Worker Sandbox<br/>bash only<br/>repo sits in the working dir (varies by benchmark)<br/>⑧ killed right after the run"]
+        GRADER["Grader Sandbox (brand new, never reused)<br/>reset → apply patch → run test cases<br/>killed right after the run"]
+    end
+
+    IMG["Image layer<br/>ready-made evaluation images (benchmarks)　/　your own images (template built from a registry)"]
+
+    AGENT -->|"⑤ Start Worker sandbox<br/>send bash / collect output"| WORKER
+    WORKER -->|"⑥ Patch returned<br/>(the sandbox's only outbound path)"| SUM
+    SUM -->|"⑨ Start Grader sandbox"| GRADER
+    WORKER -.->|pull image| IMG
+    GRADER -.->|pull image| IMG
+
+    style ORCH stroke-width:3px
+    style SBX stroke-width:3px
+```
+
+**The model runs in the orchestration layer; the sandbox only executes bash.** That way neither the model key nor repository credentials ever enter the sandbox: even if the repository content the agent reads contains malicious instructions, the worst it can do is submit an invalid patch—it cannot obtain any credentials.
+
+## A task has three parts
+
+The example task in this guide is `getmoto__moto-7365`: moto's DynamoDB `update_item` used floating-point arithmetic for `ADD` expressions, so an amount came out as `Decimal('11.700000000000003')`; it should use exact `Decimal` arithmetic.
+
+| Part | Content | Source |
+| --- | --- | --- |
+| Environment | Image `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510`, with the repository already at the defect commit and dependencies installed | Ready-made evaluation image |
+| Task | The problem statement (`problem_statement`) | Upstream dataset |
+| Grading | `FAIL_TO_PASS` (must pass after the fix), `PASS_TO_PASS` (must not regress), `test_patch` | Upstream dataset |
+
+**The image is only the environment; the task and its test cases live in the metadata.** With the image alone and no metadata, there is no task to run.
+
+## Install dependencies and configure credentials
+
+```bash
+mkdir swe-demo && cd swe-demo
+python -m venv .venv
+.venv/bin/pip install e2b "mini-swe-agent>=2.4" pyyaml
+
+export E2B_API_KEY="<your-e2b-api-key>"
+export E2B_REGION="cn-shanghai"
+export MODEL_API_KEY="<your-model-api-key>"
+export MSWEA_CONFIGURED=true MSWEA_SILENT_STARTUP=1
+```
+
+The agent loop uses the community-standard implementation [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent) directly, keeping its official prompts and submission protocol, and only replacing the execution backend with Agent Sandbox. Its execution-environment protocol has just three methods; implementing them is enough, with no changes to the upstream code.
+
+## Implement the execution environment: `fc_env.py`
+
+Below is the complete implementation. The four commented spots are where the behavior differs from a local docker execution environment and must be handled specially.
+
+```python
+# fc_env.py
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import shlex
+from dataclasses import dataclass, field
+from typing import Any
+
+from e2b import CommandExitException, Sandbox, Template
+from minisweagent.exceptions import Submitted
+
+SUBMIT_SENTINEL = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"
+
+REGIONS = {
+    "cn-shanghai": "https://api.cn-shanghai.e2b.fc.aliyuncs.com",
+    "cn-hangzhou": "https://api.cn-hangzhou.e2b.fc.aliyuncs.com",
+    "cn-beijing": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
+    "cn-hongkong": "https://api.cn-hongkong.e2b.fc.aliyuncs.com",
+    "us-west-1": "https://api.us-west-1.e2b.fc.aliyuncs.com",
+}
+
+
+@dataclass
+class FCSandboxEnvironmentConfig:
+    image: str = ""
+    template: str = ""
+    cwd: str = "/testbed"
+    env: dict[str, str] = field(default_factory=dict)
+    forward_env: list[str] = field(default_factory=list)  # keep empty: host vars must not enter the sandbox
+    timeout: int = 60
+    interpreter: list[str] = field(default_factory=lambda: ["bash", "-c"])
+    sandbox_timeout: int = 1800
+    region: str = field(default_factory=lambda: os.environ.get("E2B_REGION", "cn-shanghai"))
+    run_as_user: str = "root"  # evaluation images usually have a root-owned repo and often no sudo
+
+
+class FCSandboxEnvironment:
+    def __init__(self, *, config_class=FCSandboxEnvironmentConfig, **kwargs):
+        self.config = config_class(**kwargs)
+        self._conn = {
+            "api_key": os.environ["E2B_API_KEY"],
+            "api_url": REGIONS[self.config.region],
+            "domain": f"{self.config.region}.e2b.fc.aliyuncs.com",
+        }
+        template = self.config.template or self._ensure_template()
+        self.sbx = Sandbox.create(template, timeout=self.config.sandbox_timeout, **self._conn)
+        self.template = template
+
+        # Difference 1: docker's -w creates the directory automatically, the sandbox does not.
+        # When the directory is missing the error is `fork/exec /bin/bash: no such file or
+        # directory`, which is easily mistaken for a problem with bash itself.
+        self._run_raw(f"mkdir -p {shlex.quote(self.config.cwd)}")
+        # Difference 2: cross-user git operations are rejected (dubious ownership)
+        self._run_raw(f"git config --global --add safe.directory {shlex.quote(self.config.cwd)}")
+
+    def _ensure_template(self) -> str:
+        """Image → template, idempotent: probe by template name first, build only if that fails.
+
+        Derive the template name from a hash of the image, and do not embed a version number:
+        a given template name may only be built once, and after a failed build the name stays
+        in CREATE_FAILED, so building again returns 409 immediately.
+        """
+        name = "swe-" + hashlib.sha1(self.config.image.encode()).hexdigest()[:16]
+        try:
+            probe = Sandbox.create(name, timeout=60, **self._conn)
+            probe.kill()
+            return name
+        except Exception:
+            pass
+        Template.build(Template().from_image(self.config.image), name=name,
+                       cpu_count=2, memory_mb=8192, **self._conn)
+        return name
+
+    def _run_raw(self, command: str) -> None:
+        try:
+            self.sbx.commands.run(command, user=self.config.run_as_user or None, timeout=30)
+        except Exception:
+            pass  # best-effort setup commands; failure does not affect the main flow
+
+    def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
+        command = action.get("command", "")
+        limit = timeout or self.config.timeout
+        envs = {k: os.environ[k] for k in self.config.forward_env if k in os.environ}
+        envs.update(self.config.env)
+        cmd = shlex.join([*self.config.interpreter, command])
+        try:
+            r = self.sbx.commands.run(
+                cmd, cwd=cwd or self.config.cwd, envs=envs or None,
+                user=self.config.run_as_user or None,
+                timeout=limit, request_timeout=limit + 60,
+            )
+            out = {"output": (r.stdout or "") + (r.stderr or ""), "returncode": 0,
+                   "exception_info": ""}
+        except CommandExitException as e:
+            # Difference 3: a non-zero exit is a normal signal (a failing test, for example).
+            # It must be turned into a returncode, never raised to the caller.
+            out = {"output": (e.stdout or "") + (e.stderr or ""), "returncode": e.exit_code,
+                   "exception_info": ""}
+        except Exception as e:
+            out = {"output": "", "returncode": -1,
+                   "exception_info": f"command execution failed: {e}",
+                   "extra": {"exception_type": type(e).__name__}}
+        self._check_finished(out)
+        return out
+
+    def _check_finished(self, output: dict) -> None:
+        """Difference 4: the submission protocol must be reproduced verbatim — if the first line
+        is the sentinel and the exit code is 0, the remaining lines are the patch."""
+        lines = output.get("output", "").lstrip().splitlines(keepends=True)
+        if lines and lines[0].strip() == SUBMIT_SENTINEL and output["returncode"] == 0:
+            submission = "".join(lines[1:])
+            raise Submitted({"role": "exit", "content": submission,
+                             "extra": {"exit_status": "Submitted", "submission": submission}})
+
+    def get_template_vars(self, **kwargs) -> dict[str, Any]:
+        return {**self.config.__dict__, **platform.uname()._asdict(), **kwargs}
+
+    def serialize(self) -> dict:
+        # every trajectory must be traceable back to a specific sandbox and source image
+        return {"environment_class": "fc_env.FCSandboxEnvironment",
+                "sandbox_id": self.sbx.sandbox_id, "template": self.template,
+                "image": self.config.image, "cwd": self.config.cwd}
+
+    def cleanup(self) -> None:
+        try:
+            self.sbx.kill()
+        except Exception:
+            pass
+```
+
+## Configuration: always change the image and the working directory together
+
+```yaml
+# demo.yaml — layered on top of mini-SWE-agent's official swebench.yaml, keeping its prompts and submission protocol
+environment:
+  environment_class: fc_env.FCSandboxEnvironment
+  image: fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510
+  cwd: /testbed          # must be changed together with the image, see "What to change for another benchmark"
+  run_as_user: root
+  timeout: 120
+model:
+  model_name: openai/<your-model>
+  model_kwargs:
+    api_base: <OpenAI-compatible endpoint>
+    temperature: 0.0
+  cost_tracking: ignore_errors   # self-hosted models are not in the price table, otherwise cost tracking raises
+agent:
+  step_limit: 40
+  cost_limit: 0
+```
+
+## Drive the agent: `run.py`
+
+```python
+# run.py
+import argparse, json, os
+from pathlib import Path
+
+import yaml
+from minisweagent.agents.default import DefaultAgent
+from minisweagent.config import builtin_config_dir
+from minisweagent.models.litellm_model import LitellmModel
+from minisweagent.utils.serialize import recursive_merge
+
+from fc_env import FCSandboxEnvironment
+
+p = argparse.ArgumentParser()
+p.add_argument("-c", "--config", type=Path, default=Path("demo.yaml"))
+p.add_argument("-t", "--task", type=Path, default=Path("task.md"))
+p.add_argument("-o", "--output", type=Path, default=Path("out.patch"))
+p.add_argument("--traj", type=Path, default=Path("traj.json"))
+a = p.parse_args()
+
+# the official swebench.yaml supplies prompts and the submission protocol;
+# the local yaml only overrides the image, the model, and the limits
+official = yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text())
+cfg = recursive_merge(official, yaml.safe_load(a.config.read_text()))
+
+env_cfg = dict(cfg["environment"])
+env_cfg.pop("environment_class", None)          # instantiate directly, bypassing the registry
+env = FCSandboxEnvironment(**env_cfg)
+
+model_cfg = dict(cfg["model"])
+model_cfg.setdefault("model_kwargs", {})
+model_cfg["model_kwargs"]["api_key"] = os.environ["MODEL_API_KEY"]   # orchestration layer only
+
+agent = DefaultAgent(LitellmModel(**model_cfg), env,
+                     **recursive_merge(cfg.get("agent", {}), {"output_path": a.traj}))
+try:
+    result = agent.run(a.task.read_text())
+finally:
+    env.cleanup()
+
+patch = result.get("submission") or ""
+a.output.write_text(patch)
+print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(patch),
+                  "model_calls": agent.n_calls, "sandbox_id": env.sbx.sandbox_id},
+                 ensure_ascii=False))
+```
+
+> **Do not drive batch evaluation through the interactive CLI.** mini-SWE-agent's `mini` command asks for one interactive confirmation as the agent wraps up, and `-y` does not skip it; in a non-interactive environment it ends with `EOFError` and the patch is lost entirely—even though the agent had actually solved the task. For scripted runs, drive `DefaultAgent` directly as shown above.
+
+## Grading: `grade.py`
+
+The grading criteria match SWE-bench upstream: every `FAIL_TO_PASS` case passes and no `PASS_TO_PASS` case regresses.
+
+**Grade in a brand-new sandbox; never reuse the agent's worker sandbox.** After the agent finishes, that sandbox is no longer the original scene—it may have installed extra packages (which can make tests pass by accident), modified test files or `conftest.py`, or left temporary files behind. Sandbox images are immutable, so simply creating a new sandbox from the same image brings the repository back to its original state, with no need to clean up after the agent. The template is already cached, so the second sandbox starts in a few seconds.
+
+```python
+# grade.py
+import argparse, json, re, shlex
+from collections import Counter
+from pathlib import Path
+
+import yaml
+from fc_env import FCSandboxEnvironment
+
+# In evaluation images, python/pytest usually live in a conda environment activated via BASH_ENV.
+# Without these variables, `python -m pytest` falls back to conda base and reports
+# "No module named pytest".
+GRADE_ENV = {"PAGER": "cat", "MANPAGER": "cat", "PIP_PROGRESS_BAR": "off",
+             "TQDM_DISABLE": "1", "BASH_ENV": "/root/.bashrc"}
+
+def as_list(v):
+    if isinstance(v, str):
+        try:
+            return json.loads(v)
+        except json.JSONDecodeError:
+            return [v] if v else []
+    return list(v or [])
+
+def files_of(names):        # test case name → file name
+    # Keep only names that carry a file prefix (pytest node ids). In multi-language benchmarks a
+    # case name may be a plain description or a test class name with no file prefix; passing the
+    # whole string to pytest as a file name produces "file not found".
+    return {n.strip().strip("'\"").split("::")[0] for n in names
+            if "::" in n or n.strip().strip("'\"").endswith(".py")}
+
+def patched_files(diff):    # files touched by a patch
+    return sorted(set(re.findall(r"^\+\+\+ b/(\S+)", diff, flags=re.M)))
+
+p = argparse.ArgumentParser()
+p.add_argument("--instance", type=Path, default=Path("instance.json"))
+p.add_argument("--patch", type=Path)
+p.add_argument("--gold", action="store_true", help="self-check using the dataset's own patch")
+p.add_argument("--cwd", default="/testbed")
+a = p.parse_args()
+
+inst = json.loads(a.instance.read_text())[0]
+patch = inst["patch"] if a.gold else a.patch.read_text()
+if not patch.strip():
+    raise SystemExit(json.dumps({"resolved": False, "reason": "empty patch"}))
+
+image = yaml.safe_load(Path("demo.yaml").read_text())["environment"]["image"]
+f2p, p2p = as_list(inst["FAIL_TO_PASS"]), as_list(inst["PASS_TO_PASS"])
+
+env = FCSandboxEnvironment(image=image, cwd=a.cwd, run_as_user="root",
+                           timeout=900, env=GRADE_ENV)
+try:
+    # 1) Apply the patch under evaluation; failing to apply is itself a result
+    env.sbx.files.write("/tmp/model.patch", patch)
+    out = env.execute({"command": "git apply -v /tmp/model.patch"}, timeout=300)
+    if out["returncode"] != 0:
+        out = env.execute({"command": "patch -p1 -i /tmp/model.patch"}, timeout=300)
+        assert out["returncode"] == 0, f"patch does not apply: {out['output'][-200:]}"
+
+    # 2) Restore test files to the baseline first, then apply test_patch — test content
+    #    must not be tamperable by the agent
+    tf = patched_files(inst["test_patch"])
+    if tf:
+        env.execute({"command": f"git checkout -- {' '.join(map(shlex.quote, tf))} || true"})
+    env.sbx.files.write("/tmp/test.patch", inst["test_patch"])
+    out = env.execute({"command": "git apply -v /tmp/test.patch"}, timeout=300)
+    assert out["returncode"] == 0, f"test_patch does not apply: {out['output'][-200:]}"
+
+    # 3) Run whole test files, then match by name against the -rA report.
+    # Do not pass case names as pytest command-line arguments: parameterized names may contain
+    # spaces and brackets, which leads to "not found".
+    # Do not truncate the report with tail either: large repositories emit thousands of lines,
+    # and truncation silently drops cases that did pass.
+    files = sorted(set(tf) | files_of(f2p + p2p))
+    cmd = ("python -m pytest -rA --no-header -q " + " ".join(map(shlex.quote, files))
+           + " > /tmp/res.log 2>&1; grep -E '^(PASSED|FAILED|ERROR) ' /tmp/res.log;"
+             " echo '===TAIL==='; tail -3 /tmp/res.log")
+    res = env.execute({"command": cmd}, timeout=1800)
+    report = res["output"]
+
+    # When the grading command produces nothing, it must not be scored as "tests failed" —
+    # that would charge an infrastructure failure to the model's score. Command timeouts and
+    # empty output under high concurrency are a real scenario and must be told apart from
+    # genuine test failures.
+    if not report.strip() or res["returncode"] == -1:
+        raise SystemExit(json.dumps({"resolved": False, "graded": False,
+                                     "reason": "grading did not complete (no output, likely a "
+                                               "timeout); lower the concurrency and retry"},
+                                    ensure_ascii=False))
+
+    passed = Counter(re.findall(r"^PASSED (\S+)", report, flags=re.M))
+
+    def score(names):
+        """Exact matches count directly; the rest are grouped by truncated head and satisfied
+        **by count**.
+
+        "The head appears in the passed list, so it passed" is wrong: one parameterized head may
+        cover 4 cases of which only 2 passed, while the criteria require just 2 of them — counting
+        all of them as passed would score failures as passes. The reverse rule ("any failure under
+        the head fails everything") wrongly kills the cases that did pass. Satisfying by count is
+        the only option between the two that does not systematically favor either side (truncated
+        output cannot tell us which parameter is which).
+        """
+        groups, ok = {}, []
+        for name in names:
+            n = name.strip().strip("'\"")
+            if passed.get(n):
+                ok.append(name)
+            else:
+                groups.setdefault(n.split()[0] if n.split() else n, []).append(name)
+        for head, members in groups.items():
+            avail = sum(c for p, c in passed.items() if p.startswith(head))
+            ok += members[:avail]
+        return ok
+
+    f2p_ok, p2p_ok = score(f2p), score(p2p)
+    print(json.dumps({
+        "resolved": len(f2p_ok) == len(f2p) and len(p2p_ok) == len(p2p) and bool(f2p),
+        "FAIL_TO_PASS": f"{len(f2p_ok)}/{len(f2p)}",
+        "PASS_TO_PASS": f"{len(p2p_ok)}/{len(p2p)}",
+        "summary": report.strip().splitlines()[-1][:120],
+    }, ensure_ascii=False))
+finally:
+    env.cleanup()
+```
+
+## Run it
+
+`task.md` holds the problem statement body; `instance.json` is a single-element array whose fields come from the upstream dataset:
+
+```json
+[{"instance_id": "getmoto__moto-7365",
+  "problem_statement": "DynamoDB's `update_item` performs floating-point arithmetic …",
+  "FAIL_TO_PASS": ["tests/test_dynamodb/test_dynamodb_update_expressions.py::test_update_item_add_float"],
+  "PASS_TO_PASS": ["tests/test_dynamodb/test_dynamodb_update_expressions.py::test_update_different_map_elements_in_single_request"],
+  "test_patch": "diff --git a/tests/... (verbatim from the upstream dataset)",
+  "patch": "diff --git a/moto/... (the dataset's own correct patch, used only to self-check the grader)"}]
+```
+
+**Self-check the grader before running the agent.** Put the dataset's own correct patch through grading; it must come out `resolved: true`:
+
+```bash
+PYTHONPATH=. .venv/bin/python grade.py --gold
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.58s"}
+```
+
+If the self-check fails, the grading pipeline itself is broken (image, how test cases are introduced, case-name matching), and any score the agent gets is meaningless. Once it passes, run the agent and grade its output:
+
+```bash
+PYTHONPATH=. .venv/bin/python run.py
+# {"exit_status": "Submitted", "patch_bytes": 1839, "model_calls": 31, "sandbox_id": "sbx-…"}
+
+PYTHONPATH=. .venv/bin/python grade.py --patch out.patch
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.76s"}
+```
+
+The first run registers the image as a template (idempotent; later runs hit the cache in 1-2 seconds). Models are non-deterministic, so `model_calls` and `patch_bytes` will vary.
+
+## Extending to batch evaluation
+
+Going from one task to N tasks requires no changes to `fc_env.py`; what you add is a resolution layer and concurrency orchestration.
+
+### Resolution layer: turn two hard-coded lines into table lookups
+
+For a single task the image address and working directory sit in the config; in a batch they differ per task and must be looked up. Three things need per-instance resolution: the image address (evaluation image tags usually carry build-batch information and **cannot be derived from `instance_id`**), the working directory, and the grading criteria.
+
+```python
+# resolve.py
+import json
+
+IMAGES = dict(l.split("\t") for l in open("images.tsv").read().splitlines())
+REGISTRY = json.load(open("registry.json"))     # family → cwd / run_as_user / grading
+FAMILY = json.load(open("family-index.json"))   # instance_id → family
+
+def resolve(instance: dict) -> dict:
+    spec = REGISTRY[FAMILY[instance["instance_id"]]]
+    cwd = spec["cwd"]
+    if cwd.startswith("$dataset."):             # some benchmarks have a per-instance working dir
+        cwd = instance[cwd.split(".", 1)[1]]    # take the matching field from the dataset
+    return {"image": IMAGES[instance["instance_id"]], "cwd": cwd,
+            "run_as_user": spec["run_as_user"], "grading": spec["grading"]}
+```
+
+Resolution is pure table lookup with no network or sandbox cost, so it can be done once before the run starts. Instances that fail to resolve (missing image mapping, missing metadata) should be dropped before the run rather than failing halfway through.
+
+### Concurrency orchestration
+
+```python
+# batch.py (skeleton)
+import concurrent.futures as cf, json
+from pathlib import Path
+
+from fc_env import FCSandboxEnvironment
+from resolve import resolve
+
+def run_one(inst: dict) -> tuple[str, dict]:
+    spec = resolve(inst)
+    env = FCSandboxEnvironment(image=spec["image"], cwd=spec["cwd"],
+                               run_as_user=spec["run_as_user"], timeout=120)
+    try:
+        agent = build_agent(env)                       # same as run.py above
+        result = agent.run(inst["problem_statement"])
+        return inst["instance_id"], {
+            "model_patch": result.get("submission") or "",
+            "exit_status": result.get("exit_status"),
+            "sandbox_id": env.sbx.sandbox_id,          # keep it traceable
+        }
+    except Exception as e:                             # one failing instance must not sink the batch
+        return inst["instance_id"], {"model_patch": "", "error": f"{type(e).__name__}: {e}"}
+    finally:
+        env.cleanup()                                  # kill right away, do not wait for the TTL
+
+instances = json.loads(Path("instances.json").read_text())
+preds = {}
+with cf.ThreadPoolExecutor(max_workers=6) as ex:
+    for iid, pred in ex.map(run_one, instances):
+        preds[iid] = pred
+Path("preds.json").write_text(json.dumps(preds, ensure_ascii=False, indent=1))
+```
+
+Four orchestration constraints you must satisfy:
+
+| Constraint | How |
+| --- | --- |
+| One failing instance must not sink the batch | Catch exceptions per instance, record the error, and continue |
+| Sandboxes must always be reclaimed | Call `kill()` in `finally`. Relying on the TTL costs extra and holds concurrency slots |
+| Set limits on the agent side | `step_limit`, `cost_limit`, `wall_time_limit`; stop on exceeding them, or a single hard task can burn the whole batch's budget |
+| Tier your output truncation | 15k characters for the terminal, 20k for a single file, 50k for a batch, so the context is not swamped |
+
+**Keep concurrency around 6.** Large images can time out during sandbox creation at a concurrency of 10, and a serial retry usually succeeds; so when sandbox creation fails, retry once serially before declaring an instance unusable—otherwise concurrency pressure gets misrecorded as an image problem.
+
+### Decouple grading from the agent
+
+The agent stage only produces `preds.json`; the grading stage reads it and grades each entry concurrently in a brand-new sandbox. That way, changing the grading logic and re-grading does not require re-running the agent, saving a whole round of model spend.
+
+**The first thing to do when onboarding any new benchmark is to grade every one of the dataset's own correct patches; the pass rate must be close to 100%.** All five of the problems below silently depress scores without raising an error, and this step is the only thing that surfaces them:
+
+| Problem | Symptom | Fix |
+| --- | --- | --- |
+| A dataset field contains a literal `\n` (backslash plus n, not a newline) | bash treats it as an escape, the command is mangled, and the whole reset fails | Restore newlines for that field only, never globally |
+| Grading evidence truncated by `tail -N` | Large repositories emit thousands of report lines, passing cases get dropped, and the score comes out low | Filter the verdict lines first, then take the summary tail separately |
+| Parameterized case names contain spaces or newlines | The pytest report truncates names at the first whitespace, so exact matching misses everything | Match on the truncated prefix and satisfy by count |
+| Case names passed to pytest as command-line arguments | Names contain spaces and brackets, giving "not found" and ultimately "no tests ran" | Run whole test files, then match by name against the report |
+| A grading command that timed out with empty output scored as "tests failed" | A large test suite times out under high concurrency and the instance is recorded as zero passes; a serial re-run passes everything | When output is empty or the exit code is abnormal, mark it as **grading not completed**, exclude it from the denominator, and retry at lower concurrency |
+
+The last one is the easiest to overlook and the most harmful: it reads an infrastructure failure as poor model capability, and the more test cases a repository has the more likely it is to trigger—so the evaluation conclusion is systematically depressed without any error surfacing.
+
+## Ready-made evaluation images in the Shanghai region
+
+The China (Shanghai) region comes preloaded with images for a range of open-source evaluation sets, with the repository scene and dependencies already in place: take the image address, build a template, and use it—no need to move anything yourself. All image addresses share the prefix `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`.
+
+**The image solves only the environment.** For a task to enter evaluation, three things must all be present: the image starts, the task metadata (problem statement and test cases) is obtainable, and the grading method is implemented. By those three, these images fall into three categories:
+
+| Category | Images | State | What you need to do |
+| --- | --- | --- | --- |
+| 1. Grading criteria verified | **29,112** | All three present, and grading self-checks pass with the dataset's own correct patches | Swap the image address and working directory and start running (Scale-SWE also needs a different way of introducing test cases, see below) |
+| 2. Metadata complete, grading to be implemented | **27,837** | Sandbox starts, problem statement is obtainable, join keys verified—but the grading method differs from this guide's example | Implement grading for that benchmark's method |
+| 3. Images only | **20,755** | Images start, but the task-to-image correspondence cannot be established | Usable only as repository environments with dependencies preinstalled; grading requires finding metadata yourself |
+| Total | **77,704** | | |
+
+**If you just want to get something running, take category 1.** Category 2 is listed because the images and problem statements are complete and only the grading implementation is missing; category 3 is listed for full disclosure, but it cannot be graded automatically.
+
+> The metadata datasets are hosted on HuggingFace, which **may not be reachable from inside the sandbox**. Export the fields you need (`problem_statement` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch`) to local files from an environment with outbound access, then ship them with the evaluation task. Do not fetch them on the fly during batch evaluation—one fetch failure stalls the whole batch.
+
+### 1. Grading criteria verified: 29,112 images
+
+For the three benchmarks below, the metadata is publicly available, the "image ↔ dataset" join key has been verified **row by row** (not sampled), and grading the dataset's own correct patches passes completely.
+
+| Benchmark | Images | Repos | Task type | Metadata dataset | Join key | Working directory |
+| --- | --- | --- | --- | --- | --- | --- |
+| Scale-SWE | **19,473** | 1,180 | Real PR fixes: the repository is reset to the PR's parent commit and the task is to implement that PR | [AweAI-Team/Scale-SWE](https://huggingface.co/datasets/AweAI-Team/Scale-SWE) | `instance_id` is the instance name inside the image tag | `/workspace/<repo>`, from the dataset's `workdir` field |
+| SWE-rebench V2 (python subset) | **7,238** | 689 | Real PR fixes | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2), filtered to `language=python` | `image_name` is the original image address, character for character | The repository sits at the root under its original name (for example `/OpenTripPlanner`) and must be probed at runtime |
+| SWE-Gym | **2,401** | 11 | Real issue fixes, standard SWE-bench shape | [SWE-Gym/SWE-Gym](https://huggingface.co/datasets/SWE-Gym/SWE-Gym) | `instance_id` (**image tags are forced to lowercase**, so normalize case when matching) | `/testbed` |
+
+All three grade on `FAIL_TO_PASS` + `PASS_TO_PASS`, but **they introduce test cases differently**:
+
+- **SWE-Gym and SWE-rebench V2 (python)**: identical to this guide's `grade.py`—apply `test_patch` to introduce the cases, then run pytest. The python subset of SWE-rebench V2 uses `pytest --no-header` throughout, so the criteria line up directly; switching to it only requires changing the image address and probing the working directory at runtime.
+- **Scale-SWE**: there is **no `test_patch`**. `FAIL_TO_PASS` points at an injected new test file whose content is in the `f2p_script` field (or a `f2p_patch` applied to an existing test file), and the reset is handled by `pre_commands`. You need to change the part of `grade.py` that introduces test cases, and the order matters—`git clean -fd` inside `pre_commands` deletes untracked files, so writing the test before resetting throws it away.
+
+**Repository diversity varies a lot**: Scale-SWE covers 1,180 repositories and the SWE-rebench V2 python subset 689, while SWE-Gym has only 11 (dominated by pandas, moto, and a few others). Look at the "Repos" column when picking a baseline for cross-repository generalization—SWE-Gym alone has a ceiling, since no matter how many tasks there are they concentrate in the same few repositories.
+
+### 2. Metadata complete, grading to be implemented: 27,837 images
+
+The images below start, the problem statements are obtainable, and the join keys have been verified to 100% (99.7% for `SWE-smith`). What is missing is only the grading implementation—their grading methods differ from this guide's example.
+
+| Benchmark | Count | Task type | Metadata dataset | Join key | Grading method and what is missing |
+| --- | --- | --- | --- | --- | --- |
+| SWE-rebench V2 (the 19 languages other than python) | **24,836** | Real PR fixes, the broadest repository coverage (3,614 repositories across the whole family) | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` is the original image address | Also `FAIL_TO_PASS` + `PASS_TO_PASS`, but case-name shapes vary by test framework, so **grading must be routed per language**. The dataset's `install_config.test_cmd` and `log_parser` give the run command and the parsing method per instance |
+| CyberGym | **1,507** | Vulnerability discovery: trigger and fix a known vulnerability in a real OSS project (from OSS-Fuzz / ARVO) | [sunblaze-ucb/cybergym](https://huggingface.co/datasets/sunblaze-ucb/cybergym) | `task_id`, equal to the image tag with the trailing `-vul` removed | Does not use `FAIL_TO_PASS`; the verdict is whether the vulnerability can be triggered and whether it stops triggering after the fix, which needs a fuzz reproduction pipeline |
+| SWE-bench Pro | **731** | Enterprise-repository issue fixes, longer context, includes Go / Node and other languages | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro), or [AweAI-Team/AweAgent-Meta-SWE-Bench-Pro](https://huggingface.co/datasets/AweAI-Team/AweAgent-Meta-SWE-Bench-Pro) | `dockerhub_tag` | Also `FAIL_TO_PASS` + `PASS_TO_PASS`, routed by `repo_language`. **Prefer the AweAI one**: same row count but it additionally carries `run_script_sh` / `parser_py`, so both the run and the parsing scripts are provided |
+| SWE-smith | **363 environment images** (covering **79,418 upstream tasks**) | Synthetic defect fixes; one image carries many tasks for the same repository | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) and the other 6 language subsets (py / java / js / ts / rs / cpp / php, 7 in total). Upstream also has a go subset, for which there is **no corresponding image** | `image_name` | Grading evidence is the same as SWE-bench, but **task selection has to be wired up yourself**: run `git checkout <instance_id>` inside the image's `/testbed` to move to the matching defect state |
+| SEC-bench | **300** | Security vulnerability reproduction and fixing (CVEs) | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | Does not use `FAIL_TO_PASS`; it reads the sanitizer report and the exit code. The dataset ships `work_dir` / `build_sh` / `secb_sh`, so both the run and the verdict scripts are provided |
+| Terminal-Bench 2.x | **89** | Terminal tasks (not code fixes): complete an instruction in a shell; no git repository and no patch | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | The task directory name is the image tag | Runs the task's own `tests/test.sh`, so **you do not write the grader**; but the agent loop has to change—these tasks produce no patch |
+| SWE-Atlas QnA | **11** | Repository question answering, produces no patch | [ScaleAI/SWE-Atlas-QnA](https://huggingface.co/datasets/ScaleAI/SWE-Atlas-QnA) | `docker_image` | Scored against a rubric, which needs a model as judge rather than a test run |
+
+SWE-smith deserves a note of its own: **its image count and its task count are not the same thing.** The 363 are environment images (one per repository), and they carry 79,418 upstream tasks selected by checking out branches—once task selection is wired up, it is the largest source of tasks in this whole collection.
+
+**Multi-language benchmarks must route grading per language.** Take SWE-rebench V2: case-name shapes follow the test framework—python uses pytest node ids (`tests/test_x.py::TestA::test_b`), TS / JS use jest and mocha case descriptions, and Java uses test class names. Applying one pytest parsing path to every language marks **every non-python instance as failed**. The `swerebenchv2-languages.tsv` list (id → language) can be used to filter. Test commands are more concentrated than languages: Go is always `go test`, Rust always `cargo test`, Java is either Maven or Gradle, and JS / TS are npm-based jest / mocha / vitest and friends—four or five groups of parsers cover most of it. The same applies to SWE-bench Pro, routed by `repo_language`.
+
+### 3. Images only: metadata must be matched yourself, 20,755 images
+
+The images below are equally usable (building templates, creating sandboxes, and working inside the container all behave normally), but **the platform does not provide the correspondence between tasks and grading test cases**. Before using them you need to find the metadata source yourself and establish the mapping to the images; otherwise they can only serve as real repository environments with dependencies preinstalled, with no automated grading.
+
+| Benchmark | Images | Image content | Why you must match it yourself |
+| --- | --- | --- | --- |
+| TMax | 14,490 | General terminal task environments (varied domains, including audio/video and data processing) | The upstream dataset's task identifiers and the image tags (12 hex characters) come from different sources, with no overlap in testing, so no mapping can be established |
+| TerminalTraj | 5,646 | Terminal task containers with only `tmux` / `asciinema` preinstalled; the task description is not in the image | Upstream ships task bundles (tar); you must unpack them and trace the image identifier back from each task's Dockerfile |
+| ProgramBench | 200 | Clean-room implementation tasks: repository code has been emptied, leaving only the target artifacts and a description | No public metadata dataset was found. Note also that these are "implement from scratch" rather than "fix a defect" tasks, so agent prompts need adjusting |
+| SEC-bench Pro | 183 | Security task environments | The image tags are plain numeric identifiers with no matching record in the known public datasets |
+| DeepSWE | 114 | SWE-bench-shaped repository environments | The image tags are irreversible random strings, so upstream instances cannot be traced back |
+| NL2RepoBench | 104 | Implement repository features from natural-language descriptions | No public metadata dataset was found |
+| Frontier | 17 | Performance optimization tasks: the image holds training and timing scripts, with no git repository | No public metadata dataset was found. The verdict is a benchmark score rather than a test run |
+| Toolathlon | 1 | Tool-calling task environment | Upstream publishes only trajectory data, not the task set |
+
+### Getting the image lists
+
+Whichever category you use, you need a mapping from `instance_id` (or image tag) to image address: **image tags carry build-batch information and cannot be derived from `instance_id`**. The lists are tab-separated text files, one `instance_id<TAB>image address` per line, ready for `grep` or `cut -f2` in a script.
+
+**By the three categories above** (these three files correspond one-to-one with the three sections above):
+
+| Category | List file | Lines | Download |
+| --- | --- | --- | --- |
+| 1. Grading criteria verified | `tier-A-images.tsv` | 29,112 | TBD |
+| 2. Metadata complete, grading to be implemented | `tier-B-images.tsv` | 27,837 | TBD |
+| 3. Images only | `tier-C-images.tsv` | 20,755 | TBD |
+
+All three files have three columns: `instance_id` / image address / benchmark name, so the third column is enough to slice out a single benchmark.
+
+**By individual benchmark**:
+
+| Benchmark | List file | Lines | Download |
+| --- | --- | --- | --- |
+| SWE-rebench V2 (whole family) | `swerebenchv2-images.tsv` | 32,074 | TBD |
+| SWE-rebench V2 (python subset) | `swerebenchv2-python-images.tsv` | 7,238 | TBD |
+| SWE-rebench V2 (id → language map) | `swerebenchv2-languages.tsv` | 32,074 | TBD |
+| Scale-SWE | `scaleswe-images.tsv` | 19,473 | TBD |
+| SWE-Gym | `swegym-images.tsv` | 2,401 | TBD |
+| CyberGym | `cybergym-images.tsv` | 1,507 | TBD |
+| SWE-bench Pro | `swebpro-images.tsv` | 731 | TBD |
+| SWE-smith | `swesmith-images.tsv` | 363 | TBD |
+| SEC-bench | `secbench-images.tsv` | 300 | TBD |
+| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | TBD |
+| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | TBD |
+
+Companion files:
+
+| File | Content | Download |
+| --- | --- | --- |
+| `all-images.tsv` | All 77,704 images, four columns: `instance_id` / image address / benchmark / category | TBD |
+| `image-registry.json` | Per-benchmark working directory, run-as user, grading method, and metadata source, for a runner to read | TBD |
+| `MANIFEST.tsv` | Line count, byte size, and **sha256** for each file; verifying after download is recommended | TBD |
+| Bundle | An archive of all the files above (about 3 MB), including a README | TBD |
+
+Lists larger than 200 KB also come as `.gz`, with identical content. Lists are never updated in place: a new batch of images is published to a new directory, and already-published files keep their content.
+
+**The shape of `instance_id` differs per benchmark.** Look at the actual content before writing a filter, and do not reuse one regular expression across benchmarks:
+
+| Benchmark | `instance_id` shape | Example |
+| --- | --- | --- |
+| SWE-Gym | `owner__repo-number` | `getmoto__moto-7365` |
+| Scale-SWE | `user_repo_prNumber` | `geopandas_geopandas_pr2027` |
+| SWE-rebench V2 | `owner-repo:PR-commit prefix` | `keras-team-keras:19955-ca9519b` |
+
+```bash
+# look up the image address for one task
+grep '^getmoto__moto-7365' swegym-images.tsv | cut -f2
+
+# pull every task for one repository (use that benchmark's own id shape)
+grep '^pandas-dev__' swegym-images.tsv | cut -f1 > my-instances.txt
+grep '^geopandas_geopandas_' scaleswe-images.tsv | cut -f1 >> my-instances.txt
+
+# take just one benchmark out of the category-1 list (the third column is the benchmark name)
+awk -F'\t' '$3=="scaleswe"{print $2}' tier-A-images.tsv | head
+
+# verify download integrity (on macOS use shasum -a 256 -c)
+awk -F'\t' 'NR>1{print $4"  "$1}' MANIFEST.tsv > sums && sha256sum -c sums
+```
+
+## What to change for another benchmark
+
+Evaluation images from different sources are **not homogeneous**, starting with the working directory:
+
+| Image shape | Working directory | How to get it |
+| --- | --- | --- |
+| Standard SWE-bench shape | `/testbed` | Fixed value; the python environment often lives in conda's `testbed`, activated via `BASH_ENV` |
+| One directory per repository | `/workspace/<repo>` | From the dataset's `workdir` field, different for each instance |
+| Single application directory | `/app` | Fixed value |
+| Original repository name at the root | For example `/OpenTripPlanner`, `/ApplicationInsights-node.js` | **Cannot be derived from the image tag** (tags are lowercase, directories keep their original case); must be probed at runtime |
+
+The last shape has to be probed inside the container, for example:
+
+```bash
+for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
+```
+
+Making that an `auto` option in the resolution layer is more reliable than enumerating entries in a config.
+
+The image address and working directory must be changed **as a pair**. Changing only one produces `fork/exec /bin/bash: no such file or directory`—that means the working directory does not exist and has nothing to do with bash.
+
+Two practices to avoid:
+
+- **Hard-coding the working directory in the evaluation config.** It only holds for some benchmarks and is guaranteed to break on a switch; look it up as described above.
+- **Choosing the grading executor from the language tag in image metadata.** One batch of images often mixes Go, Node, Java, and Python repositories; route by the dataset's `repo_language` field instead.
+
+## Onboarding your own images
+
+Your own repositories, internal frameworks, and private evaluation sets follow this path; once onboarded, the agent and grading pipeline above can be reused as-is, with only the image layer swapped.
+
+The full process for turning your own image into a usable template is in [Build Custom Image Templates](../04.Features/02.Templates/03.Build Custom Image Templates.md), which covers the platform's hard requirements for images (`linux/amd64` architecture, writable `/etc/passwd` and `/etc/group`, a fixed `/bin/bash` path for `commands.run` and PTY, and so on). Two common scenarios have their own guides:
+
+- The image lives in a registry that requires authentication: [Build a Sandbox Template from a GHCR Custom Image](./07.Build a Sandbox Template from a GHCR Custom Image.md), which passes registry credentials through the `X-E2B-Template-Source-Username` / `X-E2B-Template-Source-Password` headers
+- Wiring template builds into a pipeline: [Publish a Sandbox Template with GitHub Actions](./09.Publish a Sandbox Template with GitHub Actions.md)
+
+On top of that, evaluation scenarios have five more things to watch:
+
+| Constraint | Symptom | What to do |
+| --- | --- | --- |
+| A template name may only be built once | Retrying after a failed build returns `409: template build is not allowed in current status CREATE_FAILED`, and that name is permanently unusable | Always retry under a new name. Derive template names from a hash of the image, without a version number |
+| The build stage does not support execution steps | Declaring `run_cmd` / `set_user` / `set_workdir` returns `400: steps are not supported` | Dependencies and environment must already be in the source image; permissions and working directory can only be handled at runtime via `user="root"` |
+| A source image that does not meet envd injection requirements fails to build | The platform injects envd into the image during the build. If the image does not meet the prerequisites, the log prints `template build failed: envd inject failed` while still printing `Build finished` (building `python:3.11-slim` directly reproduces this) | Check the image against [Build Custom Image Templates](../04.Features/02.Templates/03.Build Custom Image Templates.md) (`linux/amd64`, writable `/etc/passwd` and `/etc/group`, a fixed `/bin/bash` path, and so on). **Note that `Build finished` does not mean success—look for `envd inject failed`** |
+| The SDK may hang for a long time on a failed build | After a failure the client keeps polling the build status, and with large logs it can take a long time before raising `ReadTimeout` | Add your own timeout around `Template.build` instead of relying on it to return |
+| Large images time out on sandbox creation | High concurrency reports `TimeoutException` | Keep concurrency around 6 and retry once serially on failure |
+
+Once an image is onboarded, do not stop acceptance testing at "the sandbox started". Sample some instances and run all four steps below; failing any one means it is not usable:
+
+1. Building the template and creating the sandbox succeed.
+2. The repository directory exists, is a git repository, and `HEAD` resolves.
+3. The test executor for that language is available.
+4. Test cases can actually be collected (for example `pytest --collect-only -q`).
+
+**Acceptance testing must run under exactly the same environment variables as the grader.** Three common misjudgements make a perfectly good image look unusable:
+
+| Cause of misjudgement | Consequence |
+| --- | --- |
+| `BASH_ENV` omitted during acceptance testing | The conda environment is not activated and `python -m pytest` reports "No module named pytest" |
+| Go installed in `/usr/local/go/bin`, not on the default PATH | A perfectly good Go repository image is judged to have "no test executor" |
+| Java projects ship `./gradlew` instead of a global mvn/gradle | A perfectly good image is misjudged |
+
+## Production recommendations
+
+- **Credential management**: inject `E2B_API_KEY` and the model API key through environment variables or a secrets manager; never hard-code them or commit them to a repository. Keep model calls in the orchestration layer and no credentials inside the sandbox.
+- **Restrict outbound traffic**: set `deny_out: ["0.0.0.0/0"]` on the sandbox plus an allowlist, opening only code hosting, image registries, and the model endpoint. Note that domain filtering only applies to the Host header on port 80 and SNI on 443—other ports need CIDRs; `allow` takes precedence over `deny`; and a rejected TCP connection looks successful from inside the sandbox, so judge by the application-layer response.
+- **Two layers of timeout**: distinguish the sandbox TTL from the per-command timeout. Do not use `timeout=0`, since a stuck process will not recover on its own; for long tasks use `on_timeout="pause"` together with `auto_resume`, which neither bills nor holds a concurrency slot while paused.
+- **The patch is the only outbound artifact**: the sandbox needs only read access to the repository. Once the orchestration layer has the patch, it rebuilds a clean repository, verifies it, runs the tests, and only then creates a PR. Do not push or open PRs from inside the sandbox.
+- **Destroy promptly**: call `sandbox.kill()` in `finally`; per-second billing only counts running time.
+- **Keep it traceable**: record `sandbox_id` and the source image address on every trajectory (`serialize()` above already includes both) for reproduction and troubleshooting.
+- **Cost accounting**: record start and end times in the orchestration layer and read the specification via `get_info()` to compute cost yourself.
+
+## Related features
+
+- [Build Custom Image Templates](../04.Features/02.Templates/03.Build Custom Image Templates.md)
+- [Build a Sandbox Template from a GHCR Custom Image](./07.Build a Sandbox Template from a GHCR Custom Image.md)
+- [Publish a Sandbox Template with GitHub Actions](./09.Publish a Sandbox Template with GitHub Actions.md)
+- [Use Claude Code Sandbox](./05.Use Claude Code Sandbox.md)
+- [Run Commands](../04.Features/03.Commands/02.Run Commands.md)
+- [Read and Write Files](../04.Features/04.Filesystem/02.Read and Write Files.md)

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
@@ -602,9 +602,9 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 | 分类 | 清单文件 | 行数 | 下载地址 |
 | --- | --- | --- | --- |
-| 一、判定口径已验证 | `tier-A-images.tsv` | 29,112 | 待补充 |
-| 二、元数据齐备，判定需自行实现 | `tier-B-images.tsv` | 27,837 | 待补充 |
-| 三、仅提供镜像 | `tier-C-images.tsv` | 20,755 | 待补充 |
+| 一、判定口径已验证 | `tier-A-images.tsv` | 29,112 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-A-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-A-images.tsv.gz)） |
+| 二、元数据齐备，判定需自行实现 | `tier-B-images.tsv` | 27,837 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-B-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-B-images.tsv.gz)） |
+| 三、仅提供镜像 | `tier-C-images.tsv` | 20,755 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv.gz)） |
 
 这三个文件都是三列：`instance_id` / 镜像地址 / 题库名，用第三列即可切到单个题库。
 
@@ -612,26 +612,25 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 | 题库 | 清单文件 | 行数 | 下载地址 |
 | --- | --- | --- | --- |
-| SWE-rebench V2（整族） | `swerebenchv2-images.tsv` | 32,074 | 待补充 |
-| SWE-rebench V2（python 子集） | `swerebenchv2-python-images.tsv` | 7,238 | 待补充 |
-| SWE-rebench V2（id → 语言对照） | `swerebenchv2-languages.tsv` | 32,074 | 待补充 |
-| Scale-SWE | `scaleswe-images.tsv` | 19,473 | 待补充 |
-| SWE-Gym | `swegym-images.tsv` | 2,401 | 待补充 |
-| CyberGym | `cybergym-images.tsv` | 1,507 | 待补充 |
-| SWE-bench Pro | `swebpro-images.tsv` | 731 | 待补充 |
-| SWE-smith | `swesmith-images.tsv` | 363 | 待补充 |
-| SEC-bench | `secbench-images.tsv` | 300 | 待补充 |
-| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | 待补充 |
-| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | 待补充 |
+| SWE-rebench V2（整族） | `swerebenchv2-images.tsv` | 32,074 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv.gz)） |
+| SWE-rebench V2（python 子集） | `swerebenchv2-python-images.tsv` | 7,238 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv.gz)） |
+| SWE-rebench V2（id → 语言对照） | `swerebenchv2-languages.tsv` | 32,074 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv.gz)） |
+| Scale-SWE | `scaleswe-images.tsv` | 19,473 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv.gz)） |
+| SWE-Gym | `swegym-images.tsv` | 2,401 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv.gz)） |
+| CyberGym | `cybergym-images.tsv` | 1,507 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/cybergym-images.tsv) |
+| SWE-bench Pro | `swebpro-images.tsv` | 731 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv.gz)） |
+| SWE-smith | `swesmith-images.tsv` | 363 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swesmith-images.tsv) |
+| SEC-bench | `secbench-images.tsv` | 300 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/secbench-images.tsv) |
+| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tb21-images.tsv) |
+| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/sweatlas-images.tsv) |
 
 配套文件：
 
 | 文件 | 内容 | 下载地址 |
 | --- | --- | --- |
-| `all-images.tsv` | 全部 77,704 张，四列：`instance_id` / 镜像地址 / 题库 / 所属分类 | 待补充 |
-| `image-registry.json` | 每个题库的工作目录、运行用户、判定方式、元数据来源，供 runner 读取 | 待补充 |
-| `MANIFEST.tsv` | 各文件的行数、字节数与 **sha256**，下载后建议校验完整性 | 待补充 |
-| 整包 | 以上文件的压缩包（约 3 MB），含一份说明 README | 待补充 |
+| `all-images.tsv` | 全部 77,704 张，四列：`instance_id` / 镜像地址 / 题库 / 所属分类 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv.gz)） |
+| `image-registry.json` | 每个题库的工作目录、运行用户、判定方式、元数据来源，供 runner 读取 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/image-registry.json) |
+| `MANIFEST.tsv` | 各文件的行数、字节数与 **sha256**，下载后建议校验完整性 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/MANIFEST.tsv) |
 
 超过 200 KB 的清单另有 `.gz` 版本，内容一致。清单不做原地更新：新一批镜像会发布到新的目录，已发布文件的内容保持不变。
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
@@ -514,10 +514,11 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 | SWE-bench Pro | **731** | 企业级仓库 issue 修复，上下文更长，含 Go/Node 等多语言 | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro) | `dockerhub_tag` | `/app` |
 | SWE-smith | **363**<br/>（环境级镜像） | 合成缺陷修复，一个镜像承载同一仓库的多道题（上游共 88,130 道） | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) 等 8 个语言子集（py / java / js / ts / rs / cpp / php / go） | `image_name` | `/testbed`，用 `git checkout <instance_id>` 选题 |
 | SEC-bench | **300** | 安全漏洞复现与修复（CVE） | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | 取数据集 `work_dir` 字段 |
+| CyberGym | **1,507** | 漏洞挖掘：在真实 OSS 项目中触发并修复已知漏洞（来自 OSS-Fuzz / ARVO） | [sunblaze-ucb/cybergym](https://huggingface.co/datasets/sunblaze-ucb/cybergym) | `task_id`，去掉镜像 tag 末尾的 `-vul` 后缀即相等 | 随项目而异，见数据集字段 |
 | Terminal-Bench 2.x | **89** | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | 任务目录名即镜像 tag | `/app` |
 | SWE-Atlas QnA | **11** | 仓库问答，按 rubric 评分，不产补丁 | [ScaleAI/SWE-Atlas-QnA](https://huggingface.co/datasets/ScaleAI/SWE-Atlas-QnA) | `docker_image` | `/app` |
 
-判定方式并非只有一种，接入前先确认：SWE-rebench V2 / Scale-SWE / SWE-Gym / SWE-bench Pro 用 `FAIL_TO_PASS` + `PASS_TO_PASS`；SEC-bench 用 sanitizer 报告与退出码；Terminal-Bench 跑任务自带的 `tests/test.sh`；SWE-Atlas QnA 需按 rubric 打分。Scale-SWE 的用例引入方式也与 SWE-bench 不同，详见「换题库要改什么」。
+判定方式并非只有一种，接入前先确认：SWE-rebench V2 / Scale-SWE / SWE-Gym / SWE-bench Pro 用 `FAIL_TO_PASS` + `PASS_TO_PASS`；SEC-bench 用 sanitizer 报告与退出码；CyberGym 判定漏洞能否被触发、修复后是否不再触发，需接 fuzz 复现链路；Terminal-Bench 跑任务自带的 `tests/test.sh`；SWE-Atlas QnA 需按 rubric 打分。Scale-SWE 的用例引入方式也与 SWE-bench 不同，详见「换题库要改什么」。
 
 ### 二、仅提供镜像：元数据需自行匹配
 
@@ -546,6 +547,7 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 | SWE-bench Pro | <!-- TODO: 补充下载地址 --> |
 | SWE-smith | <!-- TODO: 补充下载地址 --> |
 | SEC-bench | <!-- TODO: 补充下载地址 --> |
+| CyberGym | <!-- TODO: 补充下载地址 --> |
 | Terminal-Bench 2.x | <!-- TODO: 补充下载地址 --> |
 | 其余题库 | <!-- TODO: 补充下载地址 --> |
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
@@ -508,17 +508,19 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 | 题库 | 镜像数 | 题目类型 | 元数据数据集 | 关联字段 | 工作目录 |
 | --- | --- | --- | --- | --- | --- |
-| SWE-rebench V2 | **32,074**<br/>（3,614 个仓库） | 真实 PR 修复，仓库覆盖面最广 | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` 字段即镜像的原始地址，逐字相等 | 仓库在根目录、以仓库原名命名（如 `/OpenTripPlanner`），需运行时探测 |
+| SWE-rebench V2 | **32,074**<br/>（3,614 个仓库<br/>20 种语言） | 真实 PR 修复，仓库覆盖面最广；python 7,238 张，其余为 Go / TS / JS / Rust / Java 等 | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` 字段即镜像的原始地址，逐字相等 | 仓库在根目录、以仓库原名命名（如 `/OpenTripPlanner`），需运行时探测 |
 | Scale-SWE | **19,473**<br/>（1,180 个仓库） | 真实 PR 修复：仓库复位到 PR 的父提交，要求实现该 PR | [AweAI-Team/Scale-SWE](https://huggingface.co/datasets/AweAI-Team/Scale-SWE) | `instance_id` 即镜像 tag 中的实例名 | `/workspace/<repo>`，取数据集 `workdir` 字段 |
 | SWE-Gym | **2,401**<br/>（11 个仓库） | 真实 issue 修复，SWE-bench 标准形态 | [SWE-Gym/SWE-Gym](https://huggingface.co/datasets/SWE-Gym/SWE-Gym) | `instance_id`（**镜像 tag 强制小写**，比对时需统一大小写） | `/testbed` |
 | SWE-bench Pro | **731** | 企业级仓库 issue 修复，上下文更长，含 Go/Node 等多语言 | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro) | `dockerhub_tag` | `/app` |
-| SWE-smith | **363**<br/>（环境级镜像） | 合成缺陷修复，一个镜像承载同一仓库的多道题（上游共 88,130 道） | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) 等 8 个语言子集（py / java / js / ts / rs / cpp / php / go） | `image_name` | `/testbed`，用 `git checkout <instance_id>` 选题 |
+| SWE-smith | **363**<br/>（环境级镜像） | 合成缺陷修复，一个镜像承载同一仓库的多道题：这 363 张环境对应上游 **79,418 道题** | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) 等 7 个语言子集（py / java / js / ts / rs / cpp / php）。上游另有 go 子集，**无对应镜像** | `image_name` | `/testbed`，用 `git checkout <instance_id>` 选题 |
 | SEC-bench | **300** | 安全漏洞复现与修复（CVE） | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | 取数据集 `work_dir` 字段 |
 | CyberGym | **1,507** | 漏洞挖掘：在真实 OSS 项目中触发并修复已知漏洞（来自 OSS-Fuzz / ARVO） | [sunblaze-ucb/cybergym](https://huggingface.co/datasets/sunblaze-ucb/cybergym) | `task_id`，去掉镜像 tag 末尾的 `-vul` 后缀即相等 | 随项目而异，见数据集字段 |
 | Terminal-Bench 2.x | **89** | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | 任务目录名即镜像 tag | `/app` |
 | SWE-Atlas QnA | **11** | 仓库问答，按 rubric 评分，不产补丁 | [ScaleAI/SWE-Atlas-QnA](https://huggingface.co/datasets/ScaleAI/SWE-Atlas-QnA) | `docker_image` | `/app` |
 
 判定方式并非只有一种，接入前先确认：SWE-rebench V2 / Scale-SWE / SWE-Gym / SWE-bench Pro 用 `FAIL_TO_PASS` + `PASS_TO_PASS`；SEC-bench 用 sanitizer 报告与退出码；CyberGym 判定漏洞能否被触发、修复后是否不再触发，需接 fuzz 复现链路；Terminal-Bench 跑任务自带的 `tests/test.sh`；SWE-Atlas QnA 需按 rubric 打分。Scale-SWE 的用例引入方式也与 SWE-bench 不同，详见「换题库要改什么」。
+
+**多语言题库要按语言分流判定**。以 SWE-rebench V2 为例，用例名的形态随测试框架而变：python 是 pytest 的 node id（`tests/test_x.py::TestA::test_b`），TS / JS 是 jest、mocha 的用例描述，Java 是测试类名。用一套 pytest 的解析逻辑套所有语言，非 python 的实例会全部判为失败。该数据集的 `install_config.test_cmd` 与 `log_parser` 字段**逐实例给出了运行命令与解析方式**，按此分流即可；上表的 [id → 语言对照](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv) 可用于筛选。若只想先跑通，可直接取 [python 子集](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv)（7,238 张，测试命令统一为 `pytest`）。SWE-bench Pro 同理，按数据集的 `repo_language` 字段分流。
 
 ### 二、仅提供镜像：元数据需自行匹配
 
@@ -539,17 +541,29 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 无论哪一类，都需要一份 `instance_id`（或镜像 tag）到镜像地址的映射表：**镜像 tag 带构建批次信息，无法由 `instance_id` 推导**。映射表按题库拆分成制表符分隔的文本文件提供（每行 `instance_id<TAB>镜像地址`），便于直接检索与脚本消费：
 
-| 题库 | 映射表下载 |
+| 题库 | 映射表下载 | 行数 |
+| --- | --- | --- |
+| SWE-rebench V2 | [swerebenchv2-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv.gz)）<br/>另附 [id → 语言对照](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv)、[python 子集](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv) | 32,074 |
+| Scale-SWE | [scaleswe-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv.gz)） | 19,473 |
+| SWE-Gym | [swegym-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv) | 2,401 |
+| CyberGym | [cybergym-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/cybergym-images.tsv) | 1,507 |
+| SWE-bench Pro | [swebpro-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv) | 731 |
+| SWE-smith | [swesmith-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swesmith-images.tsv) | 363 |
+| SEC-bench | [secbench-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/secbench-images.tsv) | 300 |
+| Terminal-Bench 2.x | [tb21-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tb21-images.tsv) | 89 |
+| SWE-Atlas QnA | [sweatlas-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/sweatlas-images.tsv) | 11 |
+| 其余题库（第二类合并） | [tier-C-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv.gz)），第三列为题库名 | 20,755 |
+
+另提供跨题库的合并清单与配套文件：
+
+| 文件 | 内容 |
 | --- | --- |
-| SWE-rebench V2 | <!-- TODO: 补充下载地址 --> |
-| Scale-SWE | <!-- TODO: 补充下载地址 --> |
-| SWE-Gym | <!-- TODO: 补充下载地址 --> |
-| SWE-bench Pro | <!-- TODO: 补充下载地址 --> |
-| SWE-smith | <!-- TODO: 补充下载地址 --> |
-| SEC-bench | <!-- TODO: 补充下载地址 --> |
-| CyberGym | <!-- TODO: 补充下载地址 --> |
-| Terminal-Bench 2.x | <!-- TODO: 补充下载地址 --> |
-| 其余题库 | <!-- TODO: 补充下载地址 --> |
+| [all-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv.gz)） | 全部 77,704 张，四列：`instance_id` / 镜像地址 / 题库 / 分类 |
+| [image-registry.json](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/image-registry.json) | 每个题库的工作目录、运行用户、判定方式、元数据来源，供 runner 读取 |
+| [MANIFEST.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/MANIFEST.tsv) | 各文件的行数、字节数与 **sha256**，下载后建议校验完整性 |
+| [swe-images-20260821.tar.gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821.tar.gz) | 以上文件的整包（约 3 MB），含一份说明 README |
+
+清单不做原地更新：新一批镜像会发布到新的日期目录，上述链接指向的文件内容保持不变。
 
 ```bash
 # 查某一道题的镜像地址
@@ -557,6 +571,9 @@ grep '^getmoto__moto-7365' swegym-images.tsv | cut -f2
 
 # 挑出某个仓库的全部题目
 grep '^pandas-dev__' scaleswe-images.tsv | cut -f1 > my-instances.txt
+
+# 从合并清单里按题库取（第三列是题库名）
+awk -F'\t' '$3=="scaleswe"{print $2}' all-images.tsv | head
 ```
 
 ## 换题库要改什么

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
@@ -295,6 +295,7 @@ print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(p
 ```python
 # grade.py
 import argparse, json, re, shlex
+from collections import Counter
 from pathlib import Path
 
 import yaml
@@ -314,7 +315,10 @@ def as_list(v):
     return list(v or [])
 
 def files_of(names):        # 用例名 → 文件名
-    return {n.strip().strip("'\"").split("::")[0] for n in names}
+    # 只取带文件前缀的（pytest node id）。多语言题库的用例名可能是纯用例描述或
+    # 测试类名，没有文件前缀，整串当文件名传给 pytest 会报 file not found。
+    return {n.strip().strip("'\"").split("::")[0] for n in names
+            if "::" in n or n.strip().strip("'\"").endswith(".py")}
 
 def patched_files(diff):    # 补丁触及的文件
     return sorted(set(re.findall(r"^\+\+\+ b/(\S+)", diff, flags=re.M)))
@@ -359,15 +363,39 @@ try:
     cmd = ("python -m pytest -rA --no-header -q " + " ".join(map(shlex.quote, files))
            + " > /tmp/res.log 2>&1; grep -E '^(PASSED|FAILED|ERROR) ' /tmp/res.log;"
              " echo '===TAIL==='; tail -3 /tmp/res.log")
-    report = env.execute({"command": cmd}, timeout=1800)["output"]
-    passed = set(re.findall(r"^PASSED (\S+)", report, flags=re.M))
+    res = env.execute({"command": cmd}, timeout=1800)
+    report = res["output"]
 
-    def ok(name):
-        n = name.strip().strip("'\"")
-        head = n.split()[0] if n.split() else n
-        return n in passed or any(x.startswith(head) for x in passed)
+    # 判分命令跑不出东西时，不能判成「测试没过」—— 那是把基础设施故障算进模型分数。
+    # 高并发下命令超时、输出为空是真实场景，必须与「测试失败」区分开。
+    if not report.strip() or res["returncode"] == -1:
+        raise SystemExit(json.dumps({"resolved": False, "graded": False,
+                                     "reason": "判分未完成（无输出，疑似超时），请降低并发后重跑"},
+                                    ensure_ascii=False))
 
-    f2p_ok, p2p_ok = [t for t in f2p if ok(t)], [t for t in p2p if ok(t)]
+    passed = Counter(re.findall(r"^PASSED (\S+)", report, flags=re.M))
+
+    def score(names):
+        """精确命中的直接计入；其余按截断头分组，再按**数量**满足判定。
+
+        不能用「头出现在通过列表里就算过」：一个参数化的头下可能有 4 个用例、
+        只通过 2 个，而判定只要求其中 2 个 —— 一律算过会把失败的也算成通过。
+        反过来「头下有失败就全判失败」又会误杀通过的那些。数量满足是这两者之间
+        唯一不系统性偏向任一边的做法（截断后的输出无法区分具体是哪个参数）。
+        """
+        groups, ok = {}, []
+        for name in names:
+            n = name.strip().strip("'\"")
+            if passed.get(n):
+                ok.append(name)
+            else:
+                groups.setdefault(n.split()[0] if n.split() else n, []).append(name)
+        for head, members in groups.items():
+            avail = sum(c for p, c in passed.items() if p.startswith(head))
+            ok += members[:avail]
+        return ok
+
+    f2p_ok, p2p_ok = score(f2p), score(p2p)
     print(json.dumps({
         "resolved": len(f2p_ok) == len(f2p) and len(p2p_ok) == len(p2p) and bool(f2p),
         "FAIL_TO_PASS": f"{len(f2p_ok)}/{len(f2p)}",
@@ -487,7 +515,7 @@ Path("preds.json").write_text(json.dumps(preds, ensure_ascii=False, indent=1))
 
 Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙箱并发判定。这样调整判分逻辑后重判不需要重跑 Agent，省掉整轮模型开销。
 
-**接入任何新题库的第一件事，是把数据集自带的正确补丁全部判一遍，通过率必须接近 100%。** 以下四类问题都会静默压低分数且不报错，只有这一步能暴露：
+**接入任何新题库的第一件事，是把数据集自带的正确补丁全部判一遍，通过率必须接近 100%。** 以下五类问题都会静默压低分数且不报错，只有这一步能暴露：
 
 | 问题 | 现象 | 处置 |
 | --- | --- | --- |
@@ -495,12 +523,17 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 | 判定依据被 `tail -N` 截断 | 大仓库测试报告数千行，通过的用例被漏判，分数偏低 | 先过滤出判定行，再单独取统计尾部 |
 | 参数化用例名含空格或换行 | pytest 报告在第一个空白处截断用例名，精确匹配全部落空 | 按截断后的前缀匹配，并按数量满足判定 |
 | 用例名当命令行参数传给 pytest | 名字含空格括号，报 not found，最终 no tests ran | 跑整个测试文件，再从报告按名字匹配 |
+| 判分命令超时、输出为空被当成「测试未通过」 | 大测试集在高并发下超时，实例被记为 0 通过；串行重跑则全过 | 输出为空或退出码异常时标记为**判分未完成**，不计入分母，降并发重跑 |
+
+最后一类最容易被忽略，也最有害：它把基础设施故障读成模型能力差，而且越是测试用例多的大仓库越容易触发 —— 结果是评测结论被系统性压低，却看不出任何报错。
 
 ## 上海地域现成的评测镜像
 
 华东1（上海）地域已预置一批开源评测集的镜像，仓库现场与依赖都已就绪，拿到镜像地址构建模板即可使用，无需自行搬运。镜像前缀统一为 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`。
 
 **镜像只解决「环境」，题目与判定用例来自上游数据集，需要按 `instance_id` 与镜像关联。** 按元数据是否公开可得，分两类。
+
+> 下表的元数据数据集托管在 HuggingFace 上，**沙箱内不一定能直接访问**。建议在能出网的环境先把需要的字段（`problem_statement` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch`）导出成本地文件，再随评测任务下发；不要在批量评测的过程中现拉，一旦拉取失败会把整批拖住。
 
 ### 一、可直接使用：元数据公开，关联字段已验证
 
@@ -511,7 +544,7 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 | SWE-rebench V2 | **32,074**<br/>（3,614 个仓库<br/>20 种语言） | 真实 PR 修复，仓库覆盖面最广；python 7,238 张，其余为 Go / TS / JS / Rust / Java 等 | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` 字段即镜像的原始地址，逐字相等 | 仓库在根目录、以仓库原名命名（如 `/OpenTripPlanner`），需运行时探测 |
 | Scale-SWE | **19,473**<br/>（1,180 个仓库） | 真实 PR 修复：仓库复位到 PR 的父提交，要求实现该 PR | [AweAI-Team/Scale-SWE](https://huggingface.co/datasets/AweAI-Team/Scale-SWE) | `instance_id` 即镜像 tag 中的实例名 | `/workspace/<repo>`，取数据集 `workdir` 字段 |
 | SWE-Gym | **2,401**<br/>（11 个仓库） | 真实 issue 修复，SWE-bench 标准形态 | [SWE-Gym/SWE-Gym](https://huggingface.co/datasets/SWE-Gym/SWE-Gym) | `instance_id`（**镜像 tag 强制小写**，比对时需统一大小写） | `/testbed` |
-| SWE-bench Pro | **731** | 企业级仓库 issue 修复，上下文更长，含 Go/Node 等多语言 | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro) | `dockerhub_tag` | `/app` |
+| SWE-bench Pro | **731** | 企业级仓库 issue 修复，上下文更长，含 Go/Node 等多语言 | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro)；另有 [AweAI-Team/AweAgent-Meta-SWE-Bench-Pro](https://huggingface.co/datasets/AweAI-Team/AweAgent-Meta-SWE-Bench-Pro)，行数相同但额外带 `run_script_sh` / `parser_py`，**做多语言判分更省事** | `dockerhub_tag` | `/app` |
 | SWE-smith | **363**<br/>（环境级镜像） | 合成缺陷修复，一个镜像承载同一仓库的多道题：这 363 张环境对应上游 **79,418 道题** | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) 等 7 个语言子集（py / java / js / ts / rs / cpp / php）。上游另有 go 子集，**无对应镜像** | `image_name` | `/testbed`，用 `git checkout <instance_id>` 选题 |
 | SEC-bench | **300** | 安全漏洞复现与修复（CVE） | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | 取数据集 `work_dir` 字段 |
 | CyberGym | **1,507** | 漏洞挖掘：在真实 OSS 项目中触发并修复已知漏洞（来自 OSS-Fuzz / ARVO） | [sunblaze-ucb/cybergym](https://huggingface.co/datasets/sunblaze-ucb/cybergym) | `task_id`，去掉镜像 tag 末尾的 `-vul` 后缀即相等 | 随项目而异，见数据集字段 |
@@ -520,7 +553,7 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 判定方式并非只有一种，接入前先确认：SWE-rebench V2 / Scale-SWE / SWE-Gym / SWE-bench Pro 用 `FAIL_TO_PASS` + `PASS_TO_PASS`；SEC-bench 用 sanitizer 报告与退出码；CyberGym 判定漏洞能否被触发、修复后是否不再触发，需接 fuzz 复现链路；Terminal-Bench 跑任务自带的 `tests/test.sh`；SWE-Atlas QnA 需按 rubric 打分。Scale-SWE 的用例引入方式也与 SWE-bench 不同，详见「换题库要改什么」。
 
-**多语言题库要按语言分流判定**。以 SWE-rebench V2 为例，用例名的形态随测试框架而变：python 是 pytest 的 node id（`tests/test_x.py::TestA::test_b`），TS / JS 是 jest、mocha 的用例描述，Java 是测试类名。用一套 pytest 的解析逻辑套所有语言，非 python 的实例会全部判为失败。该数据集的 `install_config.test_cmd` 与 `log_parser` 字段**逐实例给出了运行命令与解析方式**，按此分流即可；上表的 [id → 语言对照](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv) 可用于筛选。若只想先跑通，可直接取 [python 子集](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv)（7,238 张，测试命令统一为 `pytest`）。SWE-bench Pro 同理，按数据集的 `repo_language` 字段分流。
+**多语言题库要按语言分流判定**。以 SWE-rebench V2 为例，用例名的形态随测试框架而变：python 是 pytest 的 node id（`tests/test_x.py::TestA::test_b`），TS / JS 是 jest、mocha 的用例描述，Java 是测试类名。用一套 pytest 的解析逻辑套所有语言，非 python 的实例会全部判为失败。该数据集的 `install_config.test_cmd` 与 `log_parser` 字段**逐实例给出了运行命令与解析方式**，按此分流即可；清单里的 `swerebenchv2-languages.tsv`（id → 语言）可用于筛选。若只想先跑通，可直接取 `swerebenchv2-python-images.tsv`（7,238 张，测试命令统一为 `pytest --no-header`，与本文判分脚本的口径一致）。SWE-bench Pro 同理，按数据集的 `repo_language` 字段分流。
 
 ### 二、仅提供镜像：元数据需自行匹配
 
@@ -541,29 +574,29 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 无论哪一类，都需要一份 `instance_id`（或镜像 tag）到镜像地址的映射表：**镜像 tag 带构建批次信息，无法由 `instance_id` 推导**。映射表按题库拆分成制表符分隔的文本文件提供（每行 `instance_id<TAB>镜像地址`），便于直接检索与脚本消费：
 
-| 题库 | 映射表下载 | 行数 |
-| --- | --- | --- |
-| SWE-rebench V2 | [swerebenchv2-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv.gz)）<br/>另附 [id → 语言对照](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv)、[python 子集](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv) | 32,074 |
-| Scale-SWE | [scaleswe-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv.gz)） | 19,473 |
-| SWE-Gym | [swegym-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv) | 2,401 |
-| CyberGym | [cybergym-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/cybergym-images.tsv) | 1,507 |
-| SWE-bench Pro | [swebpro-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv) | 731 |
-| SWE-smith | [swesmith-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swesmith-images.tsv) | 363 |
-| SEC-bench | [secbench-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/secbench-images.tsv) | 300 |
-| Terminal-Bench 2.x | [tb21-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tb21-images.tsv) | 89 |
-| SWE-Atlas QnA | [sweatlas-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/sweatlas-images.tsv) | 11 |
-| 其余题库（第二类合并） | [tier-C-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv.gz)），第三列为题库名 | 20,755 |
+| 题库 | 映射表文件 | 行数 | 下载地址 |
+| --- | --- | --- | --- |
+| SWE-rebench V2 | `swerebenchv2-images.tsv`<br/>另附 `swerebenchv2-languages.tsv`（id → 语言）、`swerebenchv2-python-images.tsv` | 32,074 | <!-- TODO: 补充下载地址 --> |
+| Scale-SWE | `scaleswe-images.tsv` | 19,473 | <!-- TODO: 补充下载地址 --> |
+| SWE-Gym | `swegym-images.tsv` | 2,401 | <!-- TODO: 补充下载地址 --> |
+| CyberGym | `cybergym-images.tsv` | 1,507 | <!-- TODO: 补充下载地址 --> |
+| SWE-bench Pro | `swebpro-images.tsv` | 731 | <!-- TODO: 补充下载地址 --> |
+| SWE-smith | `swesmith-images.tsv` | 363 | <!-- TODO: 补充下载地址 --> |
+| SEC-bench | `secbench-images.tsv` | 300 | <!-- TODO: 补充下载地址 --> |
+| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | <!-- TODO: 补充下载地址 --> |
+| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | <!-- TODO: 补充下载地址 --> |
+| 其余题库（第二类合并） | `tier-C-images.tsv`，第三列为题库名 | 20,755 | <!-- TODO: 补充下载地址 --> |
 
 另提供跨题库的合并清单与配套文件：
 
-| 文件 | 内容 |
-| --- | --- |
-| [all-images.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv.gz)） | 全部 77,704 张，四列：`instance_id` / 镜像地址 / 题库 / 分类 |
-| [image-registry.json](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/image-registry.json) | 每个题库的工作目录、运行用户、判定方式、元数据来源，供 runner 读取 |
-| [MANIFEST.tsv](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/MANIFEST.tsv) | 各文件的行数、字节数与 **sha256**，下载后建议校验完整性 |
-| [swe-images-20260821.tar.gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821.tar.gz) | 以上文件的整包（约 3 MB），含一份说明 README |
+| 文件 | 内容 | 下载地址 |
+| --- | --- | --- |
+| `all-images.tsv` | 全部 77,704 张，四列：`instance_id` / 镜像地址 / 题库 / 分类 | <!-- TODO: 补充下载地址 --> |
+| `image-registry.json` | 每个题库的工作目录、运行用户、判定方式、元数据来源，供 runner 读取 | <!-- TODO: 补充下载地址 --> |
+| `MANIFEST.tsv` | 各文件的行数、字节数与 **sha256**，下载后建议校验完整性 | <!-- TODO: 补充下载地址 --> |
+| 整包 | 以上文件的压缩包（约 3 MB），含一份说明 README | <!-- TODO: 补充下载地址 --> |
 
-清单不做原地更新：新一批镜像会发布到新的日期目录，上述链接指向的文件内容保持不变。
+超过 200 KB 的清单另有 `.gz` 版本，内容一致。清单不做原地更新：新一批镜像会发布到新的目录，已发布文件的内容保持不变。
 
 ```bash
 # 查某一道题的镜像地址

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
@@ -531,33 +531,57 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 华东1（上海）地域已预置一批开源评测集的镜像，仓库现场与依赖都已就绪，拿到镜像地址构建模板即可使用，无需自行搬运。镜像前缀统一为 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`。
 
-**镜像只解决「环境」，题目与判定用例来自上游数据集，需要按 `instance_id` 与镜像关联。** 按元数据是否公开可得，分两类。
+**镜像只解决「环境」。** 一道题能进评测，要三件套齐全：镜像能起、拿得到题目元信息（问题描述与判定用例）、判定方式已实现。按这三件套，这批镜像分三类：
 
-> 下表的元数据数据集托管在 HuggingFace 上，**沙箱内不一定能直接访问**。建议在能出网的环境先把需要的字段（`problem_statement` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch`）导出成本地文件，再随评测任务下发；不要在批量评测的过程中现拉，一旦拉取失败会把整批拖住。
+| 分类 | 镜像数 | 状态 | 你需要做什么 |
+| --- | --- | --- | --- |
+| 一、判定口径已验证 | **29,112** | 三件套齐全，且用数据集自带的正确补丁自检通过 | 换镜像地址与工作目录即可开跑（Scale-SWE 另需换用例引入方式，见下） |
+| 二、元数据齐备，判定需自行实现 | **27,837** | 能起沙箱、能取到题面、关联关系已核对，但判定方式与本文示例不同 | 按该题库的判定方式实现判分 |
+| 三、仅提供镜像 | **20,755** | 镜像能起，但题目与镜像的对应关系无法建立 | 只能当预置好依赖的仓库环境用；要做判分需自行找元数据 |
+| 合计 | **77,704** | | |
 
-### 一、可直接使用：元数据公开，关联字段已验证
+**只想先跑通，取第一类。** 第二类给出来是因为镜像与题面都是完备的，缺的只是判分实现；第三类给出来是为了完整披露，但它无法自动判分。
 
-下表每个题库的元数据都公开可取，且已逐条验证「镜像 ↔ 数据集」的关联字段能对上（关联率均为 100%，`SWE-smith` 为 99.7%）。拿到数据集与镜像清单即可开跑。
+> 元数据数据集托管在 HuggingFace 上，**沙箱内不一定能直接访问**。建议在能出网的环境先把需要的字段（`problem_statement` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch`）导出成本地文件，再随评测任务下发；不要在批量评测过程中现拉，一旦拉取失败会把整批拖住。
 
-| 题库 | 镜像数 | 题目类型 | 元数据数据集 | 关联字段 | 工作目录 |
+### 一、判定口径已验证：29,112 张
+
+下表三个题库的元数据公开可取，「镜像 ↔ 数据集」的关联字段已**逐条**核对（非抽样），并且用数据集自带的正确补丁走完判分全部通过。
+
+| 题库 | 镜像数 | 仓库数 | 题目类型 | 元数据数据集 | 关联字段 | 工作目录 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Scale-SWE | **19,473** | 1,180 | 真实 PR 修复：仓库复位到 PR 的父提交，要求实现该 PR | [AweAI-Team/Scale-SWE](https://huggingface.co/datasets/AweAI-Team/Scale-SWE) | `instance_id` 即镜像 tag 中的实例名 | `/workspace/<repo>`，取数据集 `workdir` 字段 |
+| SWE-rebench V2（python 子集） | **7,238** | 689 | 真实 PR 修复 | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2)，筛 `language=python` | `image_name` 字段即镜像的原始地址，逐字相等 | 仓库在根目录、以仓库原名命名（如 `/OpenTripPlanner`），需运行时探测 |
+| SWE-Gym | **2,401** | 11 | 真实 issue 修复，SWE-bench 标准形态 | [SWE-Gym/SWE-Gym](https://huggingface.co/datasets/SWE-Gym/SWE-Gym) | `instance_id`（**镜像 tag 强制小写**，比对时需统一大小写） | `/testbed` |
+
+三者的判定依据都是 `FAIL_TO_PASS` + `PASS_TO_PASS`，但**用例引入方式有别**：
+
+- **SWE-Gym、SWE-rebench V2（python）**：与本文 `grade.py` 完全一致 —— 打 `test_patch` 引入用例，再跑 pytest。SWE-rebench V2 的 python 子集测试命令统一是 `pytest --no-header`，所以口径能直接对上；换库只需换镜像地址，工作目录改为运行时探测。
+- **Scale-SWE**：**没有 `test_patch`**。`FAIL_TO_PASS` 指向一个注入的新测试文件，内容在 `f2p_script` 字段（或打在已有测试文件上的 `f2p_patch`）；复位靠 `pre_commands`。要改 `grade.py` 里引入用例的那一段，顺序也不能反 —— `pre_commands` 里的 `git clean -fd` 会删掉未跟踪文件，先写测试再复位等于白写。
+
+**仓库多样性差别很大**：Scale-SWE 覆盖 1,180 个仓库，SWE-rebench V2 的 python 子集 689 个，而 SWE-Gym 只有 11 个（pandas、moto 等占大头）。做跨仓库泛化的基线要看「仓库数」这一列 —— 只用 SWE-Gym 会有天花板，题目再多也集中在同几个仓库上。
+
+### 二、元数据齐备，判定需自行实现：27,837 张
+
+下表的镜像能起、题面能取、关联字段也已核对到 100%（`SWE-smith` 为 99.7%），差的只是判定实现 —— 它们的判定方式与本文示例不同。
+
+| 题库 | 数量 | 题目类型 | 元数据数据集 | 关联字段 | 判定方式与待补内容 |
 | --- | --- | --- | --- | --- | --- |
-| SWE-rebench V2 | **32,074**<br/>（3,614 个仓库<br/>20 种语言） | 真实 PR 修复，仓库覆盖面最广；python 7,238 张，其余为 Go / TS / JS / Rust / Java 等 | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` 字段即镜像的原始地址，逐字相等 | 仓库在根目录、以仓库原名命名（如 `/OpenTripPlanner`），需运行时探测 |
-| Scale-SWE | **19,473**<br/>（1,180 个仓库） | 真实 PR 修复：仓库复位到 PR 的父提交，要求实现该 PR | [AweAI-Team/Scale-SWE](https://huggingface.co/datasets/AweAI-Team/Scale-SWE) | `instance_id` 即镜像 tag 中的实例名 | `/workspace/<repo>`，取数据集 `workdir` 字段 |
-| SWE-Gym | **2,401**<br/>（11 个仓库） | 真实 issue 修复，SWE-bench 标准形态 | [SWE-Gym/SWE-Gym](https://huggingface.co/datasets/SWE-Gym/SWE-Gym) | `instance_id`（**镜像 tag 强制小写**，比对时需统一大小写） | `/testbed` |
-| SWE-bench Pro | **731** | 企业级仓库 issue 修复，上下文更长，含 Go/Node 等多语言 | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro)；另有 [AweAI-Team/AweAgent-Meta-SWE-Bench-Pro](https://huggingface.co/datasets/AweAI-Team/AweAgent-Meta-SWE-Bench-Pro)，行数相同但额外带 `run_script_sh` / `parser_py`，**做多语言判分更省事** | `dockerhub_tag` | `/app` |
-| SWE-smith | **363**<br/>（环境级镜像） | 合成缺陷修复，一个镜像承载同一仓库的多道题：这 363 张环境对应上游 **79,418 道题** | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) 等 7 个语言子集（py / java / js / ts / rs / cpp / php）。上游另有 go 子集，**无对应镜像** | `image_name` | `/testbed`，用 `git checkout <instance_id>` 选题 |
-| SEC-bench | **300** | 安全漏洞复现与修复（CVE） | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | 取数据集 `work_dir` 字段 |
-| CyberGym | **1,507** | 漏洞挖掘：在真实 OSS 项目中触发并修复已知漏洞（来自 OSS-Fuzz / ARVO） | [sunblaze-ucb/cybergym](https://huggingface.co/datasets/sunblaze-ucb/cybergym) | `task_id`，去掉镜像 tag 末尾的 `-vul` 后缀即相等 | 随项目而异，见数据集字段 |
-| Terminal-Bench 2.x | **89** | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | 任务目录名即镜像 tag | `/app` |
-| SWE-Atlas QnA | **11** | 仓库问答，按 rubric 评分，不产补丁 | [ScaleAI/SWE-Atlas-QnA](https://huggingface.co/datasets/ScaleAI/SWE-Atlas-QnA) | `docker_image` | `/app` |
+| SWE-rebench V2（python 以外的 19 种语言） | **24,836** | 真实 PR 修复，仓库覆盖面最广（整族 3,614 个仓库） | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` 字段即镜像的原始地址 | 同为 `FAIL_TO_PASS` + `PASS_TO_PASS`，但用例名形态随测试框架而变，**必须按语言分流**。数据集的 `install_config.test_cmd` 与 `log_parser` 逐实例给出了运行命令与解析方式 |
+| CyberGym | **1,507** | 漏洞挖掘：在真实 OSS 项目中触发并修复已知漏洞（来自 OSS-Fuzz / ARVO） | [sunblaze-ucb/cybergym](https://huggingface.co/datasets/sunblaze-ucb/cybergym) | `task_id`，去掉镜像 tag 末尾的 `-vul` 后缀即相等 | 不用 `FAIL_TO_PASS`，判定漏洞能否被触发、修复后是否不再触发，需接 fuzz 复现链路 |
+| SWE-bench Pro | **731** | 企业级仓库 issue 修复，上下文更长，含 Go / Node 等多语言 | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro)，或 [AweAI-Team/AweAgent-Meta-SWE-Bench-Pro](https://huggingface.co/datasets/AweAI-Team/AweAgent-Meta-SWE-Bench-Pro) | `dockerhub_tag` | 同为 `FAIL_TO_PASS` + `PASS_TO_PASS`，需按 `repo_language` 分流。**优先用 AweAI 那份**：行数相同但额外带 `run_script_sh` / `parser_py`，运行与解析脚本都给了 |
+| SWE-smith | **363 张环境镜像**（对应上游 **79,418 道题**） | 合成缺陷修复，一个镜像承载同一仓库的多道题 | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) 等 7 个语言子集（py / java / js / ts / rs / cpp / php）。上游另有 go 子集，**无对应镜像** | `image_name` | 判定依据同 SWE-bench，但**选题机制要自己接**：在镜像内 `/testbed` 执行 `git checkout <instance_id>` 切到对应缺陷状态 |
+| SEC-bench | **300** | 安全漏洞复现与修复（CVE） | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | 不用 `FAIL_TO_PASS`，看 sanitizer 报告与退出码。数据集自带 `work_dir` / `build_sh` / `secb_sh`，运行与判定脚本都给了 |
+| Terminal-Bench 2.x | **89** | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | 任务目录名即镜像 tag | 跑任务自带的 `tests/test.sh`，**判分不用自己写**；但 Agent 循环要换 —— 它不产出补丁 |
+| SWE-Atlas QnA | **11** | 仓库问答，不产补丁 | [ScaleAI/SWE-Atlas-QnA](https://huggingface.co/datasets/ScaleAI/SWE-Atlas-QnA) | `docker_image` | 按 rubric 打分，需要模型评判而非跑测试 |
 
-判定方式并非只有一种，接入前先确认：SWE-rebench V2 / Scale-SWE / SWE-Gym / SWE-bench Pro 用 `FAIL_TO_PASS` + `PASS_TO_PASS`；SEC-bench 用 sanitizer 报告与退出码；CyberGym 判定漏洞能否被触发、修复后是否不再触发，需接 fuzz 复现链路；Terminal-Bench 跑任务自带的 `tests/test.sh`；SWE-Atlas QnA 需按 rubric 打分。Scale-SWE 的用例引入方式也与 SWE-bench 不同，详见「换题库要改什么」。
+其中 SWE-smith 值得单独一提：**它的「镜像数」和「题量」不是一回事**。363 张是环境镜像（一个仓库一张），背后挂着上游 79,418 道题，靠切分支选题 —— 接好选题机制后，它是这批资产里题量最大的一个来源。
 
-**多语言题库要按语言分流判定**。以 SWE-rebench V2 为例，用例名的形态随测试框架而变：python 是 pytest 的 node id（`tests/test_x.py::TestA::test_b`），TS / JS 是 jest、mocha 的用例描述，Java 是测试类名。用一套 pytest 的解析逻辑套所有语言，非 python 的实例会全部判为失败。该数据集的 `install_config.test_cmd` 与 `log_parser` 字段**逐实例给出了运行命令与解析方式**，按此分流即可；清单里的 `swerebenchv2-languages.tsv`（id → 语言）可用于筛选。若只想先跑通，可直接取 `swerebenchv2-python-images.tsv`（7,238 张，测试命令统一为 `pytest --no-header`，与本文判分脚本的口径一致）。SWE-bench Pro 同理，按数据集的 `repo_language` 字段分流。
+**多语言题库要按语言分流判定。** 以 SWE-rebench V2 为例，用例名的形态随测试框架而变：python 是 pytest 的 node id（`tests/test_x.py::TestA::test_b`），TS / JS 是 jest、mocha 的用例描述，Java 是测试类名。用一套 pytest 的解析逻辑套所有语言，非 python 的实例会**全部判为失败**。清单里的 `swerebenchv2-languages.tsv`（id → 语言）可用于筛选。测试命令的形态比语言集中：Go 全是 `go test`、Rust 全是 `cargo test`、Java 是 Maven 与 Gradle 两种、JS / TS 是 npm 系的 jest / mocha / vitest 等 —— 按四到五组实现解析器即可覆盖大部分。SWE-bench Pro 同理，按 `repo_language` 分流。
 
-### 二、仅提供镜像：元数据需自行匹配
+### 三、仅提供镜像：元数据需自行匹配，20,755 张
 
-下表的镜像同样可用（构建模板、创建沙箱、进容器操作都正常），但**平台不提供题目与判定用例的关联关系**，原因见「说明」列。使用前需要自己找到元数据来源并建立与镜像的对应关系，否则只能把它们当作「预置好依赖的真实仓库环境」使用，无法做自动判分。
+下表的镜像同样能用（构建模板、创建沙箱、进容器操作都正常），但**平台不提供题目与判定用例的关联关系**。使用前需要自己找到元数据来源并建立与镜像的对应关系，否则只能把它们当作「预置好依赖的真实仓库环境」使用，无法做自动判分。
 
 | 题库 | 镜像数 | 镜像内容 | 说明：为什么需要自行匹配 |
 | --- | --- | --- | --- |
@@ -572,41 +596,66 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 ### 镜像清单获取
 
-无论哪一类，都需要一份 `instance_id`（或镜像 tag）到镜像地址的映射表：**镜像 tag 带构建批次信息，无法由 `instance_id` 推导**。映射表按题库拆分成制表符分隔的文本文件提供（每行 `instance_id<TAB>镜像地址`），便于直接检索与脚本消费：
+无论哪一类，都需要一份 `instance_id`（或镜像 tag）到镜像地址的映射表：**镜像 tag 带构建批次信息，无法由 `instance_id` 推导**。清单是制表符分隔的文本文件，每行 `instance_id<TAB>镜像地址`，可直接 `grep` 或 `cut -f2` 喂给脚本。
 
-| 题库 | 映射表文件 | 行数 | 下载地址 |
+**按上面三类取用**（这三个文件与前文的三个小节一一对应）：
+
+| 分类 | 清单文件 | 行数 | 下载地址 |
 | --- | --- | --- | --- |
-| SWE-rebench V2 | `swerebenchv2-images.tsv`<br/>另附 `swerebenchv2-languages.tsv`（id → 语言）、`swerebenchv2-python-images.tsv` | 32,074 | <!-- TODO: 补充下载地址 --> |
-| Scale-SWE | `scaleswe-images.tsv` | 19,473 | <!-- TODO: 补充下载地址 --> |
-| SWE-Gym | `swegym-images.tsv` | 2,401 | <!-- TODO: 补充下载地址 --> |
-| CyberGym | `cybergym-images.tsv` | 1,507 | <!-- TODO: 补充下载地址 --> |
-| SWE-bench Pro | `swebpro-images.tsv` | 731 | <!-- TODO: 补充下载地址 --> |
-| SWE-smith | `swesmith-images.tsv` | 363 | <!-- TODO: 补充下载地址 --> |
-| SEC-bench | `secbench-images.tsv` | 300 | <!-- TODO: 补充下载地址 --> |
-| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | <!-- TODO: 补充下载地址 --> |
-| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | <!-- TODO: 补充下载地址 --> |
-| 其余题库（第二类合并） | `tier-C-images.tsv`，第三列为题库名 | 20,755 | <!-- TODO: 补充下载地址 --> |
+| 一、判定口径已验证 | `tier-A-images.tsv` | 29,112 | 待补充 |
+| 二、元数据齐备，判定需自行实现 | `tier-B-images.tsv` | 27,837 | 待补充 |
+| 三、仅提供镜像 | `tier-C-images.tsv` | 20,755 | 待补充 |
 
-另提供跨题库的合并清单与配套文件：
+这三个文件都是三列：`instance_id` / 镜像地址 / 题库名，用第三列即可切到单个题库。
+
+**按题库单独取用**：
+
+| 题库 | 清单文件 | 行数 | 下载地址 |
+| --- | --- | --- | --- |
+| SWE-rebench V2（整族） | `swerebenchv2-images.tsv` | 32,074 | 待补充 |
+| SWE-rebench V2（python 子集） | `swerebenchv2-python-images.tsv` | 7,238 | 待补充 |
+| SWE-rebench V2（id → 语言对照） | `swerebenchv2-languages.tsv` | 32,074 | 待补充 |
+| Scale-SWE | `scaleswe-images.tsv` | 19,473 | 待补充 |
+| SWE-Gym | `swegym-images.tsv` | 2,401 | 待补充 |
+| CyberGym | `cybergym-images.tsv` | 1,507 | 待补充 |
+| SWE-bench Pro | `swebpro-images.tsv` | 731 | 待补充 |
+| SWE-smith | `swesmith-images.tsv` | 363 | 待补充 |
+| SEC-bench | `secbench-images.tsv` | 300 | 待补充 |
+| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | 待补充 |
+| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | 待补充 |
+
+配套文件：
 
 | 文件 | 内容 | 下载地址 |
 | --- | --- | --- |
-| `all-images.tsv` | 全部 77,704 张，四列：`instance_id` / 镜像地址 / 题库 / 分类 | <!-- TODO: 补充下载地址 --> |
-| `image-registry.json` | 每个题库的工作目录、运行用户、判定方式、元数据来源，供 runner 读取 | <!-- TODO: 补充下载地址 --> |
-| `MANIFEST.tsv` | 各文件的行数、字节数与 **sha256**，下载后建议校验完整性 | <!-- TODO: 补充下载地址 --> |
-| 整包 | 以上文件的压缩包（约 3 MB），含一份说明 README | <!-- TODO: 补充下载地址 --> |
+| `all-images.tsv` | 全部 77,704 张，四列：`instance_id` / 镜像地址 / 题库 / 所属分类 | 待补充 |
+| `image-registry.json` | 每个题库的工作目录、运行用户、判定方式、元数据来源，供 runner 读取 | 待补充 |
+| `MANIFEST.tsv` | 各文件的行数、字节数与 **sha256**，下载后建议校验完整性 | 待补充 |
+| 整包 | 以上文件的压缩包（约 3 MB），含一份说明 README | 待补充 |
 
 超过 200 KB 的清单另有 `.gz` 版本，内容一致。清单不做原地更新：新一批镜像会发布到新的目录，已发布文件的内容保持不变。
+
+**`instance_id` 的形态各题库不同**，写筛选脚本前先看一眼实际内容，不要跨题库套用同一个正则：
+
+| 题库 | `instance_id` 形态 | 示例 |
+| --- | --- | --- |
+| SWE-Gym | `owner__repo-编号` | `getmoto__moto-7365` |
+| Scale-SWE | `user_repo_pr编号` | `geopandas_geopandas_pr2027` |
+| SWE-rebench V2 | `owner-repo:PR-提交前缀` | `keras-team-keras:19955-ca9519b` |
 
 ```bash
 # 查某一道题的镜像地址
 grep '^getmoto__moto-7365' swegym-images.tsv | cut -f2
 
-# 挑出某个仓库的全部题目
-grep '^pandas-dev__' scaleswe-images.tsv | cut -f1 > my-instances.txt
+# 挑出某个仓库的全部题目（注意用该题库自己的 id 形态）
+grep '^pandas-dev__' swegym-images.tsv | cut -f1 > my-instances.txt
+grep '^geopandas_geopandas_' scaleswe-images.tsv | cut -f1 >> my-instances.txt
 
-# 从合并清单里按题库取（第三列是题库名）
-awk -F'\t' '$3=="scaleswe"{print $2}' all-images.tsv | head
+# 从第一类清单里只取某个题库（第三列是题库名）
+awk -F'\t' '$3=="scaleswe"{print $2}' tier-A-images.tsv | head
+
+# 校验下载完整性（macOS 用 shasum -a 256 -c）
+awk -F'\t' 'NR>1{print $4"  "$1}' MANIFEST.tsv > sums && sha256sum -c sums
 ```
 
 ## 换题库要改什么

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
@@ -500,26 +500,54 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 华东1（上海）地域已预置一批开源评测集的镜像，仓库现场与依赖都已就绪，拿到镜像地址构建模板即可使用，无需自行搬运。镜像前缀统一为 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`。
 
-| 题库 | 镜像数 | 题目类型 | 元数据来源 | 工作目录 |
-| --- | --- | --- | --- | --- |
-| Scale-SWE | 19,473（1,180 个仓库） | 真实 PR 修复：仓库复位到 PR 的父提交，要求实现该 PR | `AweAI-Team/Scale-SWE` | `/workspace/<repo>`，每实例不同 |
-| SWE-Gym | 2,401（11 个仓库） | 真实 issue 修复，SWE-bench 标准形态 | `SWE-Gym/SWE-Gym` | `/testbed` |
-| SWE-bench Pro | 731 | 企业级仓库 issue 修复，上下文更长，含 Go/Node 等多语言仓库 | `ScaleAI/SWE-bench_Pro` | `/app` |
-| SWE-smith | 363（环境级镜像） | 合成缺陷修复，一个镜像承载同一仓库的多道题，通过 `git checkout <instance_id>` 选题 | `SWE-bench/SWE-smith-*` | `/testbed` |
-| Terminal-Bench 2.x | 89 | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | `harborframework/terminal-bench-2.0` | `/app` |
+**镜像只解决「环境」，题目与判定用例来自上游数据集，需要按 `instance_id` 与镜像关联。** 按元数据是否公开可得，分两类。
 
-选型上，需要跨仓库泛化能力优先用 Scale-SWE（覆盖 1,180 个仓库）；SWE-Gym 只覆盖 11 个仓库，更适合做快速回归。前两个题库的判分口径与本文一致，可直接复用前文代码；后三个需要按其形态调整判分（多语言测试执行器、选题方式、跑任务自带的 `tests/test.sh`）。
+### 一、可直接使用：元数据公开，关联字段已验证
 
-**题目元数据需要单独获取。** 上表的元数据来源是公开数据集，其中的问题描述与判定用例不随镜像分发；镜像与元数据靠 `instance_id` 关联。评测镜像的 tag 带构建批次信息，**无法由 `instance_id` 推导**，因此需要一份 `instance_id` 到镜像地址的映射表。该映射按题库拆分成制表符分隔的文本文件提供（每行 `instance_id<TAB>镜像地址`），便于直接检索与脚本消费：
+下表每个题库的元数据都公开可取，且已逐条验证「镜像 ↔ 数据集」的关联字段能对上（关联率均为 100%，`SWE-smith` 为 99.7%）。拿到数据集与镜像清单即可开跑。
+
+| 题库 | 镜像数 | 题目类型 | 元数据数据集 | 关联字段 | 工作目录 |
+| --- | --- | --- | --- | --- | --- |
+| SWE-rebench V2 | **32,074**<br/>（3,614 个仓库） | 真实 PR 修复，仓库覆盖面最广 | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` 字段即镜像的原始地址，逐字相等 | 仓库在根目录、以仓库原名命名（如 `/OpenTripPlanner`），需运行时探测 |
+| Scale-SWE | **19,473**<br/>（1,180 个仓库） | 真实 PR 修复：仓库复位到 PR 的父提交，要求实现该 PR | [AweAI-Team/Scale-SWE](https://huggingface.co/datasets/AweAI-Team/Scale-SWE) | `instance_id` 即镜像 tag 中的实例名 | `/workspace/<repo>`，取数据集 `workdir` 字段 |
+| SWE-Gym | **2,401**<br/>（11 个仓库） | 真实 issue 修复，SWE-bench 标准形态 | [SWE-Gym/SWE-Gym](https://huggingface.co/datasets/SWE-Gym/SWE-Gym) | `instance_id`（**镜像 tag 强制小写**，比对时需统一大小写） | `/testbed` |
+| SWE-bench Pro | **731** | 企业级仓库 issue 修复，上下文更长，含 Go/Node 等多语言 | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro) | `dockerhub_tag` | `/app` |
+| SWE-smith | **363**<br/>（环境级镜像） | 合成缺陷修复，一个镜像承载同一仓库的多道题（上游共 88,130 道） | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) 等 8 个语言子集（py / java / js / ts / rs / cpp / php / go） | `image_name` | `/testbed`，用 `git checkout <instance_id>` 选题 |
+| SEC-bench | **300** | 安全漏洞复现与修复（CVE） | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | 取数据集 `work_dir` 字段 |
+| Terminal-Bench 2.x | **89** | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | 任务目录名即镜像 tag | `/app` |
+| SWE-Atlas QnA | **11** | 仓库问答，按 rubric 评分，不产补丁 | [ScaleAI/SWE-Atlas-QnA](https://huggingface.co/datasets/ScaleAI/SWE-Atlas-QnA) | `docker_image` | `/app` |
+
+判定方式并非只有一种，接入前先确认：SWE-rebench V2 / Scale-SWE / SWE-Gym / SWE-bench Pro 用 `FAIL_TO_PASS` + `PASS_TO_PASS`；SEC-bench 用 sanitizer 报告与退出码；Terminal-Bench 跑任务自带的 `tests/test.sh`；SWE-Atlas QnA 需按 rubric 打分。Scale-SWE 的用例引入方式也与 SWE-bench 不同，详见「换题库要改什么」。
+
+### 二、仅提供镜像：元数据需自行匹配
+
+下表的镜像同样可用（构建模板、创建沙箱、进容器操作都正常），但**平台不提供题目与判定用例的关联关系**，原因见「说明」列。使用前需要自己找到元数据来源并建立与镜像的对应关系，否则只能把它们当作「预置好依赖的真实仓库环境」使用，无法做自动判分。
+
+| 题库 | 镜像数 | 镜像内容 | 说明：为什么需要自行匹配 |
+| --- | --- | --- | --- |
+| TMax | 14,490 | 通用终端任务环境（领域各异，含音视频、数据处理等） | 上游数据集的任务标识与镜像 tag（12 位十六进制）不同源，实测无交集，无法建立对应关系 |
+| TerminalTraj | 5,646 | 终端任务容器，仅预装 `tmux` / `asciinema`，任务描述不在镜像内 | 上游以任务包（tar）形式分发，需自行解包后从每个任务的 Dockerfile 反查镜像标识 |
+| ProgramBench | 200 | 净室实现任务：仓库代码已清空，只保留目标产物与说明 | 未找到公开的元数据数据集。另注意此类任务是「从零实现」而非「修复缺陷」，Agent 提示词需相应调整 |
+| SEC-bench Pro | 183 | 安全类任务环境 | 镜像 tag 是纯数字标识，在已知的公开数据集中无对应记录 |
+| DeepSWE | 114 | SWE-bench 形态仓库环境 | 镜像 tag 是不可逆的随机串，无法反查上游实例 |
+| NL2RepoBench | 104 | 按自然语言描述实现仓库功能 | 未找到公开的元数据数据集 |
+| Frontier | 17 | 性能优化任务：镜像内是训练脚本与计时脚本，无 git 仓库 | 未找到公开的元数据数据集。判定方式是跑分而非跑测试 |
+| Toolathlon | 1 | 工具调用任务环境 | 上游仅公开轨迹数据，未公开题目集 |
+
+### 镜像清单获取
+
+无论哪一类，都需要一份 `instance_id`（或镜像 tag）到镜像地址的映射表：**镜像 tag 带构建批次信息，无法由 `instance_id` 推导**。映射表按题库拆分成制表符分隔的文本文件提供（每行 `instance_id<TAB>镜像地址`），便于直接检索与脚本消费：
 
 | 题库 | 映射表下载 |
 | --- | --- |
+| SWE-rebench V2 | <!-- TODO: 补充下载地址 --> |
 | Scale-SWE | <!-- TODO: 补充下载地址 --> |
 | SWE-Gym | <!-- TODO: 补充下载地址 --> |
 | SWE-bench Pro | <!-- TODO: 补充下载地址 --> |
 | SWE-smith | <!-- TODO: 补充下载地址 --> |
+| SEC-bench | <!-- TODO: 补充下载地址 --> |
 | Terminal-Bench 2.x | <!-- TODO: 补充下载地址 --> |
-
+| 其余题库 | <!-- TODO: 补充下载地址 --> |
 
 ```bash
 # 查某一道题的镜像地址
@@ -533,11 +561,20 @@ grep '^pandas-dev__' scaleswe-images.tsv | cut -f1 > my-instances.txt
 
 不同来源的评测镜像**不是同构的**，工作目录就不一样：
 
-| 镜像来源形态 | 工作目录 |
-| --- | --- |
-| SWE-bench 标准形态 | `/testbed`，且 python 环境常在 conda 的 `testbed` 里 |
-| 按仓库名分目录 | `/workspace/<repo>`，每实例不同，需从数据集字段取 |
-| 单一应用目录 | `/app` |
+| 镜像来源形态 | 工作目录 | 怎么拿到 |
+| --- | --- | --- |
+| SWE-bench 标准形态 | `/testbed` | 固定值；python 环境常在 conda 的 `testbed` 里，需 `BASH_ENV` 激活 |
+| 按仓库名分目录 | `/workspace/<repo>` | 取数据集的 `workdir` 字段，每实例不同 |
+| 单一应用目录 | `/app` | 固定值 |
+| 根目录下以仓库原名命名 | 如 `/OpenTripPlanner`、`/ApplicationInsights-node.js` | **无法从镜像 tag 推导**（tag 是小写、目录保留原始大小写），需运行时探测 |
+
+最后一种要在容器里探测，例如：
+
+```bash
+for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
+```
+
+把它做成解析层的一个 `auto` 选项，比在配置里逐条枚举更可靠。
 
 镜像地址与工作目录必须**成对**更换。只改一个会报 `fork/exec /bin/bash: no such file or directory` —— 那是工作目录不存在，与 bash 无关。
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
@@ -1,0 +1,602 @@
+# 构建 SWE Agent
+
+SWE Agent（软件工程 Agent）自动完成 Issue 修复、PR 生成这类开发任务：把一个真实仓库的缺陷描述交给它，它在沙箱里读代码、改文件、跑测试，最后产出一个补丁。评估它做得好不好，业界标准做法是跑 SWE-bench 这类基准 —— 每道题给定一个包含仓库现场的镜像，用测试用例判定补丁是否真的修好了问题。
+
+本文以一道真实的 SWE-bench 形态题目为例，说明如何在云沙箱上跑通「Agent 修复 → 产出补丁 → 判定是否修好」的完整闭环，再扩展到批量评测，并说明如何接入自有仓库的镜像。文中代码可直接复制运行。
+
+## 业务场景
+
+- 团队需要一个可复现的评测底座，用统一口径比较不同模型、不同提示词在真实仓库缺陷上的修复能力。
+- Agent 会执行仓库里的代码和测试，需要强隔离环境，避免影响本地或 CI 机器。
+- 批量评测要同时跑几十上百个实例，需要按实例隔离、跑完即回收，成本可控。
+- 自研仓库需要构造私有评测集，希望复用同一套 Agent 与判分链路。
+
+## 前置条件
+
+- 已开通云沙箱，并获取目标地域的 `E2B_API_KEY`。本文以华东1（上海）地域为例，对应接入点：
+  - `api_url`：`https://api.cn-shanghai.e2b.fc.aliyuncs.com`
+  - `domain`：`cn-shanghai.e2b.fc.aliyuncs.com`
+- 一个可用的模型 API Key（本文用兼容 OpenAI 协议的端点）。
+- Python 3.10 及以上。
+
+> API Key 与地域绑定，跨地域使用会返回 401。
+
+## 整体架构
+
+```mermaid
+flowchart TB
+    subgraph ORCH["编排层：沙箱外 · 持凭据 · 无状态"]
+        direction LR
+        META["① 取题<br/>数据集元数据<br/>问题描述 / 判定用例"]
+        RESOLVE["② 解析<br/>id → 镜像地址<br/>id → 工作目录 / 判分口径"]
+        TPL["③ 注册模板<br/>Template.build（幂等，缓存 1~2s）"]
+        AGENT["④ Agent 循环<br/>agent 框架 + 模型<br/>（凭据只存在于这一层）"]
+        SUM["⑦ 收补丁　⑩ 判分　⑪ 汇总<br/>preds / grade / 轨迹"]
+        META --> RESOLVE --> TPL --> AGENT --> SUM
+    end
+
+    subgraph SBX["沙箱层：无任何凭据"]
+        direction LR
+        WORKER["Worker Sandbox<br/>只有 bash<br/>仓库在工作目录（随题库而变）<br/>⑧ 跑完即杀"]
+        GRADER["Grader Sandbox（全新，不复用）<br/>复位 → 打补丁 → 跑用例<br/>跑完即杀"]
+    end
+
+    IMG["镜像层<br/>现成评测镜像（题库）　／　自有镜像（从镜像仓库构建模板）"]
+
+    AGENT -->|"⑤ 起 Worker 沙箱<br/>下发 bash / 收 output"| WORKER
+    WORKER -->|"⑥ 补丁回传<br/>（沙箱唯一出口）"| SUM
+    SUM -->|"⑨ 起 Grader 沙箱"| GRADER
+    WORKER -.->|拉取镜像| IMG
+    GRADER -.->|拉取镜像| IMG
+
+    style ORCH stroke-width:3px
+    style SBX stroke-width:3px
+```
+
+**模型跑在编排层，沙箱只执行 bash。** 这样模型 Key 与代码仓库凭据都不进沙箱：Agent 读到的仓库内容即使包含恶意指令，最坏也只能提交一个无效补丁，拿不到任何凭据。
+
+## 一道题由三部分组成
+
+本文例题 `getmoto__moto-7365`：moto 的 DynamoDB `update_item` 用 `ADD` 表达式做加法时走了浮点运算，金额算出 `Decimal('11.700000000000003')`，应当用 `Decimal` 精确运算。
+
+| 组成 | 内容 | 来源 |
+| --- | --- | --- |
+| 环境 | 镜像 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510`，仓库已停在缺陷提交上、依赖已装好 | 现成评测镜像 |
+| 任务 | 问题描述 `problem_statement` | 上游数据集 |
+| 判定 | `FAIL_TO_PASS`（修好后应通过）、`PASS_TO_PASS`（不能回归）、`test_patch` | 上游数据集 |
+
+**镜像只是环境，题目与判定在元数据里。** 只有镜像、没有元数据，题是跑不了的。
+
+## 装依赖与配置凭据
+
+```bash
+mkdir swe-demo && cd swe-demo
+python -m venv .venv
+.venv/bin/pip install e2b "mini-swe-agent>=2.4" pyyaml
+
+export E2B_API_KEY="<your-e2b-api-key>"
+export E2B_REGION="cn-shanghai"
+export MODEL_API_KEY="<your-model-api-key>"
+export MSWEA_CONFIGURED=true MSWEA_SILENT_STARTUP=1
+```
+
+Agent 循环直接用社区标准实现 [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent)，提示词与提交协议全部沿用官方，只把执行底座替换成云沙箱。它的执行环境协议只有三个方法，实现即可，不需要修改上游代码。
+
+## 实现执行环境：`fc_env.py`
+
+以下是完整实现。注释标出的四处，是与本地 docker 执行环境不同、必须特殊处理的地方。
+
+```python
+# fc_env.py
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import shlex
+from dataclasses import dataclass, field
+from typing import Any
+
+from e2b import CommandExitException, Sandbox, Template
+from minisweagent.exceptions import Submitted
+
+SUBMIT_SENTINEL = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"
+
+REGIONS = {
+    "cn-shanghai": "https://api.cn-shanghai.e2b.fc.aliyuncs.com",
+    "cn-hangzhou": "https://api.cn-hangzhou.e2b.fc.aliyuncs.com",
+    "cn-beijing": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
+    "cn-hongkong": "https://api.cn-hongkong.e2b.fc.aliyuncs.com",
+    "us-west-1": "https://api.us-west-1.e2b.fc.aliyuncs.com",
+}
+
+
+@dataclass
+class FCSandboxEnvironmentConfig:
+    image: str = ""
+    template: str = ""
+    cwd: str = "/testbed"
+    env: dict[str, str] = field(default_factory=dict)
+    forward_env: list[str] = field(default_factory=list)  # 保持为空：宿主变量不进沙箱
+    timeout: int = 60
+    interpreter: list[str] = field(default_factory=lambda: ["bash", "-c"])
+    sandbox_timeout: int = 1800
+    region: str = field(default_factory=lambda: os.environ.get("E2B_REGION", "cn-shanghai"))
+    run_as_user: str = "root"  # 评测镜像的仓库属主通常是 root，且镜像里往往没有 sudo
+
+
+class FCSandboxEnvironment:
+    def __init__(self, *, config_class=FCSandboxEnvironmentConfig, **kwargs):
+        self.config = config_class(**kwargs)
+        self._conn = {
+            "api_key": os.environ["E2B_API_KEY"],
+            "api_url": REGIONS[self.config.region],
+            "domain": f"{self.config.region}.e2b.fc.aliyuncs.com",
+        }
+        template = self.config.template or self._ensure_template()
+        self.sbx = Sandbox.create(template, timeout=self.config.sandbox_timeout, **self._conn)
+        self.template = template
+
+        # 差异 1：docker 的 -w 会自动创建目录，沙箱不会。目录不存在时报的是
+        # `fork/exec /bin/bash: no such file or directory`，容易误判成 bash 有问题。
+        self._run_raw(f"mkdir -p {shlex.quote(self.config.cwd)}")
+        # 差异 2：跨用户的 git 操作会被拒绝（dubious ownership）
+        self._run_raw(f"git config --global --add safe.directory {shlex.quote(self.config.cwd)}")
+
+    def _ensure_template(self) -> str:
+        """镜像 → 模板，幂等：先用模板名探活，失败才构建。
+
+        模板名用镜像内容哈希、不要带版本号：同名模板只允许构建一次，
+        构建失败后该名字会停留在 CREATE_FAILED，再次构建直接返回 409。
+        """
+        name = "swe-" + hashlib.sha1(self.config.image.encode()).hexdigest()[:16]
+        try:
+            probe = Sandbox.create(name, timeout=60, **self._conn)
+            probe.kill()
+            return name
+        except Exception:
+            pass
+        Template.build(Template().from_image(self.config.image), name=name,
+                       cpu_count=2, memory_mb=8192, **self._conn)
+        return name
+
+    def _run_raw(self, command: str) -> None:
+        try:
+            self.sbx.commands.run(command, user=self.config.run_as_user or None, timeout=30)
+        except Exception:
+            pass  # 探路性质的命令，失败不影响主流程
+
+    def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
+        command = action.get("command", "")
+        limit = timeout or self.config.timeout
+        envs = {k: os.environ[k] for k in self.config.forward_env if k in os.environ}
+        envs.update(self.config.env)
+        cmd = shlex.join([*self.config.interpreter, command])
+        try:
+            r = self.sbx.commands.run(
+                cmd, cwd=cwd or self.config.cwd, envs=envs or None,
+                user=self.config.run_as_user or None,
+                timeout=limit, request_timeout=limit + 60,
+            )
+            out = {"output": (r.stdout or "") + (r.stderr or ""), "returncode": 0,
+                   "exception_info": ""}
+        except CommandExitException as e:
+            # 差异 3：命令非零退出是正常信号（测试失败等），必须转成 returncode，不能外抛
+            out = {"output": (e.stdout or "") + (e.stderr or ""), "returncode": e.exit_code,
+                   "exception_info": ""}
+        except Exception as e:
+            out = {"output": "", "returncode": -1,
+                   "exception_info": f"命令执行异常: {e}",
+                   "extra": {"exception_type": type(e).__name__}}
+        self._check_finished(out)
+        return out
+
+    def _check_finished(self, output: dict) -> None:
+        """差异 4：提交协议必须原样复刻 —— 首行是哨兵且退出码为 0，其余行即补丁。"""
+        lines = output.get("output", "").lstrip().splitlines(keepends=True)
+        if lines and lines[0].strip() == SUBMIT_SENTINEL and output["returncode"] == 0:
+            submission = "".join(lines[1:])
+            raise Submitted({"role": "exit", "content": submission,
+                             "extra": {"exit_status": "Submitted", "submission": submission}})
+
+    def get_template_vars(self, **kwargs) -> dict[str, Any]:
+        return {**self.config.__dict__, **platform.uname()._asdict(), **kwargs}
+
+    def serialize(self) -> dict:
+        # 每条轨迹都要能回溯到具体沙箱与源镜像
+        return {"environment_class": "fc_env.FCSandboxEnvironment",
+                "sandbox_id": self.sbx.sandbox_id, "template": self.template,
+                "image": self.config.image, "cwd": self.config.cwd}
+
+    def cleanup(self) -> None:
+        try:
+            self.sbx.kill()
+        except Exception:
+            pass
+```
+
+## 配置：镜像与工作目录成对指定
+
+```yaml
+# demo.yaml —— 与 mini-SWE-agent 官方 swebench.yaml 叠加，提示词与提交协议沿用官方
+environment:
+  environment_class: fc_env.FCSandboxEnvironment
+  image: fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510
+  cwd: /testbed          # 换题库必须同时更换，见「换题库要改什么」
+  run_as_user: root
+  timeout: 120
+model:
+  model_name: openai/<your-model>
+  model_kwargs:
+    api_base: <兼容 OpenAI 协议的端点>
+    temperature: 0.0
+  cost_tracking: ignore_errors   # 自建端点的模型不在价格表里，否则成本计算会抛错
+agent:
+  step_limit: 40
+  cost_limit: 0
+```
+
+## 驱动 Agent：`run.py`
+
+```python
+# run.py
+import argparse, json, os
+from pathlib import Path
+
+import yaml
+from minisweagent.agents.default import DefaultAgent
+from minisweagent.config import builtin_config_dir
+from minisweagent.models.litellm_model import LitellmModel
+from minisweagent.utils.serialize import recursive_merge
+
+from fc_env import FCSandboxEnvironment
+
+p = argparse.ArgumentParser()
+p.add_argument("-c", "--config", type=Path, default=Path("demo.yaml"))
+p.add_argument("-t", "--task", type=Path, default=Path("task.md"))
+p.add_argument("-o", "--output", type=Path, default=Path("out.patch"))
+p.add_argument("--traj", type=Path, default=Path("traj.json"))
+a = p.parse_args()
+
+# 官方 swebench.yaml 提供提示词与提交协议；本地 yaml 只覆盖镜像、模型与上限
+official = yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text())
+cfg = recursive_merge(official, yaml.safe_load(a.config.read_text()))
+
+env_cfg = dict(cfg["environment"])
+env_cfg.pop("environment_class", None)          # 直接实例化，不走注册表
+env = FCSandboxEnvironment(**env_cfg)
+
+model_cfg = dict(cfg["model"])
+model_cfg.setdefault("model_kwargs", {})
+model_cfg["model_kwargs"]["api_key"] = os.environ["MODEL_API_KEY"]   # 只在编排层
+
+agent = DefaultAgent(LitellmModel(**model_cfg), env,
+                     **recursive_merge(cfg.get("agent", {}), {"output_path": a.traj}))
+try:
+    result = agent.run(a.task.read_text())
+finally:
+    env.cleanup()
+
+patch = result.get("submission") or ""
+a.output.write_text(patch)
+print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(patch),
+                  "model_calls": agent.n_calls, "sandbox_id": env.sbx.sandbox_id},
+                 ensure_ascii=False))
+```
+
+> **批量评测不要用交互式命令行驱动。** mini-SWE-agent 的 `mini` 命令在 Agent 收尾时有一次交互确认，`-y` 不跳过它；非交互环境下会以 `EOFError` 结束，补丁全部丢失（而 Agent 其实已经解出来了）。脚本化请像上面一样直接驱动 `DefaultAgent`。
+
+## 判分：`grade.py`
+
+判定口径与 SWE-bench 官方一致：`FAIL_TO_PASS` 全部通过，且 `PASS_TO_PASS` 没有回归。
+
+**判分在全新沙箱里做，不复用 Agent 的工作沙箱。** Agent 跑完后那个沙箱已经不是原始现场了 —— 它可能装过额外的包（测试可能因此意外通过）、改过测试文件或 `conftest.py`、留下临时文件。云沙箱的镜像是不可变的，所以只要用同一镜像新建一个沙箱，仓库就自动回到原始状态，不需要清理 Agent 的痕迹。模板已缓存，第二个沙箱起来只要几秒。
+
+```python
+# grade.py
+import argparse, json, re, shlex
+from pathlib import Path
+
+import yaml
+from fc_env import FCSandboxEnvironment
+
+# 评测镜像的 python/pytest 常装在 conda 环境里，靠 BASH_ENV 激活。
+# 不带这套环境变量，`python -m pytest` 会用到 conda base，报 No module named pytest。
+GRADE_ENV = {"PAGER": "cat", "MANPAGER": "cat", "PIP_PROGRESS_BAR": "off",
+             "TQDM_DISABLE": "1", "BASH_ENV": "/root/.bashrc"}
+
+def as_list(v):
+    if isinstance(v, str):
+        try:
+            return json.loads(v)
+        except json.JSONDecodeError:
+            return [v] if v else []
+    return list(v or [])
+
+def files_of(names):        # 用例名 → 文件名
+    return {n.strip().strip("'\"").split("::")[0] for n in names}
+
+def patched_files(diff):    # 补丁触及的文件
+    return sorted(set(re.findall(r"^\+\+\+ b/(\S+)", diff, flags=re.M)))
+
+p = argparse.ArgumentParser()
+p.add_argument("--instance", type=Path, default=Path("instance.json"))
+p.add_argument("--patch", type=Path)
+p.add_argument("--gold", action="store_true", help="用数据集自带补丁自检")
+p.add_argument("--cwd", default="/testbed")
+a = p.parse_args()
+
+inst = json.loads(a.instance.read_text())[0]
+patch = inst["patch"] if a.gold else a.patch.read_text()
+if not patch.strip():
+    raise SystemExit(json.dumps({"resolved": False, "reason": "补丁为空"}))
+
+image = yaml.safe_load(Path("demo.yaml").read_text())["environment"]["image"]
+f2p, p2p = as_list(inst["FAIL_TO_PASS"]), as_list(inst["PASS_TO_PASS"])
+
+env = FCSandboxEnvironment(image=image, cwd=a.cwd, run_as_user="root",
+                           timeout=900, env=GRADE_ENV)
+try:
+    # 1) 打被判定的补丁；打不上也是一种结果
+    env.sbx.files.write("/tmp/model.patch", patch)
+    out = env.execute({"command": "git apply -v /tmp/model.patch"}, timeout=300)
+    if out["returncode"] != 0:
+        out = env.execute({"command": "patch -p1 -i /tmp/model.patch"}, timeout=300)
+        assert out["returncode"] == 0, f"补丁打不上: {out['output'][-200:]}"
+
+    # 2) 先把测试文件恢复到基线，再打 test_patch —— 测试内容不可被 Agent 篡改
+    tf = patched_files(inst["test_patch"])
+    if tf:
+        env.execute({"command": f"git checkout -- {' '.join(map(shlex.quote, tf))} || true"})
+    env.sbx.files.write("/tmp/test.patch", inst["test_patch"])
+    out = env.execute({"command": "git apply -v /tmp/test.patch"}, timeout=300)
+    assert out["returncode"] == 0, f"test_patch 打不上: {out['output'][-200:]}"
+
+    # 3) 跑整个测试文件，再从 -rA 报告里按名字匹配。
+    # 不要把用例名当命令行参数传给 pytest：参数化用例名里可能有空格和括号，会 not found。
+    # 也不要对报告做 tail 截断：大仓库有几千行，截断会漏判已通过的用例。
+    files = sorted(set(tf) | files_of(f2p + p2p))
+    cmd = ("python -m pytest -rA --no-header -q " + " ".join(map(shlex.quote, files))
+           + " > /tmp/res.log 2>&1; grep -E '^(PASSED|FAILED|ERROR) ' /tmp/res.log;"
+             " echo '===TAIL==='; tail -3 /tmp/res.log")
+    report = env.execute({"command": cmd}, timeout=1800)["output"]
+    passed = set(re.findall(r"^PASSED (\S+)", report, flags=re.M))
+
+    def ok(name):
+        n = name.strip().strip("'\"")
+        head = n.split()[0] if n.split() else n
+        return n in passed or any(x.startswith(head) for x in passed)
+
+    f2p_ok, p2p_ok = [t for t in f2p if ok(t)], [t for t in p2p if ok(t)]
+    print(json.dumps({
+        "resolved": len(f2p_ok) == len(f2p) and len(p2p_ok) == len(p2p) and bool(f2p),
+        "FAIL_TO_PASS": f"{len(f2p_ok)}/{len(f2p)}",
+        "PASS_TO_PASS": f"{len(p2p_ok)}/{len(p2p)}",
+        "summary": report.strip().splitlines()[-1][:120],
+    }, ensure_ascii=False))
+finally:
+    env.cleanup()
+```
+
+## 运行
+
+`task.md` 是问题描述正文；`instance.json` 是单元素数组，字段取自上游数据集：
+
+```json
+[{"instance_id": "getmoto__moto-7365",
+  "problem_statement": "DynamoDB's `update_item` performs floating-point arithmetic …",
+  "FAIL_TO_PASS": ["tests/test_dynamodb/test_dynamodb_update_expressions.py::test_update_item_add_float"],
+  "PASS_TO_PASS": ["tests/test_dynamodb/test_dynamodb_update_expressions.py::test_update_different_map_elements_in_single_request"],
+  "test_patch": "diff --git a/tests/... （上游数据集原文）",
+  "patch": "diff --git a/moto/... （数据集自带的正确补丁，仅用于判分器自检）"}]
+```
+
+**先让判分器自检，再跑 Agent。** 用数据集自带的正确补丁走一遍判分，必须 `resolved: true`：
+
+```bash
+PYTHONPATH=. .venv/bin/python grade.py --gold
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.58s"}
+```
+
+自检不通过，说明判分链路本身有问题（镜像、测试引入方式、用例名匹配），此时 Agent 的得分没有意义。自检通过后跑 Agent 并判分：
+
+```bash
+PYTHONPATH=. .venv/bin/python run.py
+# {"exit_status": "Submitted", "patch_bytes": 1839, "model_calls": 31, "sandbox_id": "sbx-…"}
+
+PYTHONPATH=. .venv/bin/python grade.py --patch out.patch
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.76s"}
+```
+
+首次运行会把镜像注册成模板（幂等，之后命中缓存 1~2 秒）。模型有随机性，`model_calls` 与 `patch_bytes` 会浮动。
+
+## 扩展到批量评测
+
+从一道题到 N 道题，`fc_env.py` 不用改，增加的是解析层与并发编排。
+
+### 解析层：把写死的两行变成查表
+
+单题时镜像地址与工作目录写在配置里；批量时每道题都不同，必须查表。三件事需要按实例解析：镜像地址（评测镜像的 tag 通常带构建批次信息，**不能由 instance_id 推导**）、工作目录、判分口径。
+
+```python
+# resolve.py
+import json
+
+IMAGES = dict(l.split("\t") for l in open("images.tsv").read().splitlines())
+REGISTRY = json.load(open("registry.json"))     # family → cwd / run_as_user / grading
+FAMILY = json.load(open("family-index.json"))   # instance_id → family
+
+def resolve(instance: dict) -> dict:
+    spec = REGISTRY[FAMILY[instance["instance_id"]]]
+    cwd = spec["cwd"]
+    if cwd.startswith("$dataset."):             # 某些题库的工作目录每实例不同
+        cwd = instance[cwd.split(".", 1)[1]]    # 取数据集里对应字段
+    return {"image": IMAGES[instance["instance_id"]], "cwd": cwd,
+            "run_as_user": spec["run_as_user"], "grading": spec["grading"]}
+```
+
+解析是纯查表，没有网络与沙箱开销，可以在开跑前一次性完成。解析失败的实例（缺镜像映射、缺元数据）应当在开跑前剔除，而不是跑到一半才失败。
+
+### 并发编排
+
+```python
+# batch.py（骨架）
+import concurrent.futures as cf, json
+from pathlib import Path
+
+from fc_env import FCSandboxEnvironment
+from resolve import resolve
+
+def run_one(inst: dict) -> tuple[str, dict]:
+    spec = resolve(inst)
+    env = FCSandboxEnvironment(image=spec["image"], cwd=spec["cwd"],
+                               run_as_user=spec["run_as_user"], timeout=120)
+    try:
+        agent = build_agent(env)                       # 同前文 run.py
+        result = agent.run(inst["problem_statement"])
+        return inst["instance_id"], {
+            "model_patch": result.get("submission") or "",
+            "exit_status": result.get("exit_status"),
+            "sandbox_id": env.sbx.sandbox_id,          # 保证可回溯
+        }
+    except Exception as e:                             # 单实例失败不拖垮整批
+        return inst["instance_id"], {"model_patch": "", "error": f"{type(e).__name__}: {e}"}
+    finally:
+        env.cleanup()                                  # 跑完即杀，不要等 TTL
+
+instances = json.loads(Path("instances.json").read_text())
+preds = {}
+with cf.ThreadPoolExecutor(max_workers=6) as ex:
+    for iid, pred in ex.map(run_one, instances):
+        preds[iid] = pred
+Path("preds.json").write_text(json.dumps(preds, ensure_ascii=False, indent=1))
+```
+
+四个必须做到的编排约束：
+
+| 约束 | 做法 |
+| --- | --- |
+| 单实例失败不拖垮整批 | 每个实例独立捕获异常，记录错误后继续 |
+| 沙箱一定要回收 | `finally` 里调用 `kill()`。靠 TTL 兜底会额外计费并占用并发 |
+| Agent 侧设上限 | `step_limit`、`cost_limit`、`wall_time_limit`，超限即停，否则一道难题可能耗掉整批预算 |
+| 输出截断分档 | 终端 15k、单文件 20k、批量 50k 字符，防止上下文被占满 |
+
+**并发建议压在 6 左右。** 大镜像在 10 并发下创建沙箱可能超时，串行重试即可成功；因此创建沙箱失败时应先串行重试一次，再判定实例不可用，否则会把并发压力误记成镜像问题。
+
+### 判分与 Agent 解耦
+
+Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙箱并发判定。这样调整判分逻辑后重判不需要重跑 Agent，省掉整轮模型开销。
+
+**接入任何新题库的第一件事，是把数据集自带的正确补丁全部判一遍，通过率必须接近 100%。** 以下四类问题都会静默压低分数且不报错，只有这一步能暴露：
+
+| 问题 | 现象 | 处置 |
+| --- | --- | --- |
+| 数据集字段里是字面量 `\n`（反斜杠加 n，不是换行） | bash 视为转义符，命令被拼坏，整条复位失败 | 仅对该字段还原换行，不要全局处理 |
+| 判定依据被 `tail -N` 截断 | 大仓库测试报告数千行，通过的用例被漏判，分数偏低 | 先过滤出判定行，再单独取统计尾部 |
+| 参数化用例名含空格或换行 | pytest 报告在第一个空白处截断用例名，精确匹配全部落空 | 按截断后的前缀匹配，并按数量满足判定 |
+| 用例名当命令行参数传给 pytest | 名字含空格括号，报 not found，最终 no tests ran | 跑整个测试文件，再从报告按名字匹配 |
+
+## 上海地域现成的评测镜像
+
+华东1（上海）地域已预置一批开源评测集的镜像，仓库现场与依赖都已就绪，拿到镜像地址构建模板即可使用，无需自行搬运。镜像前缀统一为 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`。
+
+| 题库 | 镜像数 | 题目类型 | 元数据来源 | 工作目录 |
+| --- | --- | --- | --- | --- |
+| Scale-SWE | 19,473（1,180 个仓库） | 真实 PR 修复：仓库复位到 PR 的父提交，要求实现该 PR | `AweAI-Team/Scale-SWE` | `/workspace/<repo>`，每实例不同 |
+| SWE-Gym | 2,401（11 个仓库） | 真实 issue 修复，SWE-bench 标准形态 | `SWE-Gym/SWE-Gym` | `/testbed` |
+| SWE-bench Pro | 731 | 企业级仓库 issue 修复，上下文更长，含 Go/Node 等多语言仓库 | `ScaleAI/SWE-bench_Pro` | `/app` |
+| SWE-smith | 363（环境级镜像） | 合成缺陷修复，一个镜像承载同一仓库的多道题，通过 `git checkout <instance_id>` 选题 | `SWE-bench/SWE-smith-*` | `/testbed` |
+| Terminal-Bench 2.x | 89 | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | `harborframework/terminal-bench-2.0` | `/app` |
+
+选型上，需要跨仓库泛化能力优先用 Scale-SWE（覆盖 1,180 个仓库）；SWE-Gym 只覆盖 11 个仓库，更适合做快速回归。前两个题库的判分口径与本文一致，可直接复用前文代码；后三个需要按其形态调整判分（多语言测试执行器、选题方式、跑任务自带的 `tests/test.sh`）。
+
+**题目元数据需要单独获取。** 上表的元数据来源是公开数据集，其中的问题描述与判定用例不随镜像分发；镜像与元数据靠 `instance_id` 关联。评测镜像的 tag 带构建批次信息，**无法由 `instance_id` 推导**，因此需要一份 `instance_id` 到镜像地址的映射表。该映射按题库拆分成制表符分隔的文本文件提供（每行 `instance_id<TAB>镜像地址`），便于直接检索与脚本消费：
+
+| 题库 | 映射表下载 |
+| --- | --- |
+| Scale-SWE | <!-- TODO: 补充下载地址 --> |
+| SWE-Gym | <!-- TODO: 补充下载地址 --> |
+| SWE-bench Pro | <!-- TODO: 补充下载地址 --> |
+| SWE-smith | <!-- TODO: 补充下载地址 --> |
+| Terminal-Bench 2.x | <!-- TODO: 补充下载地址 --> |
+
+
+```bash
+# 查某一道题的镜像地址
+grep '^getmoto__moto-7365' swegym-images.tsv | cut -f2
+
+# 挑出某个仓库的全部题目
+grep '^pandas-dev__' scaleswe-images.tsv | cut -f1 > my-instances.txt
+```
+
+## 换题库要改什么
+
+不同来源的评测镜像**不是同构的**，工作目录就不一样：
+
+| 镜像来源形态 | 工作目录 |
+| --- | --- |
+| SWE-bench 标准形态 | `/testbed`，且 python 环境常在 conda 的 `testbed` 里 |
+| 按仓库名分目录 | `/workspace/<repo>`，每实例不同，需从数据集字段取 |
+| 单一应用目录 | `/app` |
+
+镜像地址与工作目录必须**成对**更换。只改一个会报 `fork/exec /bin/bash: no such file or directory` —— 那是工作目录不存在，与 bash 无关。
+
+两个要避免的做法：
+
+- **把工作目录写死在评测配置里**。它只对部分题库成立，换库必挂，应当按前文查表。
+- **依据镜像元数据里的语言标记选判分执行器**。同一批镜像里常混有 Go、Node、Java、Python 多种仓库，应按数据集的 `repo_language` 字段分流。
+
+## 接入自有镜像
+
+自研仓库、内部框架、私有评测集走这条路，接入后前文的 Agent 与判分链路可直接复用，只替换镜像层。
+
+把自有镜像变成可用模板的完整流程见[构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)，
+其中包含镜像的平台硬性要求（`linux/amd64` 架构、`/etc/passwd` 与 `/etc/group` 可写、
+`commands.run` 与 PTY 依赖固定路径的 `/bin/bash` 等）。两种常见场景另有专文：
+
+- 镜像在需要鉴权的仓库里：[使用 GHCR 自定义镜像构建 Sandbox 模板](./07.使用%20GHCR%20自定义镜像构建%20Sandbox%20模板.md)，
+  通过 `X-E2B-Template-Source-Username` / `X-E2B-Template-Source-Password` 两个 header 传入仓库凭据
+- 把模板构建接入流水线：[使用 GitHub Actions 发布 Sandbox 模板](./09.使用%20GitHub%20Actions%20发布%20Sandbox%20模板.md)
+
+在此基础上，评测场景还有四点需要注意：
+
+| 约束 | 现象 | 应对 |
+| --- | --- | --- |
+| 一个模板名只允许构建一次 | 构建失败后重试返回 `409: template build is not allowed in current status CREATE_FAILED`，该名字永久失效 | 重试必须换名。模板名用镜像内容哈希，不要带版本号 |
+| 构建阶段不支持执行步骤 | 声明 `run_cmd` / `set_user` / `set_workdir` 会返回 `400: steps are not supported` | 依赖与环境必须在源镜像里就绪；权限与工作目录只能在运行时用 `user="root"` 解决 |
+| 匿名拉取公共镜像可能失败 | 未传凭据 header 时，构建流程会走完并打出 `Build finished`，但模板最终状态为 `CREATE_FAILED`，SDK 不报错而是一直等待就绪 | 按上文引用的文档传入仓库凭据；并在 `Template.build` 外层自行加超时 |
+| 大镜像创建沙箱会超时 | 高并发下报 `TimeoutException` | 并发压到 6 左右，失败先串行重试一次 |
+
+镜像接入后，验收不要停在「沙箱起来了」。抽样跑完以下四步，任何一步不过都不算可用：
+
+1. 构建模板、创建沙箱成功。
+2. 仓库目录存在、是 git 仓库、`HEAD` 能解析。
+3. 该语言的测试执行器可用。
+4. 能真正收集到用例（如 `pytest --collect-only -q`）。
+
+**验收必须在与判分器完全相同的环境变量下进行。** 三类常见误判会让正常镜像被判为不可用：
+
+| 误判原因 | 后果 |
+| --- | --- |
+| 验收时漏掉 `BASH_ENV` | conda 环境未激活，`python -m pytest` 报 No module named pytest |
+| Go 装在 `/usr/local/go/bin`，不在默认 PATH | 正常的 Go 仓库镜像被判「没有测试执行器」 |
+| Java 项目不装全局 mvn/gradle，而是带 `./gradlew` | 正常镜像被误判 |
+
+## 上线建议
+
+- **凭据管理**：`E2B_API_KEY` 与模型 API Key 通过环境变量或密钥管理服务注入，不要硬编码或提交进代码仓库。模型调用放在编排层，沙箱内不放任何凭据。
+- **出网收敛**：沙箱按 `deny_out: ["0.0.0.0/0"]` 加白名单，只放代码托管、镜像源与模型端点。注意域名过滤只对 80 端口的 Host 头与 443 的 SNI 生效，其他端口只能用 CIDR；`allow` 优先于 `deny`；被拒绝的 TCP 从沙箱内部看像是连接成功，需用应用层响应判定。
+- **两层超时**：区分沙箱级 TTL 与命令级超时。不要使用 `timeout=0`，卡住的进程不会自愈；长任务用 `on_timeout="pause"` 配合 `auto_resume`，暂停期间不计费、不占并发。
+- **补丁是唯一出口**：沙箱只需要仓库读权限。编排层拿到补丁后重建干净仓库校验并跑测试，通过再创建 PR。不要在沙箱内 push 或建 PR。
+- **及时销毁**：`finally` 里调用 `sandbox.kill()`，按秒计费仅统计运行中的时间。
+- **可回溯**：每条轨迹记录 `sandbox_id` 与源镜像地址（前文 `serialize()` 已包含），便于复现与排障。
+- **成本核算**：编排层自行记录起止时间，配合 `get_info()` 读取规格自算成本。
+
+## 相关功能
+
+- [构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)
+- [使用 GHCR 自定义镜像构建 Sandbox 模板](./07.使用%20GHCR%20自定义镜像构建%20Sandbox%20模板.md)
+- [使用 GitHub Actions 发布 Sandbox 模板](./09.使用%20GitHub%20Actions%20发布%20Sandbox%20模板.md)
+- [使用 Claude Code Sandbox](./05.使用%20Claude%20Code%20Sandbox.md)
+- [运行命令](../04.功能说明/03.命令/02.运行命令.md)
+- [读写文件](../04.功能说明/04.文件系统/02.读写文件.md)

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md
@@ -595,13 +595,14 @@ for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
   通过 `X-E2B-Template-Source-Username` / `X-E2B-Template-Source-Password` 两个 header 传入仓库凭据
 - 把模板构建接入流水线：[使用 GitHub Actions 发布 Sandbox 模板](./09.使用%20GitHub%20Actions%20发布%20Sandbox%20模板.md)
 
-在此基础上，评测场景还有四点需要注意：
+在此基础上，评测场景还有五点需要注意：
 
 | 约束 | 现象 | 应对 |
 | --- | --- | --- |
 | 一个模板名只允许构建一次 | 构建失败后重试返回 `409: template build is not allowed in current status CREATE_FAILED`，该名字永久失效 | 重试必须换名。模板名用镜像内容哈希，不要带版本号 |
 | 构建阶段不支持执行步骤 | 声明 `run_cmd` / `set_user` / `set_workdir` 会返回 `400: steps are not supported` | 依赖与环境必须在源镜像里就绪；权限与工作目录只能在运行时用 `user="root"` 解决 |
-| 匿名拉取公共镜像可能失败 | 未传凭据 header 时，构建流程会走完并打出 `Build finished`，但模板最终状态为 `CREATE_FAILED`，SDK 不报错而是一直等待就绪 | 按上文引用的文档传入仓库凭据；并在 `Template.build` 外层自行加超时 |
+| 源镜像不满足 envd 注入条件会构建失败 | 构建阶段平台会向镜像注入 envd。若镜像不满足前置条件，日志里会打出 `template build failed: envd inject failed`，且仍会输出 `Build finished`（实测用 `python:3.11-slim` 直接构建即触发） | 按[构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)核对镜像要求（`linux/amd64`、`/etc/passwd` 与 `/etc/group` 可写、固定路径的 `/bin/bash` 等）。**注意 `Build finished` 不代表成功，要看有没有 `envd inject failed`** |
+| 构建失败时 SDK 可能长时间不返回 | 失败后客户端会持续轮询构建状态，日志量大时可能拖很久才抛 `ReadTimeout` | 在 `Template.build` 外层自行加超时，不要依赖它自己返回 |
 | 大镜像创建沙箱会超时 | 高并发下报 `TimeoutException` | 并发压到 6 左右，失败先串行重试一次 |
 
 镜像接入后，验收不要停在「沙箱起来了」。抽样跑完以下四步，任何一步不过都不算可用：


### PR DESCRIPTION
## 做了什么

新增 `docs/zh-CN/01.云沙箱/05.最佳实践/11.构建 SWE Agent.md`，单文件 602 行。

以一道真实 SWE-bench 形态题目（`getmoto__moto-7365`）为主线，走通
「Agent 修复 → 产出补丁 → 判定是否修好」的完整闭环，再扩展到批量评测，
最后说明如何接入自有仓库镜像。

## 特点

- **代码完整内联，照抄可跑**：执行环境（`fc_env.py`）、驱动（`run.py`）、
  判分（`grade.py`）三份代码全在正文里，不依赖外部仓库。已按文档原文重建目录
  并端到端实跑通过：gold 自检 resolved、Agent 产出补丁后判分 resolved。
- **架构用 mermaid** 呈现编排层 / 沙箱层 / 镜像层的分工与十一步流程。
- **明确 Worker / Grader 两个沙箱的分工**：判分在全新沙箱进行，避免 Agent
  装过的包、改过的配置污染判定结果。这与 SWE-bench 官方 harness 结构一致
  （`run_instance` 每实例新建容器、eval 脚本先复位测试文件、支持用 gold 补丁自检）。
- **列出上海地域现成的评测镜像题库**（5 个，含题目类型、元数据来源、工作目录）。
- **自有镜像接入引用既有文档**，不重复：《构建自定义镜像模板》《GHCR 自定义镜像
  构建》《GitHub Actions 发布模板》。

## 合并前待补

- [ ] 映射表下载地址（文中 5 处 `<!-- TODO: 补充下载地址 -->`）
- [ ] 英文版 `docs/en-US/.../11.Build a SWE Agent.md`

## 自检

- 6 个相对链接全部指向 `main` 上真实存在的文件
- mermaid 语法自检通过（subgraph 配对、节点全定义）
- 无内部信息（内部仓库名、开发机、具体模型端点等）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 文档范围

- 涉及产品：阿里云云沙箱。
- 涉及章节：
  - 中文：`文档/云沙箱/最佳实践`
  - 英文：`FC Agent Sandbox/Best Practices`
- 新增页面：
  - 中文《构建 SWE Agent》
  - 英文《Build a SWE Agent》
- 文档内容：介绍 SWE Agent 的运行环境、架构设计、Agent 驱动、补丁生成与独立判分、批量评测、题库与镜像适配、自有镜像接入、安全隔离和资源回收。
- 文档包含 `FCSandboxEnvironment` 等可运行示例代码，并使用 Mermaid 展示架构和流程。

## 页面与图片变更

- 新增 2 个文档页面。
- 未删除页面。
- 未改动图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->