### PR TITLE
docs(fc-extensions): 新增沙箱存储追加挂载文档

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/01.Overview.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/01.Overview.md
@@ -13,6 +13,7 @@ FC Extensions do not change the basic usage of the E2B SDK or CLI. Applications 
 - [Team Quota Management](06.Quota%20Management.md): Set CPU and memory quotas for a specified Team through the Alibaba Cloud POP SDK. For creating Teams, resource groups, and subscription plans, see [Teams and Subscription Plans](../../01.Getting%20Started/04.Teams%20and%20Subscription%20Plans.md).
 - [Create an OSS Volume](07.Create%20an%20OSS%20Volume.md): Create a reusable Volume mount configuration for an OSS Bucket or bucket sub-directory.
 - [Create an AgenticFS Volume](08.Create%20an%20AgenticFS%20Volume.md): Create a reusable Volume mount configuration for an AgenticFS AgenticSpace Access Point.
+- [Append Sandbox Storage Mounts](09.Append%20Sandbox%20Storage%20Mounts.md): Append inline storage mounts or existing Volumes to a running sandbox.
 
 ## How to Use
 
@@ -38,3 +39,4 @@ For more configuration details, see the official documentation:
 - [Quota Management](./06.Quota%20Management.md)
 - [Create an OSS Volume](./07.Create%20an%20OSS%20Volume.md)
 - [Create an AgenticFS Volume](./08.Create%20an%20AgenticFS%20Volume.md)
+- [Append Sandbox Storage Mounts](./09.Append%20Sandbox%20Storage%20Mounts.md)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/09.Append Sandbox Storage Mounts.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/09.Append Sandbox Storage Mounts.md
@@ -1,0 +1,173 @@
+# Append Sandbox Storage Mounts
+
+Use this API to append storage mounts to a running Sandbox without recreating it.
+
+This API only supports appending mounts. It does not support deleting, replacing, or unmounting existing mounts. Do not treat it as a full-update API: omitting an existing mount from the request does not delete that mount, and submitting the same mount more than once usually results in a conflict error.
+
+The storage types currently available to users are OSS and AgenticFS.
+
+## API Information
+
+```text
+POST /sandboxes/{sandboxID}/fc-volume-mounts
+```
+
+Request headers:
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `X-API-Key` | Yes | Cloud sandbox API Key. |
+| `Content-Type: application/json` | Yes | The request body is in JSON format. |
+
+The API returns `204 No Content` with an empty response body upon success.
+
+## Prerequisites
+
+Before calling the API, make sure that:
+
+- The Sandbox is in the `running` state. Resume a paused Sandbox before calling this API.
+- The API Key and target Sandbox belong to the same Team.
+- When using `namedVolumeMounts`, the referenced Volume has been created in the same Team and is available. You can currently use an [OSS Volume](./07.Create%20an%20OSS%20Volume.md) or [AgenticFS Volume](./08.Create%20an%20AgenticFS%20Volume.md).
+- When creating the Sandbox, you configured the execution Role required by the new storage and the VPC required by AgenticFS through `createSandbox`. `UpdateVolumeMounts` only appends mounts; it does not add or modify these configurations.
+
+The following table lists the configurations required by each storage type when you call `createSandbox`:
+
+| Storage type | Complete VPC configuration | Execution Role |
+| --- | --- | --- |
+| OSS | Not required | Required |
+| AgenticFS | Required | Required |
+
+- If you plan to append an OSS mount, configure the execution Role through `fc.sandbox.auth.role` when calling `createSandbox`.
+- If you plan to append an AgenticFS mount, in addition to the execution Role, configure a complete VPC through `fc.sandbox.network.vpc`. The configuration must include `vpcId`, `securityGroupId`, and `vSwitchIds` with at least one element. For details, see [VPC Network Configuration](./02.VPC%20Network%20Configuration.md).
+
+## Request Parameters
+
+The request body supports inline mounts, existing Volumes, or both:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `inlineVolumeMounts` | object | Conditionally required | Declares the storage mount configuration directly. Currently supports `oss` and `agenticFS`. |
+| `namedVolumeMounts` | array | Conditionally required | References existing Volumes in the current Team. Each item contains the Volume name in `name` and the mount path inside the Sandbox in `path`. |
+
+You must provide at least one valid mount point in `inlineVolumeMounts` or `namedVolumeMounts`. An empty request or empty configuration returns `400`.
+
+The following table describes the inline configuration fields. Field names are case-sensitive. Pay particular attention to `agenticFS` and the AgenticFS fields `userID` and `groupID`:
+
+| Configuration | Field | Required | Constraints |
+| --- | --- | --- | --- |
+| `oss` | `mountPoints` | Yes | Contains 1 to 5 mount points. |
+| `oss` | `mountPoints[].bucketName` | Yes | 3 to 64 characters in length. |
+| `oss` | `mountPoints[].bucketPath` | No | Path within the Bucket, up to 128 characters. Set it to `/` or leave it empty to specify the Bucket root directory. |
+| `oss` | `mountPoints[].endpoint` | Yes | OSS Endpoint, up to 128 characters. It must match the region of the Bucket. |
+| `oss` | `mountPoints[].mountDir` | Yes | Absolute path inside the Sandbox, 2 to 64 characters in length. It cannot be `/`. |
+| `oss` | `mountPoints[].readOnly` | No | Specifies whether the mount is read-only. Boolean value. |
+| `agenticFS` | `userID` | No | Value range: `-1` to `65534`. |
+| `agenticFS` | `groupID` | No | Value range: `-1` to `65534`. |
+| `agenticFS` | `mountPoints` | Yes | Contains 1 to 5 mount points. |
+| `agenticFS` | `mountPoints[].serverAddr` | Yes | AgenticFS Access Point address, up to 128 characters. |
+| `agenticFS` | `mountPoints[].mountDir` | Yes | Normalized absolute path inside the Sandbox, up to 128 characters. It cannot be `/`. |
+
+## Append an Existing Volume
+
+The following example appends an existing Volume to a running Sandbox:
+
+```bash
+export E2B_API_KEY="<your-e2b-api-key>"
+export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
+export SANDBOX_ID="<sandbox-id>"
+
+curl --include --request POST \
+  "${E2B_API_URL}/sandboxes/${SANDBOX_ID}/fc-volume-mounts" \
+  --header "X-API-Key: ${E2B_API_KEY}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "namedVolumeMounts": [
+      {
+        "name": "oss-workspace",
+        "path": "/mnt/oss"
+      }
+    ]
+  }'
+```
+
+Use the Volume name, not the Volume ID, for `name`. `path` must be a normalized absolute Unix path. It cannot be `/`, contain leading or trailing spaces, or contain `.` or `..` path segments.
+
+## Append an Inline Mount
+
+The following example directly appends a read-only OSS mount:
+
+```bash
+curl --include --request POST \
+  "${E2B_API_URL}/sandboxes/${SANDBOX_ID}/fc-volume-mounts" \
+  --header "X-API-Key: ${E2B_API_KEY}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "inlineVolumeMounts": {
+      "oss": {
+        "mountPoints": [
+          {
+            "bucketName": "example-bucket",
+            "bucketPath": "/datasets",
+            "endpoint": "oss-cn-hangzhou.aliyuncs.com",
+            "mountDir": "/mnt/datasets",
+            "readOnly": true
+          }
+        ]
+      }
+    }
+  }'
+```
+
+The execution Role used for the OSS mount must be included in the `createSandbox` request that creates the Sandbox, must already be in effect, and must have permission to access the target Bucket path. For details about fields and permission configuration, see [Dynamic OSS Mounts](./04.Dynamic%20OSS%20Mounts.md).
+
+You can also combine inline mounts and existing Volumes in the same request:
+
+```json
+{
+  "inlineVolumeMounts": {
+    "agenticFS": {
+      "userID": 1000,
+      "groupID": 1000,
+      "mountPoints": [
+        {
+          "serverAddr": "ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/",
+          "mountDir": "/mnt/agenticfs"
+        }
+      ]
+    }
+  },
+  "namedVolumeMounts": [
+    {
+      "name": "oss-workspace",
+      "path": "/mnt/oss"
+    }
+  ]
+}
+```
+
+## Verify the Mounts
+
+A `204` response indicates that the append request has been accepted. We recommend that you continue with the following checks:
+
+1. Call `GET /sandboxes/{sandboxID}`. Normally, mounts appended through `namedVolumeMounts` appear in `volumeMounts` in the response, whereas inline mounts do not. If the request returned `204` but the named Volume does not appear, the mount may still be in effect. Verify the mount directory before resubmitting the request.
+2. List the mount directory inside the Sandbox, and read or write a test file as permitted by the storage permissions.
+3. For a read-only mount, perform only a read test to avoid mistaking an expected write failure for a mount failure.
+
+## Behavior and Limits
+
+- This API only appends mounts. It does not support deleting, replacing, or unmounting them. To remove a mount, release and recreate the Sandbox.
+- A single request can append multiple storage types, but every new mount directory must be unique and cannot conflict with an existing mount directory in the current Sandbox.
+- AgenticFS uses UID/GID. The new configuration must match the UID/GID of the current active Sandbox.
+- Quotas are validated against the combined total of existing and new mounts in the current Sandbox. OSS and AgenticFS each support up to five mount points. Even if the current request does not exceed the limit on its own, the combined total may exceed the limit because of existing Sandbox mounts and result in a `400` response.
+- Do not concurrently update mounts for the same Sandbox. Duplicate, overlapping, or concurrent conflicting requests usually return `400`.
+
+## Common Errors
+
+| Status code | Possible cause | Resolution |
+| --- | --- | --- |
+| `400` | Invalid JSON, no valid mount points, invalid fields or paths, duplicate mount directories, or too many mounts | Check the case of request body fields, mount paths, and the combined mount count. |
+| `401` | No valid API Key was provided | Check the `X-API-Key` request header. |
+| `403` | The API Key is not authorized to call this API, or the required storage access permission is missing | Check the restricted API Key Action, storage capability, execution Role, and storage-side permissions. |
+| `404` | The Sandbox or named Volume does not exist or does not belong to the current Team | Check the Sandbox ID, Volume name, and the Team to which the API Key belongs. |
+| `409` | The Sandbox is not running, the required VPC or execution Role was not provided through `createSandbox`, or the UID/GID conflicts with the current Sandbox | Resume the Sandbox. If configuration is missing, recreate the Sandbox and provide the required configuration through `createSandbox`. |
+| `503` | Storage declarations or other dependencies are temporarily unavailable | Retain the request correlation information, check whether the mount has taken effect, and then decide whether to retry. |

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/01.概览.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/01.概览.md
@@ -13,6 +13,7 @@ FC Extensions 不改变 E2B SDK / CLI 的基本使用方式。应用仍然使用
 - [Team 配额管理](06.配额管理.md)：通过阿里云 POP SDK 为指定 Team 设置 CPU 和内存配额。创建 Team、资源组与订阅计划参见[Team 与订阅计划](../../01.开始使用/04.Team%20与订阅计划.md)。
 - [创建 OSS Volume](07.创建%20OSS%20Volume.md)：为 OSS Bucket 或 Bucket 子目录创建可复用的 Volume 挂载配置。
 - [创建 AgenticFS Volume](08.创建%20AgenticFS%20Volume.md)：为 AgenticFS AgenticSpace Access Point 创建可复用的 Volume 挂载配置。
+- [追加挂载沙箱存储](09.追加挂载沙箱存储.md)：向运行中的 Sandbox 追加内联存储挂载或已创建的 Volume。
 
 ## 使用方式
 
@@ -38,3 +39,4 @@ FC Extensions 不改变 E2B SDK / CLI 的基本使用方式。应用仍然使用
 - [配额管理](./06.配额管理.md)
 - [创建 OSS Volume](./07.创建%20OSS%20Volume.md)
 - [创建 AgenticFS Volume](./08.创建%20AgenticFS%20Volume.md)
+- [追加挂载沙箱存储](./09.追加挂载沙箱存储.md)

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/09.追加挂载沙箱存储.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/09.追加挂载沙箱存储.md
@@ -1,0 +1,176 @@
+# 追加挂载沙箱存储
+
+该接口用于向正在运行的 Sandbox 追加存储挂载，无需重新创建 Sandbox。
+
+该接口只支持追加，不支持删除、替换或解绑已有挂载。请勿将它当作全量更新接口：请求中省略已有挂载不会删除已有挂载，重复提交同一个挂载通常会返回冲突错误。
+
+当前对用户开放的存储类型为 OSS 和 AgenticFS。
+
+## 接口信息
+
+```text
+POST /sandboxes/{sandboxID}/fc-volume-mounts
+```
+
+请求头：
+
+| 请求头                              | 是否必填 | 说明           |
+|----------------------------------|------|--------------|
+| `X-API-Key`                      | 是    | 云沙箱 API Key。 |
+| `Content-Type: application/json` | 是    | 请求体为 JSON。   |
+
+接口成功时返回 `204 No Content`，响应体为空。
+
+## 前提条件
+
+调用接口前，请确认：
+
+- Sandbox 处于 `running` 状态。已暂停的 Sandbox 需要先恢复运行。
+- API Key 与目标 Sandbox 属于同一个 Team。
+- 使用 `namedVolumeMounts` 时，引用的 Volume 已在同一个 Team 中创建并可用。当前可以使用 [OSS Volume](./07.创建%20OSS%20Volume.md)
+  或 [AgenticFS Volume](./08.创建%20AgenticFS%20Volume.md)。
+- 创建 Sandbox 时，已通过 `createSandbox` 配置新增存储所需的执行 Role，以及 AgenticFS 所需的 VPC。`UpdateVolumeMounts` 只追加挂载，不会补充或修改这些配置。
+
+不同存储类型在 `createSandbox` 时所需的配置如下：
+
+| 存储类型      | 完整 VPC 配置 | 执行 Role |
+|-----------|-----------|---------|
+| OSS       | 不需要       | 需要      |
+| AgenticFS | 需要        | 需要      |
+
+- 如果计划追加 OSS，需要在 `createSandbox` 时通过 `fc.sandbox.auth.role` 配置执行 Role。
+- 如果计划追加 AgenticFS，除执行 Role 外，还需要通过 `fc.sandbox.network.vpc` 配置完整 VPC，包括 `vpcId`、`securityGroupId` 和至少包含一个元素的 `vSwitchIds`。VPC 配置方式参见
+[VPC 网络配置](./02.VPC%20网络配置.md)。
+
+## 请求参数
+
+请求体支持内联挂载、已创建的 Volume，或者同时使用两种方式：
+
+| 字段                   | 类型     | 是否必填 | 说明                                                                   |
+|----------------------|--------|------|----------------------------------------------------------------------|
+| `inlineVolumeMounts` | object | 条件必填 | 直接声明存储配置。当前支持 `oss` 和 `agenticFS`。                                   |
+| `namedVolumeMounts`  | array  | 条件必填 | 引用当前 Team 中已有的 Volume。每一项包含 Volume 名称 `name` 和 Sandbox 内挂载路径 `path`。 |
+
+`inlineVolumeMounts` 和 `namedVolumeMounts` 至少需要提供一个有效挂载点。空请求或空配置会返回 `400`。
+
+内联配置字段如下。字段名区分大小写，尤其需要注意 `agenticFS` 以及 AgenticFS 的 `userID`、`groupID`：
+
+| 配置          | 字段                         | 是否必填 | 约束                                              |
+|-------------|----------------------------|------|-------------------------------------------------|
+| `oss`       | `mountPoints`              | 是    | 包含 1～5 个挂载点。                                    |
+| `oss`       | `mountPoints[].bucketName` | 是    | 长度为 3～64 个字符。                                   |
+| `oss`       | `mountPoints[].bucketPath` | 否    | Bucket 内路径，最长 128 个字符；设置为 `/` 或留空表示 Bucket 根目录。 |
+| `oss`       | `mountPoints[].endpoint`   | 是    | OSS Endpoint，最长 128 个字符，应与 Bucket 所在地域匹配。       |
+| `oss`       | `mountPoints[].mountDir`   | 是    | Sandbox 内的绝对路径，长度为 2～64 个字符，不能为 `/`。            |
+| `oss`       | `mountPoints[].readOnly`   | 否    | 是否只读挂载，布尔值。                                     |
+| `agenticFS` | `userID`                   | 否    | 取值范围为 `-1`～`65534`。                             |
+| `agenticFS` | `groupID`                  | 否    | 取值范围为 `-1`～`65534`。                             |
+| `agenticFS` | `mountPoints`              | 是    | 包含 1～5 个挂载点。                                    |
+| `agenticFS` | `mountPoints[].serverAddr` | 是    | AgenticFS Access Point 地址，最长 128 个字符。           |
+| `agenticFS` | `mountPoints[].mountDir`   | 是    | Sandbox 内的规范化绝对路径，最长 128 个字符，不能为 `/`。           |
+
+## 追加已创建的 Volume
+
+以下示例向运行中的 Sandbox 追加一个已创建的 Volume：
+
+```bash
+export E2B_API_KEY="<your-e2b-api-key>"
+export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
+export SANDBOX_ID="<sandbox-id>"
+
+curl --include --request POST \
+  "${E2B_API_URL}/sandboxes/${SANDBOX_ID}/fc-volume-mounts" \
+  --header "X-API-Key: ${E2B_API_KEY}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "namedVolumeMounts": [
+      {
+        "name": "oss-workspace",
+        "path": "/mnt/oss"
+      }
+    ]
+  }'
+```
+
+`name` 使用 Volume 名称，不使用 Volume ID。`path` 必须是规范化的绝对 Unix 路径，不能为 `/`，不能包含前后空格、`.` 或 `..` 路径段。
+
+## 追加内联挂载
+
+以下示例直接追加一个只读 OSS 挂载：
+
+```bash
+curl --include --request POST \
+  "${E2B_API_URL}/sandboxes/${SANDBOX_ID}/fc-volume-mounts" \
+  --header "X-API-Key: ${E2B_API_KEY}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "inlineVolumeMounts": {
+      "oss": {
+        "mountPoints": [
+          {
+            "bucketName": "example-bucket",
+            "bucketPath": "/datasets",
+            "endpoint": "oss-cn-hangzhou.aliyuncs.com",
+            "mountDir": "/mnt/datasets",
+            "readOnly": true
+          }
+        ]
+      }
+    }
+  }'
+```
+
+OSS 挂载所使用的执行 Role 必须在创建 Sandbox 的 `createSandbox` 请求中传入并已经生效，同时具备访问目标 Bucket
+路径的权限。字段和权限配置参见[动态挂载 OSS](./04.动态挂载%20OSS.md)。
+
+也可以在同一次请求中组合内联挂载和已创建的 Volume：
+
+```json
+{
+  "inlineVolumeMounts": {
+    "agenticFS": {
+      "userID": 1000,
+      "groupID": 1000,
+      "mountPoints": [
+        {
+          "serverAddr": "ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/",
+          "mountDir": "/mnt/agenticfs"
+        }
+      ]
+    }
+  },
+  "namedVolumeMounts": [
+    {
+      "name": "oss-workspace",
+      "path": "/mnt/oss"
+    }
+  ]
+}
+```
+
+## 验证挂载
+
+收到 `204` 表示已接受本次追加。建议继续执行以下验证：
+
+1. 调用 `GET /sandboxes/{sandboxID}`。正常情况下，使用 `namedVolumeMounts` 追加的挂载会出现在响应的 `volumeMounts` 中；内联挂载不会出现在该字段中。如果请求已返回 `204` 但 named Volume 未回显，挂载仍可能已经生效，应先验证挂载目录，不要直接重复提交。
+2. 在 Sandbox 内列出挂载目录，并根据存储权限实际读取或写入一个测试文件。
+3. 只读挂载只执行读取验证，避免将写入失败误判为挂载失败。
+
+## 行为与限制
+
+- 接口是追加操作，不支持删除、替换或解绑。需要移除挂载时，请释放并重新创建 Sandbox。
+- 一个请求可以同时追加多种存储，但所有新增挂载目录必须唯一，也不能与当前 Sandbox 的已有挂载目录冲突。
+- AgenticFS 使用 UID/GID，新增配置必须与当前活动 Sandbox 的 UID/GID 一致。
+- 按当前 Sandbox 的已有挂载与新增挂载的累计结果校验配额。OSS 和 AgenticFS 分别最多挂载 5 个挂载点。即使本次请求没有超过限制，也可能因为 Sandbox 已有挂载使累计数量超限并返回 `400`。
+- 不要并发更新同一个 Sandbox 的挂载。重复、重叠或并发冲突通常返回 `400`。
+
+## 常见错误
+
+| 状态码   | 可能原因                                                                        | 处理方式                                                        |
+|-------|-----------------------------------------------------------------------------|-------------------------------------------------------------|
+| `400` | JSON 无效、没有有效挂载点、字段或路径不合法、挂载目录重复、挂载数量超限                                      | 检查请求体字段大小写、挂载路径和累计挂载数量。                                     |
+| `401` | 未提供有效 API Key                                                               | 检查 `X-API-Key` 请求头。                                         |
+| `403` | API Key 不允许调用本接口，或没有访问存储的权限                                                 | 检查受限 API Key Action、存储 capability、执行 Role 及存储侧权限。           |
+| `404` | Sandbox 或 named Volume 不存在，或者不属于当前 Team                                     | 检查 Sandbox ID、Volume 名称和 API Key 所属 Team。                   |
+| `409` | Sandbox 不在运行状态、`createSandbox` 时未传入所需的 VPC/执行 Role，或 UID/GID 与当前 Session 冲突 | 恢复 Sandbox；如果缺少配置，请重新创建 Sandbox，并在 `createSandbox` 时传入所需配置。 |
+| `503` | 存储声明或其他依赖暂时不可用                                                              | 保留请求关联信息，先检查挂载是否已经生效，再决定是否重试。                               |

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/09.追加挂载沙箱存储.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/09.追加挂载沙箱存储.md
@@ -172,5 +172,5 @@ OSS 挂载所使用的执行 Role 必须在创建 Sandbox 的 `createSandbox` �
 | `401` | 未提供有效 API Key                                                               | 检查 `X-API-Key` 请求头。                                         |
 | `403` | API Key 不允许调用本接口，或没有访问存储的权限                                                 | 检查受限 API Key Action、存储 capability、执行 Role 及存储侧权限。           |
 | `404` | Sandbox 或 named Volume 不存在，或者不属于当前 Team                                     | 检查 Sandbox ID、Volume 名称和 API Key 所属 Team。                   |
-| `409` | Sandbox 不在运行状态、`createSandbox` 时未传入所需的 VPC/执行 Role，或 UID/GID 与当前 Session 冲突 | 恢复 Sandbox；如果缺少配置，请重新创建 Sandbox，并在 `createSandbox` 时传入所需配置。 |
+| `409` | Sandbox 不在运行状态、`createSandbox` 时未传入所需的 VPC/执行 Role，或 UID/GID 与当前 Sandbox 冲突 | 恢复 Sandbox；如果缺少配置，请重新创建 Sandbox，并在 `createSandbox` 时传入所需配置。 |
 | `503` | 存储声明或其他依赖暂时不可用                                                              | 保留请求关联信息，先检查挂载是否已经生效，再决定是否重试。                               |


### PR DESCRIPTION
## 变更说明

  本次修改涉及云沙箱（FC Agent Sandbox）产品的「功能说明 > FC 扩展」章节。

  - 新增中英文「追加挂载沙箱存储」页面，介绍如何向运行中的 Sandbox 追加 OSS 或 AgenticFS 存储挂载。
  - 补充接口路径、前置条件、请求参数、调用示例、挂载验证方式、行为限制和常见错误处理。
  - 更新中英文 FC Extensions 概览，增加新页面的入口及功能简介。
  - 修正中文文档中 `409` 状态码的描述，将冲突对象明确为 Sandbox。

  ## 变更类型

  - [x] 修正文档内容
  - [x] 新增或删除页面
  - [ ] 更新图片或媒体资源
  - [ ] 修改构建脚本或 CI

  ## 验证

  - [ ] 已运行 `make check`
    - 已执行，但构建阶段因本地未安装 `mkdocs` 而中断。
    - 13 项单元测试全部通过。
    - 文档检查通过：已检查 707 个 Markdown 文件、682 个资源及全部本地引用。
  - [x] 已检查新增或修改的链接和图片
  - [x] 未提交真实凭证或敏感信息

  ## 相关 Issue

  无。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 更新函数计算（FC）的云沙箱（FC Agent Sandbox）文档，范围包括：

- 在中英文“功能说明 > FC 扩展”章节新增“追加挂载沙箱存储”页面。
- 新增运行中 Sandbox 追加 OSS、AgenticFS 或已有 Volume 挂载的 API 说明。
- 补充接口参数、调用示例、前置条件、挂载验证、限制和错误处理。
- 更新中英文 FC Extensions 概览页，增加新页面入口和功能简介。
- 修正中文文档中 `409` 状态码的 Sandbox 冲突对象描述。

本 PR 新增 2 个页面，并更新 2 个概览页面。未删除页面。未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->