### PR TITLE
docs: clarify injected env vars only apply to commands.run API

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/08.Environment Variables.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/01.Sandbox/08.Environment Variables.md
@@ -37,6 +37,8 @@ result = sandbox.commands.run("echo $TASK_ID")
 print(result.stdout.strip())
 ```
 
+> **Note**: Currently, environment variables injected through this feature only take effect for the E2B `commands.run` API. They are not available as process-level environment variables in the sandbox's main container.
+
 ## Override Environment Variables When Running a Command
 
 ```typescript

--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.沙箱/08.环境变量.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.沙箱/08.环境变量.md
@@ -37,6 +37,8 @@ result = sandbox.commands.run("echo $TASK_ID")
 print(result.stdout.strip())
 ```
 
+> **说明**：目前通过该功能注入的环境变量仅对 E2B 的 `commands.run` API 生效，无法作为进程级环境变量供沙箱主容器使用。
+
 ## 执行命令时覆盖环境变量
 
 ```typescript


### PR DESCRIPTION
## Summary
- Add a note to the FC Agent Sandbox environment variables docs (zh-CN and en-US) clarifying that env vars injected at sandbox creation only take effect for the E2B `commands.run` API
- They are not available as process-level environment variables in the sandbox's main container

## Test plan
- [ ] Review rendered note placement in both language docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 更新阿里云函数计算（FC）Agent Sandbox 文档，涉及以下章节：

- 中文文档：`云沙箱 > 功能说明 > 沙箱 > 环境变量`
- 英文文档：`FC Agent Sandbox > Features > Sandbox > Environment Variables`

文档在创建沙箱的环境变量示例后补充说明：注入的环境变量仅对 E2B `commands.run` API 生效，不会作为沙箱主容器的进程级环境变量提供。

本次未新增或删除页面，也未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->