### PR TITLE
Docs/swe agent e2b dependency

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
@@ -13,9 +13,7 @@ This guide walks through the full loop of "agent fixes → produces a patch → 
 
 ## Prerequisites
 
-- Agent Sandbox is enabled and you have an `E2B_API_KEY` for the target region. This guide uses China (Shanghai) as the example, with these endpoints:
-  - `api_url`: `https://api.cn-shanghai.e2b.fc.aliyuncs.com`
-  - `domain`: `cn-shanghai.e2b.fc.aliyuncs.com`
+- Agent Sandbox is enabled and you have an `E2B_API_KEY` for the target region. This guide uses China (Shanghai) as the example; its domain is `cn-shanghai.e2b.fc.aliyuncs.com`, from which the SDK derives the API address `https://api.cn-shanghai.e2b.fc.aliyuncs.com`.
 - A working model API key (this guide uses an OpenAI-compatible endpoint).
 - Python 3.10 or later.
 
@@ -72,163 +70,55 @@ The example task in this guide is `getmoto__moto-7365`: moto's DynamoDB `update_
 ```bash
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
-.venv/bin/pip install e2b "mini-swe-agent>=2.4" pyyaml
+.venv/bin/pip install pyyaml \
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@v2.4.6-fc.1"
 
+# The SDK derives the endpoint from the domain (https://api.<domain>); no separate api_url needed
 export E2B_API_KEY="<your-e2b-api-key>"
-export E2B_REGION="cn-shanghai"
+export E2B_DOMAIN="cn-shanghai.e2b.fc.aliyuncs.com"
+# The model credential is used in the orchestration layer only; it never enters the sandbox
 export MODEL_API_KEY="<your-model-api-key>"
 export MSWEA_CONFIGURED=true MSWEA_SILENT_STARTUP=1
 ```
 
-The agent loop uses the community-standard implementation [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent) directly, keeping its official prompts and submission protocol, and only replacing the execution backend with Agent Sandbox. Its execution-environment protocol has just three methods; implementing them is enough, with no changes to the upstream code.
+> On a restricted network, `git clone https://github.com/aliyun-fc/mini-swe-agent` first, then `pip install -e ".[e2b]"`.
 
-## Implement the execution environment: `fc_env.py`
+## Execution environment: use the built-in `e2b`
 
-Below is the complete implementation. The four commented spots are where the behavior differs from a local docker execution environment and must be handled specially.
+The agent loop uses the community-standard implementation [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent) directly, keeping its official prompts and submission protocol, and only replacing the execution backend with Agent Sandbox. The version installed above ships an `e2b` execution environment, so one line of configuration is all you need -- there is nothing to implement:
 
-```python
-# fc_env.py
-from __future__ import annotations
-
-import hashlib
-import os
-import platform
-import shlex
-from dataclasses import dataclass, field
-from typing import Any
-
-from e2b import CommandExitException, Sandbox, Template
-from minisweagent.exceptions import Submitted
-
-SUBMIT_SENTINEL = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"
-
-REGIONS = {
-    "cn-shanghai": "https://api.cn-shanghai.e2b.fc.aliyuncs.com",
-    "cn-hangzhou": "https://api.cn-hangzhou.e2b.fc.aliyuncs.com",
-    "cn-beijing": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
-    "cn-hongkong": "https://api.cn-hongkong.e2b.fc.aliyuncs.com",
-    "us-west-1": "https://api.us-west-1.e2b.fc.aliyuncs.com",
-}
-
-
-@dataclass
-class FCSandboxEnvironmentConfig:
-    image: str = ""
-    template: str = ""
-    cwd: str = "/testbed"
-    env: dict[str, str] = field(default_factory=dict)
-    forward_env: list[str] = field(default_factory=list)  # keep empty: host vars must not enter the sandbox
-    timeout: int = 60
-    interpreter: list[str] = field(default_factory=lambda: ["bash", "-c"])
-    sandbox_timeout: int = 1800
-    region: str = field(default_factory=lambda: os.environ.get("E2B_REGION", "cn-shanghai"))
-    run_as_user: str = "root"  # evaluation images usually have a root-owned repo and often no sudo
-
-
-class FCSandboxEnvironment:
-    def __init__(self, *, config_class=FCSandboxEnvironmentConfig, **kwargs):
-        self.config = config_class(**kwargs)
-        self._conn = {
-            "api_key": os.environ["E2B_API_KEY"],
-            "api_url": REGIONS[self.config.region],
-            "domain": f"{self.config.region}.e2b.fc.aliyuncs.com",
-        }
-        template = self.config.template or self._ensure_template()
-        self.sbx = Sandbox.create(template, timeout=self.config.sandbox_timeout, **self._conn)
-        self.template = template
-
-        # Difference 1: docker's -w creates the directory automatically, the sandbox does not.
-        # When the directory is missing the error is `fork/exec /bin/bash: no such file or
-        # directory`, which is easily mistaken for a problem with bash itself.
-        self._run_raw(f"mkdir -p {shlex.quote(self.config.cwd)}")
-        # Difference 2: cross-user git operations are rejected (dubious ownership)
-        self._run_raw(f"git config --global --add safe.directory {shlex.quote(self.config.cwd)}")
-
-    def _ensure_template(self) -> str:
-        """Image → template, idempotent: probe by template name first, build only if that fails.
-
-        Derive the template name from a hash of the image, and do not embed a version number:
-        a given template name may only be built once, and after a failed build the name stays
-        in CREATE_FAILED, so building again returns 409 immediately.
-        """
-        name = "swe-" + hashlib.sha1(self.config.image.encode()).hexdigest()[:16]
-        try:
-            probe = Sandbox.create(name, timeout=60, **self._conn)
-            probe.kill()
-            return name
-        except Exception:
-            pass
-        Template.build(Template().from_image(self.config.image), name=name,
-                       cpu_count=2, memory_mb=8192, **self._conn)
-        return name
-
-    def _run_raw(self, command: str) -> None:
-        try:
-            self.sbx.commands.run(command, user=self.config.run_as_user or None, timeout=30)
-        except Exception:
-            pass  # best-effort setup commands; failure does not affect the main flow
-
-    def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
-        command = action.get("command", "")
-        limit = timeout or self.config.timeout
-        envs = {k: os.environ[k] for k in self.config.forward_env if k in os.environ}
-        envs.update(self.config.env)
-        cmd = shlex.join([*self.config.interpreter, command])
-        try:
-            r = self.sbx.commands.run(
-                cmd, cwd=cwd or self.config.cwd, envs=envs or None,
-                user=self.config.run_as_user or None,
-                timeout=limit, request_timeout=limit + 60,
-            )
-            out = {"output": (r.stdout or "") + (r.stderr or ""), "returncode": 0,
-                   "exception_info": ""}
-        except CommandExitException as e:
-            # Difference 3: a non-zero exit is a normal signal (a failing test, for example).
-            # It must be turned into a returncode, never raised to the caller.
-            out = {"output": (e.stdout or "") + (e.stderr or ""), "returncode": e.exit_code,
-                   "exception_info": ""}
-        except Exception as e:
-            out = {"output": "", "returncode": -1,
-                   "exception_info": f"command execution failed: {e}",
-                   "extra": {"exception_type": type(e).__name__}}
-        self._check_finished(out)
-        return out
-
-    def _check_finished(self, output: dict) -> None:
-        """Difference 4: the submission protocol must be reproduced verbatim — if the first line
-        is the sentinel and the exit code is 0, the remaining lines are the patch."""
-        lines = output.get("output", "").lstrip().splitlines(keepends=True)
-        if lines and lines[0].strip() == SUBMIT_SENTINEL and output["returncode"] == 0:
-            submission = "".join(lines[1:])
-            raise Submitted({"role": "exit", "content": submission,
-                             "extra": {"exit_status": "Submitted", "submission": submission}})
-
-    def get_template_vars(self, **kwargs) -> dict[str, Any]:
-        return {**self.config.__dict__, **platform.uname()._asdict(), **kwargs}
-
-    def serialize(self) -> dict:
-        # every trajectory must be traceable back to a specific sandbox and source image
-        return {"environment_class": "fc_env.FCSandboxEnvironment",
-                "sandbox_id": self.sbx.sandbox_id, "template": self.template,
-                "image": self.config.image, "cwd": self.config.cwd}
-
-    def cleanup(self) -> None:
-        try:
-            self.sbx.kill()
-        except Exception:
-            pass
+```yaml
+environment:
+  environment_class: e2b
 ```
+
+What it does: the first time an image is used it is registered as a persistent template (`Template.build`) and reused from cache afterwards; each instance gets its own sandbox, commands are dispatched through `commands.run`, and the patch comes back over the official submission protocol.
+
+**Agent Sandbox differs from local docker in four ways.** The built-in environment class already handles them, but you need to know they exist -- you will hit them if you implement your own backend or debug a failing run:
+
+| Difference | Consequence if unhandled | How it is handled |
+| --- | --- | --- |
+| `docker run -w` creates the working directory; a sandbox does not | A missing directory fails at process creation **without an exit code**, so every command is recorded as an infrastructure error and the agent burns a whole run for nothing | `mkdir -p <cwd>` right after the sandbox starts |
+| git refuses to operate when the repository owner differs from the running user | `fatal: detected dubious ownership`; `git diff` produces nothing, which means no patch can be submitted | `git config --global --add safe.directory <cwd>` at startup |
+| A non-zero exit is raised as an exception by the SDK | Failing tests and empty `grep` results -- **normal signals** -- get treated as execution faults and the agent never sees the real output | Catch it, convert to `returncode`, and hand back stdout/stderr verbatim |
+| Evaluation images own the repository as root and usually ship without `sudo` | Running as the template's default non-root user leaves the agent unable to even write a file (Permission denied) | Set `run_as_user: root` (which matches the official docker harness) |
+
+Two things to keep in mind about template builds, especially when onboarding your own images:
+
+- **The template name must be derived from the image address *and* the resource spec.** The built-in implementation hashes "image address + `cpu_count`/`memory_mb`": an existing template is reused as-is and never rebuilt, so a name that omits the spec would silently hand you a template built with the old memory setting.
+- **A given template name can only be built once.** After a failed build the name stays in `CREATE_FAILED` and building it again returns 409. So derive the name from content instead of manually bumping a version suffix.
 
 ## Configuration: always change the image and the working directory together
 
 ```yaml
 # demo.yaml — layered on top of mini-SWE-agent's official swebench.yaml, keeping its prompts and submission protocol
 environment:
-  environment_class: fc_env.FCSandboxEnvironment
+  environment_class: e2b
   image: fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510
   cwd: /testbed          # must be changed together with the image, see "What to change for another benchmark"
   run_as_user: root
   timeout: 120
+  memory_mb: 8192        # evaluation images are large; the 2048 default will not start
 model:
   model_name: openai/<your-model>
   model_kwargs:
@@ -250,10 +140,9 @@ from pathlib import Path
 import yaml
 from minisweagent.agents.default import DefaultAgent
 from minisweagent.config import builtin_config_dir
+from minisweagent.environments import get_environment
 from minisweagent.models.litellm_model import LitellmModel
 from minisweagent.utils.serialize import recursive_merge
-
-from fc_env import FCSandboxEnvironment
 
 p = argparse.ArgumentParser()
 p.add_argument("-c", "--config", type=Path, default=Path("demo.yaml"))
@@ -267,9 +156,7 @@ a = p.parse_args()
 official = yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text())
 cfg = recursive_merge(official, yaml.safe_load(a.config.read_text()))
 
-env_cfg = dict(cfg["environment"])
-env_cfg.pop("environment_class", None)          # instantiate directly, bypassing the registry
-env = FCSandboxEnvironment(**env_cfg)
+env = get_environment(cfg["environment"])      # environment_class: e2b
 
 model_cfg = dict(cfg["model"])
 model_cfg.setdefault("model_kwargs", {})
@@ -285,7 +172,7 @@ finally:
 patch = result.get("submission") or ""
 a.output.write_text(patch)
 print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(patch),
-                  "model_calls": agent.n_calls, "sandbox_id": env.sbx.sandbox_id},
+                  "model_calls": agent.n_calls, "sandbox_id": env.sandbox.sandbox_id},
                  ensure_ascii=False))
 ```
 
@@ -304,7 +191,7 @@ from collections import Counter
 from pathlib import Path
 
 import yaml
-from fc_env import FCSandboxEnvironment
+from minisweagent.environments.extra.e2b import E2BEnvironment
 
 # In evaluation images, python/pytest usually live in a conda environment activated via BASH_ENV.
 # Without these variables, `python -m pytest` falls back to conda base and reports
@@ -345,11 +232,11 @@ if not patch.strip():
 image = yaml.safe_load(Path("demo.yaml").read_text())["environment"]["image"]
 f2p, p2p = as_list(inst["FAIL_TO_PASS"]), as_list(inst["PASS_TO_PASS"])
 
-env = FCSandboxEnvironment(image=image, cwd=a.cwd, run_as_user="root",
-                           timeout=900, env=GRADE_ENV)
+env = E2BEnvironment(image=image, cwd=a.cwd, run_as_user="root",
+                     timeout=900, memory_mb=8192, env=GRADE_ENV)
 try:
     # 1) Apply the patch under evaluation; failing to apply is itself a result
-    env.sbx.files.write("/tmp/model.patch", patch)
+    env.sandbox.files.write("/tmp/model.patch", patch)
     out = env.execute({"command": "git apply -v /tmp/model.patch"}, timeout=300)
     if out["returncode"] != 0:
         out = env.execute({"command": "patch -p1 -i /tmp/model.patch"}, timeout=300)
@@ -360,7 +247,7 @@ try:
     tf = patched_files(inst["test_patch"])
     if tf:
         env.execute({"command": f"git checkout -- {' '.join(map(shlex.quote, tf))} || true"})
-    env.sbx.files.write("/tmp/test.patch", inst["test_patch"])
+    env.sandbox.files.write("/tmp/test.patch", inst["test_patch"])
     out = env.execute({"command": "git apply -v /tmp/test.patch"}, timeout=300)
     assert out["returncode"] == 0, f"test_patch does not apply: {out['output'][-200:]}"
 
@@ -438,17 +325,17 @@ finally:
 **Self-check the grader before running the agent.** Put the dataset's own correct patch through grading; it must come out `resolved: true`:
 
 ```bash
-PYTHONPATH=. .venv/bin/python grade.py --gold
+.venv/bin/python grade.py --gold
 # {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.58s"}
 ```
 
 If the self-check fails, the grading pipeline itself is broken (image, how test cases are introduced, case-name matching), and any score the agent gets is meaningless. Once it passes, run the agent and grade its output:
 
 ```bash
-PYTHONPATH=. .venv/bin/python run.py
+.venv/bin/python run.py
 # {"exit_status": "Submitted", "patch_bytes": 1839, "model_calls": 31, "sandbox_id": "sbx-…"}
 
-PYTHONPATH=. .venv/bin/python grade.py --patch out.patch
+.venv/bin/python grade.py --patch out.patch
 # {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.76s"}
 ```
 
@@ -456,74 +343,56 @@ The first run registers the image as a template (idempotent; later runs hit the 
 
 ## Extending to batch evaluation
 
-Going from one task to N tasks requires no changes to `fc_env.py`; what you add is a resolution layer and concurrency orchestration.
+Going from one task to N tasks does not require writing your own orchestration -- mini-SWE-agent ships a batch evaluation entry point, `mini-extra swebench`, which handles per-instance isolation, concurrency, writing `preds.json`, and reclaiming sandboxes when it is done. There is exactly one thing you have to do: **feed it the image address for each task.**
 
-### Resolution layer: turn two hard-coded lines into table lookups
+### Resolution layer: the image address must come from a lookup table
 
-For a single task the image address and working directory sit in the config; in a batch they differ per task and must be looked up. Three things need per-instance resolution: the image address (evaluation image tags usually carry build-batch information and **cannot be derived from `instance_id`**), the working directory, and the grading criteria.
+Evaluation image tags usually carry build-batch information (for example `..._202607231510`) and therefore **cannot be derived from `instance_id`**, which makes a lookup mandatory. `mini-extra swebench` reads an instance's `image_name` field first, so writing the resolved address into that field is enough:
 
 ```python
-# resolve.py
+# prepare.py -- emit a local dataset carrying image_name
 import json
-
-IMAGES = dict(l.split("\t") for l in open("images.tsv").read().splitlines())
-REGISTRY = json.load(open("registry.json"))     # family → cwd / run_as_user / grading
-FAMILY = json.load(open("family-index.json"))   # instance_id → family
-
-def resolve(instance: dict) -> dict:
-    spec = REGISTRY[FAMILY[instance["instance_id"]]]
-    cwd = spec["cwd"]
-    if cwd.startswith("$dataset."):             # some benchmarks have a per-instance working dir
-        cwd = instance[cwd.split(".", 1)[1]]    # take the matching field from the dataset
-    return {"image": IMAGES[instance["instance_id"]], "cwd": cwd,
-            "run_as_user": spec["run_as_user"], "grading": spec["grading"]}
-```
-
-Resolution is pure table lookup with no network or sandbox cost, so it can be done once before the run starts. Instances that fail to resolve (missing image mapping, missing metadata) should be dropped before the run rather than failing halfway through.
-
-### Concurrency orchestration
-
-```python
-# batch.py (skeleton)
-import concurrent.futures as cf, json
 from pathlib import Path
 
-from fc_env import FCSandboxEnvironment
-from resolve import resolve
-
-def run_one(inst: dict) -> tuple[str, dict]:
-    spec = resolve(inst)
-    env = FCSandboxEnvironment(image=spec["image"], cwd=spec["cwd"],
-                               run_as_user=spec["run_as_user"], timeout=120)
-    try:
-        agent = build_agent(env)                       # same as run.py above
-        result = agent.run(inst["problem_statement"])
-        return inst["instance_id"], {
-            "model_patch": result.get("submission") or "",
-            "exit_status": result.get("exit_status"),
-            "sandbox_id": env.sbx.sandbox_id,          # keep it traceable
-        }
-    except Exception as e:                             # one failing instance must not sink the batch
-        return inst["instance_id"], {"model_patch": "", "error": f"{type(e).__name__}: {e}"}
-    finally:
-        env.cleanup()                                  # kill right away, do not wait for the TTL
-
+IMAGES = json.load(open("image-index.json"))      # instance_id → image address
 instances = json.loads(Path("instances.json").read_text())
-preds = {}
-with cf.ThreadPoolExecutor(max_workers=6) as ex:
-    for iid, pred in ex.map(run_one, instances):
-        preds[iid] = pred
-Path("preds.json").write_text(json.dumps(preds, ensure_ascii=False, indent=1))
+
+out = Path("dataset"); out.mkdir(exist_ok=True)
+with (out / "train.jsonl").open("w") as f:
+    for inst in instances:
+        if inst["instance_id"] not in IMAGES:      # drop unmapped instances before the run
+            continue
+        inst["image_name"] = IMAGES[inst["instance_id"]]
+        f.write(json.dumps(inst, ensure_ascii=False) + "\n")
 ```
 
-Four orchestration constraints you must satisfy:
+> `--subset` expects a **directory** (holding `train.jsonl` or a parquet file). Passing a single file path fails with `Couldn't find any data file`.
 
-| Constraint | How |
+Resolution is pure table lookup with no network or sandbox cost, so it can be done once before the run starts. Instances that fail to resolve should be dropped before the run rather than failing halfway through.
+
+### Run the batch
+
+```bash
+.venv/bin/mini-extra swebench \
+    --subset ./dataset --split train \
+    -c swebench.yaml -c demo.yaml \
+    --workers 6 -o ./results
+```
+
+`-c` is a **list**, and supplying your own config displaces the default, so the official `swebench.yaml` must be listed first -- passing only `-c demo.yaml` fails with `ValidationError: system_template Field required` because the prompts are missing. The `image` key in `demo.yaml` can be left out here; it is injected per instance.
+
+Results land in `results/preds.json` (`instance_id → model_patch`), and each instance also gets a trajectory recording its `sandbox_id` and `template`, so any run can be traced back to the exact execution.
+
+**A single batch may only contain images from one family.** `cwd` and `run_as_user` are shared across the whole batch in the config, while different benchmarks use different working directories (see "What to change for another benchmark"), so run one batch per image family with its own `demo.yaml`.
+
+Of the four orchestration constraints, the built-in entry point already satisfies the first two; the last two are still yours to set:
+
+| Constraint | Status |
 | --- | --- |
-| One failing instance must not sink the batch | Catch exceptions per instance, record the error, and continue |
-| Sandboxes must always be reclaimed | Call `kill()` in `finally`. Relying on the TTL costs extra and holds concurrency slots |
-| Set limits on the agent side | `step_limit`, `cost_limit`, `wall_time_limit`; stop on exceeding them, or a single hard task can burn the whole batch's budget |
-| Tier your output truncation | 15k characters for the terminal, 20k for a single file, 50k for a batch, so the context is not swamped |
+| One failing instance must not sink the batch | Built in: the exception is recorded as that instance's `exit_status` and the rest continue |
+| Sandboxes must always be reclaimed | Built in: normal completion, an agent exception, and a failing startup command all `kill`. Relying on the TTL costs extra and holds concurrency slots |
+| Set limits on the agent side | Yours: `step_limit`, `cost_limit`, `wall_time_limit`, or a single hard task can burn the whole batch's budget |
+| Tier your output truncation | Yours: 15k characters for the terminal, 20k for a single file, 50k for a batch, so the context is not swamped |
 
 **Keep concurrency around 6.** Large images can time out during sandbox creation at a concurrency of 10, and a serial retry usually succeeds; so when sandbox creation fails, retry once serially before declaring an instance unusable—otherwise concurrency pressure gets misrecorded as an image problem.
 
@@ -692,7 +561,7 @@ for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
 
 Making that an `auto` option in the resolution layer is more reliable than enumerating entries in a config.
 
-The image address and working directory must be changed **as a pair**. Changing only one produces `fork/exec /bin/bash: no such file or directory`—that means the working directory does not exist and has nothing to do with bash.
+The image address and working directory must be changed **as a pair**, and getting it wrong **raises no error**: a working directory that does not exist is created as an empty one, the agent runs a full loop inside it, submits an empty patch, and scores zero. So the first thing to do after switching benchmarks is to confirm the target repository really is at that working directory (`git rev-parse HEAD` returns something).
 
 Two practices to avoid:
 
@@ -715,7 +584,7 @@ On top of that, evaluation scenarios have five more things to watch:
 | A template name may only be built once | Retrying after a failed build returns `409: template build is not allowed in current status CREATE_FAILED`, and that name is permanently unusable | Always retry under a new name. Derive template names from a hash of the image, without a version number |
 | The build stage does not support execution steps | Declaring `run_cmd` / `set_user` / `set_workdir` returns `400: steps are not supported` | Dependencies and environment must already be in the source image; permissions and working directory can only be handled at runtime via `user="root"` |
 | A source image that does not meet envd injection requirements fails to build | The platform injects envd into the image during the build. If the image does not meet the prerequisites, the log prints `template build failed: envd inject failed` while still printing `Build finished` (building `python:3.11-slim` directly reproduces this) | Check the image against [Build Custom Image Templates](../04.Features/02.Templates/03.Build Custom Image Templates.md) (`linux/amd64`, writable `/etc/passwd` and `/etc/group`, a fixed `/bin/bash` path, and so on). **Note that `Build finished` does not mean success—look for `envd inject failed`** |
-| The SDK may hang for a long time on a failed build | After a failure the client keeps polling the build status, and with large logs it can take a long time before raising `ReadTimeout` | Add your own timeout around `Template.build` instead of relying on it to return |
+| The SDK may hang for a long time on a failed build | After a failure the client keeps polling the build status, and with large logs it can take a long time before raising `ReadTimeout` | A timeout around `Template.build` is mandatory; do not rely on it to return. The built-in `e2b` environment class already does this (`build_timeout`, 30 minutes by default) |
 | Large images time out on sandbox creation | High concurrency reports `TimeoutException` | Keep concurrency around 6 and retry once serially on failure |
 
 Once an image is onboarded, do not stop acceptance testing at "the sandbox started". Sample some instances and run all four steps below; failing any one means it is not usable:
@@ -740,7 +609,7 @@ Once an image is onboarded, do not stop acceptance testing at "the sandbox start
 - **Two layers of timeout**: distinguish the sandbox TTL from the per-command timeout. Do not use `timeout=0`, since a stuck process will not recover on its own; for long tasks use `on_timeout="pause"` together with `auto_resume`, which neither bills nor holds a concurrency slot while paused.
 - **The patch is the only outbound artifact**: the sandbox needs only read access to the repository. Once the orchestration layer has the patch, it rebuilds a clean repository, verifies it, runs the tests, and only then creates a PR. Do not push or open PRs from inside the sandbox.
 - **Destroy promptly**: call `sandbox.kill()` in `finally`; per-second billing only counts running time.
-- **Keep it traceable**: record `sandbox_id` and the source image address on every trajectory (`serialize()` above already includes both) for reproduction and troubleshooting.
+- **Keep it traceable**: record `sandbox_id`, the template name, and the source image address on every trajectory (the built-in `e2b` environment class's `serialize()` already includes all three) for reproduction and troubleshooting.
 - **Cost accounting**: record start and end times in the orchestration layer and read the specification via `get_info()` to compute cost yourself.
 
 ## Related features

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
@@ -51,7 +51,7 @@ flowchart TB
     style SBX stroke-width:3px
 ```
 
-**The model runs in the orchestration layer; the sandbox only executes bash.** That way neither the model key nor repository credentials ever enter the sandbox: even if the repository content the agent reads contains malicious instructions, the worst it can do is submit an invalid patch—it cannot obtain any credentials.
+The model runs in the orchestration layer and the sandbox only executes bash, so neither the model key nor repository credentials ever enter the sandbox. Even if the repository content the agent reads contains malicious instructions, the worst it can do is submit an invalid patch; it cannot obtain any credentials.
 
 ## A task has three parts
 
@@ -63,7 +63,7 @@ The example task in this guide is `getmoto__moto-7365`: moto's DynamoDB `update_
 | Task | The problem statement (`problem_statement`) | Upstream dataset |
 | Grading | `FAIL_TO_PASS` (must pass after the fix), `PASS_TO_PASS` (must not regress), `test_patch` | Upstream dataset |
 
-**The image is only the environment; the task and its test cases live in the metadata.** With the image alone and no metadata, there is no task to run.
+The image is only the environment; the task and its test cases live in the metadata. With the image alone and no metadata, there is no task to run.
 
 ## Install dependencies and configure credentials
 
@@ -71,7 +71,7 @@ The example task in this guide is `getmoto__moto-7365`: moto's DynamoDB `update_
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
 .venv/bin/pip install pyyaml \
-  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@571ea037897d8eb332a83c48319926505b4a05a5"
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@v2.4.6-fc.1"
 
 # The SDK derives the endpoint from the domain (https://api.<domain>); no separate api_url needed
 export E2B_API_KEY="<your-e2b-api-key>"
@@ -84,16 +84,14 @@ export OPENAI_API_KEY="<your-model-api-key>"
 export MSWEA_CONFIGURED=true MSWEA_SILENT_STARTUP=1
 ```
 
-**Pin the full commit SHA, never a branch.** A branch moves with every later commit, so what
-you install today and what you install next week are not the same code, and evaluation results
-stop being reproducible. Check what you got:
+Check what you got:
 
 ```bash
 .venv/bin/python -c "import minisweagent; print(minisweagent.__version__)"
 # 2.4.6+fc.1
 ```
 
-> On a restricted network, `git clone https://github.com/aliyun-fc/mini-swe-agent` first, then `pip install -e ".[e2b]"`.
+> On a restricted network, `git clone https://github.com/aliyun-fc/mini-swe-agent` first, then `git checkout v2.4.6-fc.1`, then `pip install -e ".[e2b]"`.
 
 ## Execution environment: use the built-in `e2b`
 
@@ -106,7 +104,7 @@ environment:
 
 What it does: the first time an image is used it is registered as a persistent template (`Template.build`) and reused from cache afterwards; each instance gets its own sandbox, commands are dispatched through `commands.run`, and the patch comes back over the official submission protocol.
 
-**Agent Sandbox differs from local docker in five ways, and the built-in class handles all of them.** You will still hit them if you implement your own backend or debug a failing run:
+Agent Sandbox differs from local docker in five ways, and the built-in class handles all of them. You will still hit them if you implement your own backend or debug a failing run:
 
 | Difference | Consequence if unhandled | How it is handled |
 | --- | --- | --- |
@@ -142,8 +140,8 @@ model:
   cost_tracking: ignore_errors   # self-hosted models are not in the price table, otherwise cost tracking raises
 agent:
   # The official swebench.yaml value. Measured at 40: three of four instances hit the limit,
-  # and one of them had already fixed the bug and was a single step short of submitting --
-  # scored 0. A low step limit understates scores systematically
+  # and one of them had already fixed the bug and was a single step short of submitting,
+  # scored 0. A low step limit understates scores across the board
   step_limit: 250
   # Steps do not bound time: measured, one instance was still going after 35 minutes, holding
   # a concurrency slot and a billed sandbox. The field is wall_time_limit_seconds -- a
@@ -152,7 +150,7 @@ agent:
   cost_limit: 0     # a self-hosted model is not in the price table, so a cost ceiling is meaningless
 ```
 
-`require_existing_cwd` defaults to off (matching upstream); **turn it on for every repository-based benchmark** -- it is the only net under this class of silent failure.
+The `require_existing_cwd` option itself defaults to off (matching upstream), but the batch entry point `mini-extra swebench` turns it on automatically for e2b; a single-instance script has to set it. **Turn it on for every repository-based benchmark** -- it is the only net under this class of silent failure.
 
 ## Drive the agent: `run.py`
 
@@ -207,7 +205,7 @@ print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(p
 
 The grading criteria match SWE-bench upstream: every `FAIL_TO_PASS` case passes and no `PASS_TO_PASS` case regresses.
 
-**Grade in a brand-new sandbox; never reuse the agent's worker sandbox.** After the agent finishes, that sandbox is no longer the original scene—it may have installed extra packages (which can make tests pass by accident), modified test files or `conftest.py`, or left temporary files behind. Sandbox images are immutable, so simply creating a new sandbox from the same image brings the repository back to its original state, with no need to clean up after the agent. The template is already cached, so the second sandbox starts in a few seconds.
+Grade in a brand-new sandbox, never in the agent's worker sandbox. After the agent finishes, that sandbox is no longer the original scene: it may have installed extra packages (which can make tests pass by accident), modified test files or `conftest.py`, or left temporary files behind. Sandbox images are immutable, so simply creating a new sandbox from the same image brings the repository back to its original state, with no need to clean up after the agent. The template is already cached, so the second sandbox starts in a few seconds.
 
 ```python
 # grade.py
@@ -356,7 +354,7 @@ finally:
 
 ```bash
 .venv/bin/python grade.py --gold
-# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.64s"}
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed, 21 warnings in 0.71s"}
 ```
 
 If the self-check fails, this pipeline itself is broken (image, working directory, how test cases are introduced, case-name matching), and any score the agent gets is meaningless. Once it passes, run the agent and grade its output:
@@ -367,7 +365,7 @@ If the self-check fails, this pipeline itself is broken (image, working director
 #  "template": "fc-e2b-registry-…-46a01131", "sandbox_id": "sbx-…"}
 
 .venv/bin/python grade.py --patch out.patch
-# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.75s"}
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed, 21 warnings in 0.76s"}
 ```
 
 The first run registers the image as a template (idempotent; later runs hit the cache in 1-2 seconds). Models are non-deterministic, so `model_calls` and `patch_bytes` will vary.
@@ -427,18 +425,18 @@ Two things bite here:
 
 Results land in `results/preds.json` (`instance_id → model_patch`), and each instance also gets a trajectory recording its `sandbox_id` and `template`, so any run can be traced back to the exact execution.
 
-**A single batch may only contain images from one family.** `cwd` and `run_as_user` are shared across the whole batch in the config, while different benchmarks use different working directories (see "What to change for another benchmark"), so run one batch per image family with its own `demo.yaml`.
+A single batch may only contain images from one family: `cwd` and `run_as_user` are shared across the whole batch in the config, while different benchmarks use different working directories (see "What to change for another benchmark"), so run one batch per image family with its own `demo.yaml`.
 
 Of the four orchestration constraints, the built-in entry point already satisfies the first two; the last two are still yours to set:
 
 | Constraint | Status |
 | --- | --- |
 | One failing instance must not sink the batch | Built in: the exception is recorded as that instance's `exit_status` and the rest continue |
-| Sandboxes must always be reclaimed | Built in, on five paths: normal completion, an agent exception, a failing startup command, a dropped environment object, and a `SIGTERM`. The last one releases **immediately, without waiting for the in-flight instances** -- the scheduler follows its own window with SIGKILL (Kubernetes defaults to 30s, less than one agent step on a large repository), so waiting first risks never sending the kill requests. Their work is lost, but `preds.json` is written per instance, so re-running the same command only picks up the ones that did not finish. Relying on the TTL costs extra and holds concurrency slots |
+| Sandboxes must always be reclaimed | Built in, on five paths: normal completion, an agent exception, a failing startup command, a dropped environment object, and a `SIGTERM`. The last one releases **immediately, without waiting for the in-flight instances** -- the scheduler follows its own window with SIGKILL (Kubernetes defaults to 30s, less than one agent step on a large repository), so waiting first risks never sending the kill requests. The kills go out concurrently under a 20-second ceiling; size your grace period from that. Their work is lost, but `preds.json` is written per instance, so re-running the same command only picks up the ones that did not finish. Relying on the TTL costs extra and holds concurrency slots |
 | Set limits on the agent side | Yours: `step_limit`, `cost_limit`, `wall_time_limit_seconds`, or a single hard task can burn the whole batch's budget. **A misspelled field name raises nothing and is silently ignored** |
 | Tier your output truncation | Yours: 15k characters for the terminal, 20k for a single file, 50k for a batch, so the context is not swamped |
 
-**Keep concurrency around 6.** Concurrent first builds of one image are already serialised per template name by the built-in environment class (see "Execution environment"), so that is not yours to handle; one reason to hold concurrency down remains — large images can time out during sandbox creation at a concurrency of 10, and a serial retry usually succeeds. So when sandbox creation fails, retry once serially before declaring an instance unusable, otherwise concurrency pressure gets misrecorded as an image problem.
+Keep concurrency around 6. Concurrent first builds of one image are already serialised per template name by the built-in environment class (see "Execution environment"), so that is not yours to handle. One reason to hold concurrency down remains: large images can time out during sandbox creation at a concurrency of 10, and a serial retry usually succeeds. So when sandbox creation fails, retry once serially before declaring an instance unusable, otherwise concurrency pressure gets misrecorded as an image problem.
 
 ### Decouple grading from the agent
 
@@ -454,13 +452,13 @@ The agent stage only produces `preds.json`; the grading stage reads it and grade
 | Case names passed to pytest as command-line arguments | Names contain spaces and brackets, giving "not found" and ultimately "no tests ran" | Run whole test files, then match by name against the report |
 | A grading command that timed out with empty output scored as "tests failed" | A large test suite times out under high concurrency and the instance is recorded as zero passes; a serial re-run passes everything | When output is empty or the exit code is abnormal, mark it as **grading not completed**, exclude it from the denominator, and retry at lower concurrency |
 
-The last one is the easiest to overlook and the most harmful: it reads an infrastructure failure as poor model capability, and the more test cases a repository has the more likely it is to trigger—so the evaluation conclusion is systematically depressed without any error surfacing.
+The last one is the easiest to miss. It reads an infrastructure failure as poor model capability, and the more test cases a repository has the more likely it is to trigger, so scores come out lower across the board without any error surfacing.
 
 ## Ready-made evaluation images in the Shanghai region
 
 The China (Shanghai) region comes preloaded with images for a range of open-source evaluation sets, with the repository scene and dependencies already in place: take the image address, build a template, and use it—no need to move anything yourself. All image addresses share the prefix `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`.
 
-**The image solves only the environment.** For a task to enter evaluation, three things must all be present: the image starts, the task metadata (problem statement and test cases) is obtainable, and the grading method is implemented. By those three, these images fall into three categories:
+The image solves only the environment. For a task to enter evaluation, three things must all be present: the image starts, the task metadata (problem statement and test cases) is obtainable, and the grading method is implemented. By those three, these images fall into three categories:
 
 | Category | Images | State | What you need to do |
 | --- | --- | --- | --- |
@@ -469,7 +467,7 @@ The China (Shanghai) region comes preloaded with images for a range of open-sour
 | 3. Images only | **20,755** | Images start, but the task-to-image correspondence cannot be established | Usable only as repository environments with dependencies preinstalled; grading requires finding metadata yourself |
 | Total | **77,704** | | |
 
-**If you just want to get something running, take category 1.** Category 2 is listed because the images and problem statements are complete and only the grading implementation is missing; category 3 is listed for full disclosure, but it cannot be graded automatically.
+If you just want to get something running, take category 1. Category 2 is listed because the images and problem statements are complete and only the grading implementation is missing; category 3 is listed for full disclosure, and it cannot be graded automatically.
 
 > The metadata datasets are hosted on HuggingFace, which **may not be reachable from inside the sandbox**. Export the fields you need (`problem_statement` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch`) to local files from an environment with outbound access, then ship them with the evaluation task. Do not fetch them on the fly during batch evaluation—one fetch failure stalls the whole batch.
 
@@ -488,7 +486,7 @@ All three grade on `FAIL_TO_PASS` + `PASS_TO_PASS`, but **they introduce test ca
 - **SWE-Gym and SWE-rebench V2 (python)**: identical to this guide's `grade.py`—apply `test_patch` to introduce the cases, then run pytest. The python subset of SWE-rebench V2 uses `pytest --no-header` throughout, so the criteria line up directly; switching to it only requires changing the image address and probing the working directory at runtime.
 - **Scale-SWE**: there is **no `test_patch`**. `FAIL_TO_PASS` points at an injected new test file whose content is in the `f2p_script` field (or a `f2p_patch` applied to an existing test file), and the reset is handled by `pre_commands`. You need to change the part of `grade.py` that introduces test cases, and the order matters—`git clean -fd` inside `pre_commands` deletes untracked files, so writing the test before resetting throws it away.
 
-**Repository diversity varies a lot**: Scale-SWE covers 1,180 repositories and the SWE-rebench V2 python subset 689, while SWE-Gym has only 11 (dominated by pandas, moto, and a few others). Look at the "Repos" column when picking a baseline for cross-repository generalization—SWE-Gym alone has a ceiling, since no matter how many tasks there are they concentrate in the same few repositories.
+Repository diversity varies a lot: Scale-SWE covers 1,180 repositories and the SWE-rebench V2 python subset 689, while SWE-Gym has only 11 (dominated by pandas, moto, and a few others). Look at the "Repos" column when picking a baseline for cross-repository generalization. SWE-Gym alone has a ceiling, since no matter how many tasks there are they concentrate in the same few repositories.
 
 ### 2. Metadata complete, grading to be implemented: 27,837 images
 
@@ -504,9 +502,9 @@ The images below start, the problem statements are obtainable, and the join keys
 | Terminal-Bench 2.x | **89** | Terminal tasks (not code fixes): complete an instruction in a shell; no git repository and no patch | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | The task directory name is the image tag | Runs the task's own `tests/test.sh`, so **you do not write the grader**; but the agent loop has to change—these tasks produce no patch |
 | SWE-Atlas QnA | **11** | Repository question answering, produces no patch | [ScaleAI/SWE-Atlas-QnA](https://huggingface.co/datasets/ScaleAI/SWE-Atlas-QnA) | `docker_image` | Scored against a rubric, which needs a model as judge rather than a test run |
 
-SWE-smith deserves a note of its own: **its image count and its task count are not the same thing.** The 363 are environment images (one per repository), and they carry 79,418 upstream tasks selected by checking out branches—once task selection is wired up, it is the largest source of tasks in this whole collection.
+SWE-smith's image count and its task count are not the same thing. The 363 are environment images, one per repository, and they carry 79,418 upstream tasks selected by checking out branches. Once task selection is wired up, it is the largest source of tasks in this collection.
 
-**Multi-language benchmarks must route grading per language.** Take SWE-rebench V2: case-name shapes follow the test framework—python uses pytest node ids (`tests/test_x.py::TestA::test_b`), TS / JS use jest and mocha case descriptions, and Java uses test class names. Applying one pytest parsing path to every language marks **every non-python instance as failed**. The `swerebenchv2-languages.tsv` list (id → language) can be used to filter. Test commands are more concentrated than languages: Go is always `go test`, Rust always `cargo test`, Java is either Maven or Gradle, and JS / TS are npm-based jest / mocha / vitest and friends—four or five groups of parsers cover most of it. The same applies to SWE-bench Pro, routed by `repo_language`.
+Multi-language benchmarks must route grading per language. Take SWE-rebench V2: case-name shapes follow the test framework. Python uses pytest node ids (`tests/test_x.py::TestA::test_b`), TS / JS use jest and mocha case descriptions, and Java uses test class names. Applying one pytest parsing path to every language marks **every non-python instance as failed**. The `swerebenchv2-languages.tsv` list (id → language) can be used to filter. Test commands are more concentrated than languages: Go is always `go test`, Rust always `cargo test`, Java is either Maven or Gradle, and JS / TS are npm-based jest / mocha / vitest and friends, so four or five groups of parsers cover most of it. The same applies to SWE-bench Pro, routed by `repo_language`.
 
 ### 3. Images only: metadata must be matched yourself, 20,755 images
 
@@ -603,7 +601,7 @@ The last shape has to be probed inside the container:
 for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done   # e.g. yields /cfn-lint
 ```
 
-**Write the probed value back into `demo.yaml`.** Resolution happens once; `run.py` and `grade.py` only accept concrete values — in a batch run this belongs to the resolution layer, done once before the run starts rather than per instance. The acceptance script below accepts `cwd: auto` and probes it for you, printing what it found.
+Write the probed value back into `demo.yaml`. Resolution happens once, and `run.py` and `grade.py` only accept concrete values. In a batch run this belongs to the resolution layer, done once before the run starts rather than per instance. The acceptance script below accepts `cwd: auto` and probes it for you, printing what it found.
 
 The image address and working directory must be changed **as a pair**. With `require_existing_cwd: true` set, getting it wrong fails at startup:
 
@@ -647,7 +645,7 @@ Once an image is onboarded, do not stop acceptance testing at "the sandbox start
 
 The script below implements those four steps: one sandbox, no model tokens. When sampling tens or hundreds of images it is an order of magnitude cheaper than `grade.py --gold`, which has to apply a patch and run whole test files. With `cwd: auto` it probes the repository directory inside the sandbox (see "What to change for another benchmark").
 
-**It only fits Python benchmarks** — the test executor is hard-coded to `python -m pytest` and case names are parsed as pytest node ids. A Go / Java / JS benchmark needs both changed, and so does the grader (see "Multi-language benchmarks need per-language grading").
+It only fits Python benchmarks: the test executor is hard-coded to `python -m pytest` and case names are parsed as pytest node ids. A Go / Java / JS benchmark needs both changed, and so does the grader (see "Multi-language benchmarks need per-language grading").
 
 ```python
 # preflight.py
@@ -772,7 +770,7 @@ Three things to watch when reading that output:
 | Go installed in `/usr/local/go/bin`, not on the default PATH | A perfectly good Go repository image is judged to have "no test executor" |
 | Java projects ship `./gradlew` instead of a global mvn/gradle | A perfectly good image is misjudged |
 
-The script above reads the same configuration as `grade.py`, so the first misjudgement cannot happen by construction — which is the reason not to let an acceptance script assemble its own environment variables.
+The script above reads the same configuration as `grade.py`, so the first misjudgement cannot happen. That is the reason not to let an acceptance script assemble its own environment variables.
 
 ## Production recommendations
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
@@ -71,7 +71,7 @@ The example task in this guide is `getmoto__moto-7365`: moto's DynamoDB `update_
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
 .venv/bin/pip install pyyaml \
-  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@9611467952032e26b190a2cdde76daff4f37e1ca"
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@571ea037897d8eb332a83c48319926505b4a05a5"
 
 # The SDK derives the endpoint from the domain (https://api.<domain>); no separate api_url needed
 export E2B_API_KEY="<your-e2b-api-key>"
@@ -434,7 +434,7 @@ Of the four orchestration constraints, the built-in entry point already satisfie
 | Constraint | Status |
 | --- | --- |
 | One failing instance must not sink the batch | Built in: the exception is recorded as that instance's `exit_status` and the rest continue |
-| Sandboxes must always be reclaimed | Built in, on five paths: normal completion, an agent exception, a failing startup command, a dropped environment object, and a `SIGTERM` (which gives the in-flight instances a grace period to submit, then releases their environments). Relying on the TTL costs extra and holds concurrency slots |
+| Sandboxes must always be reclaimed | Built in, on five paths: normal completion, an agent exception, a failing startup command, a dropped environment object, and a `SIGTERM`. The last one releases **immediately, without waiting for the in-flight instances** -- the scheduler follows its own window with SIGKILL (Kubernetes defaults to 30s, less than one agent step on a large repository), so waiting first risks never sending the kill requests. Their work is lost, but `preds.json` is written per instance, so re-running the same command only picks up the ones that did not finish. Relying on the TTL costs extra and holds concurrency slots |
 | Set limits on the agent side | Yours: `step_limit`, `cost_limit`, `wall_time_limit_seconds`, or a single hard task can burn the whole batch's budget. **A misspelled field name raises nothing and is silently ignored** |
 | Tier your output truncation | Yours: 15k characters for the terminal, 20k for a single file, 50k for a batch, so the context is not swamped |
 
@@ -780,7 +780,7 @@ The script above reads the same configuration as `grade.py`, so the first misjud
 - **Restrict outbound traffic**: set `deny_out: ["0.0.0.0/0"]` on the sandbox plus an allowlist, opening only code hosting, image registries, and the model endpoint. Note that domain filtering only applies to the Host header on port 80 and SNI on 443—other ports need CIDRs; `allow` takes precedence over `deny`; and a rejected TCP connection looks successful from inside the sandbox, so judge by the application-layer response.
 - **Two layers of timeout**: distinguish the sandbox TTL from the per-command timeout. Do not use `timeout=0`, since a stuck process will not recover on its own; for long tasks use `on_timeout="pause"` together with `auto_resume`, which neither bills nor holds a concurrency slot while paused.
 - **The patch is the only outbound artifact**: the sandbox needs only read access to the repository. Once the orchestration layer has the patch, it rebuilds a clean repository, verifies it, runs the tests, and only then creates a PR. Do not push or open PRs from inside the sandbox.
-- **Destroy promptly**: call `sandbox.kill()` in `finally`; per-second billing only counts running time. But neither `finally` nor `atexit` covers a process cut short by a signal — a batch entry point has to turn `SIGTERM` into a bounded graceful shutdown (the built-in `mini-extra swebench` does), and whatever else you do, set the sandbox TTL to the largest waste you are willing to accept: however the process dies, the platform reclaims the sandbox when the TTL expires, and that is the last line of defence.
+- **Destroy promptly**: call `sandbox.kill()` in `finally`; per-second billing only counts running time. But neither `finally` nor `atexit` covers a process cut short by a signal — a batch entry point has to release the sandboxes immediately on `SIGTERM` (the built-in `mini-extra swebench` does), and whatever else you do, set the sandbox TTL to the largest waste you are willing to accept: however the process dies, the platform reclaims the sandbox when the TTL expires, and that is the last line of defence.
 - **Keep it traceable**: record `sandbox_id`, the template name, and the source image address on every trajectory (the built-in `e2b` environment class's `serialize()` already includes all three) for reproduction and troubleshooting.
 - **Cost accounting**: record start and end times in the orchestration layer and read the specification via `get_info()` to compute cost yourself.
 

--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
@@ -71,14 +71,26 @@ The example task in this guide is `getmoto__moto-7365`: moto's DynamoDB `update_
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
 .venv/bin/pip install pyyaml \
-  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@v2.4.6-fc.1"
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@9611467952032e26b190a2cdde76daff4f37e1ca"
 
 # The SDK derives the endpoint from the domain (https://api.<domain>); no separate api_url needed
 export E2B_API_KEY="<your-e2b-api-key>"
 export E2B_DOMAIN="cn-shanghai.e2b.fc.aliyuncs.com"
-# The model credential is used in the orchestration layer only; it never enters the sandbox
-export MODEL_API_KEY="<your-model-api-key>"
+# The model credential is used in the orchestration layer only; it never enters the sandbox.
+# The variable name follows from the `openai/` prefix on `model_name` below -- put your
+# OpenAI-compatible endpoint's key in it. Using the name LiteLLM recognises is what lets the
+# single-task scripts and the batch entry point share one credential
+export OPENAI_API_KEY="<your-model-api-key>"
 export MSWEA_CONFIGURED=true MSWEA_SILENT_STARTUP=1
+```
+
+**Pin the full commit SHA, never a branch.** A branch moves with every later commit, so what
+you install today and what you install next week are not the same code, and evaluation results
+stop being reproducible. Check what you got:
+
+```bash
+.venv/bin/python -c "import minisweagent; print(minisweagent.__version__)"
+# 2.4.6+fc.1
 ```
 
 > On a restricted network, `git clone https://github.com/aliyun-fc/mini-swe-agent` first, then `pip install -e ".[e2b]"`.
@@ -94,19 +106,21 @@ environment:
 
 What it does: the first time an image is used it is registered as a persistent template (`Template.build`) and reused from cache afterwards; each instance gets its own sandbox, commands are dispatched through `commands.run`, and the patch comes back over the official submission protocol.
 
-**Agent Sandbox differs from local docker in four ways.** The built-in environment class already handles them, but you need to know they exist -- you will hit them if you implement your own backend or debug a failing run:
+**Agent Sandbox differs from local docker in five ways, and the built-in class handles all of them.** You will still hit them if you implement your own backend or debug a failing run:
 
 | Difference | Consequence if unhandled | How it is handled |
 | --- | --- | --- |
-| `docker run -w` creates the working directory; a sandbox does not | A missing directory fails at process creation **without an exit code**, so every command is recorded as an infrastructure error and the agent burns a whole run for nothing | `mkdir -p <cwd>` right after the sandbox starts |
-| git refuses to operate when the repository owner differs from the running user | `fatal: detected dubious ownership`; `git diff` produces nothing, which means no patch can be submitted | `git config --global --add safe.directory <cwd>` at startup |
-| A non-zero exit is raised as an exception by the SDK | Failing tests and empty `grep` results -- **normal signals** -- get treated as execution faults and the agent never sees the real output | Catch it, convert to `returncode`, and hand back stdout/stderr verbatim |
-| Evaluation images own the repository as root and usually ship without `sudo` | Running as the template's default non-root user leaves the agent unable to even write a file (Permission denied) | Set `run_as_user: root` (which matches the official docker harness) |
+| A sandbox does not create the working directory (`docker run -w` does) | The failure lands at process creation **without an exit code**, so every command is recorded as an infrastructure error | `mkdir -p <cwd>` at startup. But probe first and report: otherwise a misconfigured working directory is silently created empty, the agent submits an empty patch and scores 0; `require_existing_cwd: true` turns that into a startup failure |
+| git refuses to operate when the repository owner differs from the running user | `dubious ownership`; `git diff` produces nothing, so no patch can be submitted | `git config --global --add safe.directory <cwd>` at startup |
+| A non-zero exit is raised as an exception by the SDK | Failing tests and empty `grep` results -- **normal signals** -- get treated as execution faults | Convert to `returncode`, hand back the output verbatim |
+| The timeout exception carries no stdout/stderr | Thousands of lines printed before the deadline are lost, and a slow test suite on a large repository is exactly what times out | Collect through the streaming callbacks; hand back what was produced and name the timeout |
+| Evaluation images own the repository as root and usually ship without `sudo` | A non-root user cannot even write a file | `run_as_user: root` (matching the official docker harness) |
 
-Two things to keep in mind about template builds, especially when onboarding your own images:
+Three more things about template builds, which matter most when onboarding your own images or writing your own backend:
 
-- **The template name must be derived from the image address *and* the resource spec.** The built-in implementation hashes "image address + `cpu_count`/`memory_mb`": an existing template is reused as-is and never rebuilt, so a name that omits the spec would silently hand you a template built with the old memory setting.
-- **A given template name can only be built once.** After a failed build the name stays in `CREATE_FAILED` and building it again returns 409. So derive the name from content instead of manually bumping a version suffix.
+- **The template name is derived from the image address *and* the resource spec.** The built-in implementation hashes "image address + `cpu_count`/`memory_mb`"; a name that omits the spec silently hands you a template built with the old memory setting.
+- **Concurrent first builds of one image have to be serialised.** Otherwise they all find no template and all build the same alias: measured, 4 threads produced 3 failures (`409 ... resource conflict`), and each loser left an orphan template record behind.
+- **A failed name does not heal itself.** The alias endpoint carries no status, so the existence check keeps saying yes while `Sandbox.create` refuses the template and a second build is rejected outright. Recovery has to branch on the real status: wait if someone else is building, delete and rebuild only for `error` or genuinely missing (deletion is asynchronous, so wait for the alias to disappear first). Derive the name from content -- never bump a version suffix by hand.
 
 ## Configuration: always change the image and the working directory together
 
@@ -116,6 +130,7 @@ environment:
   environment_class: e2b
   image: fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510
   cwd: /testbed          # must be changed together with the image, see "What to change for another benchmark"
+  require_existing_cwd: true   # fail at startup if cwd is not in the image, instead of creating it empty and scoring 0
   run_as_user: root
   timeout: 120
   memory_mb: 8192        # evaluation images are large; the 2048 default will not start
@@ -126,15 +141,24 @@ model:
     temperature: 0.0
   cost_tracking: ignore_errors   # self-hosted models are not in the price table, otherwise cost tracking raises
 agent:
-  step_limit: 40
-  cost_limit: 0
+  # The official swebench.yaml value. Measured at 40: three of four instances hit the limit,
+  # and one of them had already fixed the bug and was a single step short of submitting --
+  # scored 0. A low step limit understates scores systematically
+  step_limit: 250
+  # Steps do not bound time: measured, one instance was still going after 35 minutes, holding
+  # a concurrency slot and a billed sandbox. The field is wall_time_limit_seconds -- a
+  # misspelling raises nothing and is silently ignored
+  wall_time_limit_seconds: 1800
+  cost_limit: 0     # a self-hosted model is not in the price table, so a cost ceiling is meaningless
 ```
+
+`require_existing_cwd` defaults to off (matching upstream); **turn it on for every repository-based benchmark** -- it is the only net under this class of silent failure.
 
 ## Drive the agent: `run.py`
 
 ```python
 # run.py
-import argparse, json, os
+import argparse, json
 from pathlib import Path
 
 import yaml
@@ -158,11 +182,11 @@ cfg = recursive_merge(official, yaml.safe_load(a.config.read_text()))
 
 env = get_environment(cfg["environment"])      # environment_class: e2b
 
-model_cfg = dict(cfg["model"])
-model_cfg.setdefault("model_kwargs", {})
-model_cfg["model_kwargs"]["api_key"] = os.environ["MODEL_API_KEY"]   # orchestration layer only
-
-agent = DefaultAgent(LitellmModel(**model_cfg), env,
+# No api_key injection here: LiteLLM resolves it from the standard environment variable
+# (`openai/` prefix -> OPENAI_API_KEY), which is what lets this script and the official batch
+# entry point share one credential. A variable only this script understands would make a batch
+# run configured the same way end in Missing credentials.
+agent = DefaultAgent(LitellmModel(**cfg["model"]), env,
                      **recursive_merge(cfg.get("agent", {}), {"output_path": a.traj}))
 try:
     result = agent.run(a.task.read_text())
@@ -172,7 +196,8 @@ finally:
 patch = result.get("submission") or ""
 a.output.write_text(patch)
 print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(patch),
-                  "model_calls": agent.n_calls, "sandbox_id": env.sandbox.sandbox_id},
+                  "model_calls": agent.n_calls, "template": env.template,
+                  "sandbox_id": env.sandbox.sandbox_id},
                  ensure_ascii=False))
 ```
 
@@ -191,13 +216,9 @@ from collections import Counter
 from pathlib import Path
 
 import yaml
-from minisweagent.environments.extra.e2b import E2BEnvironment
-
-# In evaluation images, python/pytest usually live in a conda environment activated via BASH_ENV.
-# Without these variables, `python -m pytest` falls back to conda base and reports
-# "No module named pytest".
-GRADE_ENV = {"PAGER": "cat", "MANPAGER": "cat", "PIP_PROGRESS_BAR": "off",
-             "TQDM_DISABLE": "1", "BASH_ENV": "/root/.bashrc"}
+from minisweagent.config import builtin_config_dir
+from minisweagent.environments import get_environment
+from minisweagent.utils.serialize import recursive_merge
 
 def as_list(v):
     if isinstance(v, str):
@@ -219,9 +240,9 @@ def patched_files(diff):    # files touched by a patch
 
 p = argparse.ArgumentParser()
 p.add_argument("--instance", type=Path, default=Path("instance.json"))
+p.add_argument("--config", type=Path, default=Path("demo.yaml"))
 p.add_argument("--patch", type=Path)
 p.add_argument("--gold", action="store_true", help="self-check using the dataset's own patch")
-p.add_argument("--cwd", default="/testbed")
 a = p.parse_args()
 
 inst = json.loads(a.instance.read_text())[0]
@@ -229,11 +250,18 @@ patch = inst["patch"] if a.gold else a.patch.read_text()
 if not patch.strip():
     raise SystemExit(json.dumps({"resolved": False, "reason": "empty patch"}))
 
-image = yaml.safe_load(Path("demo.yaml").read_text())["environment"]["image"]
+# The same layering as run.py: image, working directory and environment variables all come
+# from one place (the acceptance script below reads it too). A grader that assembles its own
+# environment drifts away from the agent's -- changing cwd in the config while the grader keeps
+# the old value is the classic case; and dropping the official BASH_ENV makes a healthy image
+# report "No module named pytest", which reads as an unusable image.
+cfg = recursive_merge(
+    yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text()),
+    yaml.safe_load(a.config.read_text()),
+)
 f2p, p2p = as_list(inst["FAIL_TO_PASS"]), as_list(inst["PASS_TO_PASS"])
 
-env = E2BEnvironment(image=image, cwd=a.cwd, run_as_user="root",
-                     timeout=900, memory_mb=8192, env=GRADE_ENV)
+env = get_environment(dict(cfg["environment"], timeout=1800))
 try:
     # 1) Apply the patch under evaluation; failing to apply is itself a result
     env.sandbox.files.write("/tmp/model.patch", patch)
@@ -264,13 +292,15 @@ try:
     report = res["output"]
 
     # When the grading command produces nothing, it must not be scored as "tests failed" —
-    # that would charge an infrastructure failure to the model's score. Command timeouts and
-    # empty output under high concurrency are a real scenario and must be told apart from
-    # genuine test failures.
+    # that would charge an infrastructure failure to the model's score. Command timeouts under
+    # high concurrency are a real scenario. Whatever was printed before the deadline is kept,
+    # which tells you whether it stalled during collection or on a particular case.
     if not report.strip() or res["returncode"] == -1:
         raise SystemExit(json.dumps({"resolved": False, "graded": False,
-                                     "reason": "grading did not complete (no output, likely a "
-                                               "timeout); lower the concurrency and retry"},
+                                     "reason": "grading did not complete (likely a timeout); "
+                                               "lower the concurrency and retry",
+                                     "exception_info": res.get("exception_info", ""),
+                                     "partial_output": report.strip()[-300:]},
                                     ensure_ascii=False))
 
     passed = Counter(re.findall(r"^PASSED (\S+)", report, flags=re.M))
@@ -322,21 +352,22 @@ finally:
   "patch": "diff --git a/moto/... (the dataset's own correct patch, used only to self-check the grader)"}]
 ```
 
-**Self-check the grader before running the agent.** Put the dataset's own correct patch through grading; it must come out `resolved: true`:
+**Self-check the grader before running the agent.** Put the dataset's own correct patch through grading; it must come out `resolved: true`, and it costs no model tokens:
 
 ```bash
 .venv/bin/python grade.py --gold
-# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.58s"}
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.64s"}
 ```
 
-If the self-check fails, the grading pipeline itself is broken (image, how test cases are introduced, case-name matching), and any score the agent gets is meaningless. Once it passes, run the agent and grade its output:
+If the self-check fails, this pipeline itself is broken (image, working directory, how test cases are introduced, case-name matching), and any score the agent gets is meaningless. Once it passes, run the agent and grade its output:
 
 ```bash
 .venv/bin/python run.py
-# {"exit_status": "Submitted", "patch_bytes": 1839, "model_calls": 31, "sandbox_id": "sbx-…"}
+# {"exit_status": "Submitted", "patch_bytes": 1843, "model_calls": 32,
+#  "template": "fc-e2b-registry-…-46a01131", "sandbox_id": "sbx-…"}
 
 .venv/bin/python grade.py --patch out.patch
-# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.76s"}
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.75s"}
 ```
 
 The first run registers the image as a template (idempotent; later runs hit the cache in 1-2 seconds). Models are non-deterministic, so `model_calls` and `patch_bytes` will vary.
@@ -354,7 +385,9 @@ Evaluation image tags usually carry build-batch information (for example `..._20
 import json
 from pathlib import Path
 
-IMAGES = json.load(open("image-index.json"))      # instance_id → image address
+# The manifests are tab-separated text; the first two columns are instance_id and the image
+# address (see "Getting the image manifests")
+IMAGES = dict(l.rstrip("\n").split("\t")[:2] for l in open("swegym-images.tsv"))
 instances = json.loads(Path("instances.json").read_text())
 
 out = Path("dataset"); out.mkdir(exist_ok=True)
@@ -381,6 +414,17 @@ Resolution is pure table lookup with no network or sandbox cost, so it can be do
 
 `-c` is a **list**, and supplying your own config displaces the default, so the official `swebench.yaml` must be listed first -- passing only `-c demo.yaml` fails with `ValidationError: system_template Field required` because the prompts are missing. The `image` key in `demo.yaml` can be left out here; it is injected per instance.
 
+Two things bite here:
+
+- **Credentials have to use the variable name LiteLLM recognises.** The batch entry point injects
+  no api_key; LiteLLM resolves it per provider (`openai/...` reads `OPENAI_API_KEY`). A name it
+  does not know means **three retries, 60 seconds apart**, before it reports `Missing credentials`.
+- **The batch's exit code is always 0**, even when every instance fails -- the exception goes into
+  each instance's `exit_status` and the batch runs to completion (which is what you want, see the
+  table below). The cost is that an outer wrapper cannot judge the run by its exit code: check
+  whether `model_patch` in `preds.json` is empty. Measured with three instances all failing on a
+  credential error: exit code 0, all three entries present, every patch empty.
+
 Results land in `results/preds.json` (`instance_id → model_patch`), and each instance also gets a trajectory recording its `sandbox_id` and `template`, so any run can be traced back to the exact execution.
 
 **A single batch may only contain images from one family.** `cwd` and `run_as_user` are shared across the whole batch in the config, while different benchmarks use different working directories (see "What to change for another benchmark"), so run one batch per image family with its own `demo.yaml`.
@@ -390,11 +434,11 @@ Of the four orchestration constraints, the built-in entry point already satisfie
 | Constraint | Status |
 | --- | --- |
 | One failing instance must not sink the batch | Built in: the exception is recorded as that instance's `exit_status` and the rest continue |
-| Sandboxes must always be reclaimed | Built in: normal completion, an agent exception, and a failing startup command all `kill`. Relying on the TTL costs extra and holds concurrency slots |
-| Set limits on the agent side | Yours: `step_limit`, `cost_limit`, `wall_time_limit`, or a single hard task can burn the whole batch's budget |
+| Sandboxes must always be reclaimed | Built in, on five paths: normal completion, an agent exception, a failing startup command, a dropped environment object, and a `SIGTERM` (which gives the in-flight instances a grace period to submit, then releases their environments). Relying on the TTL costs extra and holds concurrency slots |
+| Set limits on the agent side | Yours: `step_limit`, `cost_limit`, `wall_time_limit_seconds`, or a single hard task can burn the whole batch's budget. **A misspelled field name raises nothing and is silently ignored** |
 | Tier your output truncation | Yours: 15k characters for the terminal, 20k for a single file, 50k for a batch, so the context is not swamped |
 
-**Keep concurrency around 6.** Large images can time out during sandbox creation at a concurrency of 10, and a serial retry usually succeeds; so when sandbox creation fails, retry once serially before declaring an instance unusable—otherwise concurrency pressure gets misrecorded as an image problem.
+**Keep concurrency around 6.** Concurrent first builds of one image are already serialised per template name by the built-in environment class (see "Execution environment"), so that is not yours to handle; one reason to hold concurrency down remains — large images can time out during sandbox creation at a concurrency of 10, and a serial retry usually succeeds. So when sandbox creation fails, retry once serially before declaring an instance unusable, otherwise concurrency pressure gets misrecorded as an image problem.
 
 ### Decouple grading from the agent
 
@@ -553,15 +597,22 @@ Evaluation images from different sources are **not homogeneous**, starting with 
 | Single application directory | `/app` | Fixed value |
 | Original repository name at the root | For example `/OpenTripPlanner`, `/ApplicationInsights-node.js` | **Cannot be derived from the image tag** (tags are lowercase, directories keep their original case); must be probed at runtime |
 
-The last shape has to be probed inside the container, for example:
+The last shape has to be probed inside the container:
 
 ```bash
-for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
+for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done   # e.g. yields /cfn-lint
 ```
 
-Making that an `auto` option in the resolution layer is more reliable than enumerating entries in a config.
+**Write the probed value back into `demo.yaml`.** Resolution happens once; `run.py` and `grade.py` only accept concrete values — in a batch run this belongs to the resolution layer, done once before the run starts rather than per instance. The acceptance script below accepts `cwd: auto` and probes it for you, printing what it found.
 
-The image address and working directory must be changed **as a pair**, and getting it wrong **raises no error**: a working directory that does not exist is created as an empty one, the agent runs a full loop inside it, submits an empty patch, and scores zero. So the first thing to do after switching benchmarks is to confirm the target repository really is at that working directory (`git rev-parse HEAD` returns something).
+The image address and working directory must be changed **as a pair**. With `require_existing_cwd: true` set, getting it wrong fails at startup:
+
+```text
+RuntimeError: Working directory /testbed was not in the image and has been created empty.
+For a repository-based task this means it is misconfigured: …
+```
+
+**Without that switch this error is not reported at all**: a working directory that does not exist is created as an empty one, the agent runs a full loop inside it, submits an empty patch, and scores zero. So the first thing to do after switching benchmarks is to run `grade.py --gold` with the dataset's own patch — it confirms, among other things, that the target repository really is at that working directory.
 
 Two practices to avoid:
 
@@ -594,6 +645,125 @@ Once an image is onboarded, do not stop acceptance testing at "the sandbox start
 3. The test executor for that language is available.
 4. Test cases can actually be collected (for example `pytest --collect-only -q`).
 
+The script below implements those four steps: one sandbox, no model tokens. When sampling tens or hundreds of images it is an order of magnitude cheaper than `grade.py --gold`, which has to apply a patch and run whole test files. With `cwd: auto` it probes the repository directory inside the sandbox (see "What to change for another benchmark").
+
+**It only fits Python benchmarks** — the test executor is hard-coded to `python -m pytest` and case names are parsed as pytest node ids. A Go / Java / JS benchmark needs both changed, and so does the grader (see "Multi-language benchmarks need per-language grading").
+
+```python
+# preflight.py
+import argparse, json, re, shlex, sys
+from pathlib import Path
+
+import yaml
+from minisweagent.config import builtin_config_dir
+from minisweagent.environments import get_environment
+from minisweagent.utils.serialize import recursive_merge
+
+PROBE = 'for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done'
+
+def as_list(v):
+    """The same rule as grade.py: the field may be a JSON string, or just a plain string."""
+    if isinstance(v, str):
+        try:
+            return json.loads(v)
+        except json.JSONDecodeError:
+            return [v] if v else []
+    return list(v or [])
+
+def test_files(instance):
+    """Files holding the deciding cases. Only names carrying a file prefix, as in grade.py."""
+    names = as_list(instance.get("FAIL_TO_PASS")) + as_list(instance.get("PASS_TO_PASS"))
+    return sorted({n.strip().strip("'\"").split("::")[0] for n in names
+                   if "::" in n or n.strip().strip("'\"").endswith(".py")})
+
+p = argparse.ArgumentParser("preflight")
+p.add_argument("-c", "--config", type=Path, default=Path("demo.yaml"))
+p.add_argument("--instance", type=Path, default=Path("instance.json"))
+a = p.parse_args()
+
+# The same layering as run.py and grade.py, so the environment variables match by construction
+cfg = recursive_merge(
+    yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text()),
+    yaml.safe_load(a.config.read_text()),
+)
+instance = json.loads(a.instance.read_text())[0]
+env_cfg = cfg["environment"]
+report = {}
+
+# With `auto`, the sandbox starts at / (which always exists); once the repository directory is
+# probed, every command carries a cwd override, so this costs a single sandbox. With a concrete
+# value, `require_existing_cwd` catches the misconfiguration at construction instead.
+auto = env_cfg.get("cwd") == "auto"
+env = get_environment(dict(env_cfg, cwd="/" if auto else env_cfg["cwd"], timeout=600))
+report |= {"template": env.template, "sandbox_id": env.sandbox.sandbox_id}
+try:
+    cwd = env_cfg["cwd"]
+    if auto:
+        found = env.execute({"command": PROBE})["output"].strip().splitlines()
+        cwd = found[-1].strip() if found else ""
+        report["probed_cwd"] = cwd or "(no git repository at the root)"
+        if not cwd:
+            raise SystemExit(json.dumps(report | {"ok": False}, ensure_ascii=False))
+    report["cwd"] = cwd
+
+    head = env.execute({"command": "git rev-parse HEAD"}, cwd)
+    report["is_git_repo"] = head["returncode"] == 0
+    report["head"] = head["output"].strip()[:40]
+
+    # Say it out loud when the field is missing. Skipping silently reads as "this check passed",
+    # and a mismatch between image and metadata is a common cause of grading everything to 0
+    # without an error anywhere.
+    expected = instance.get("base_commit") or ""
+    report["base_commit_match"] = report["head"] == expected if expected else "(no baseline commit in the metadata; not checked)"
+
+    ver = env.execute({"command": "python -m pytest --version"}, cwd)
+    report["pytest"] = ver["output"].strip().splitlines()[0][:60] if ver["returncode"] == 0 else ""
+
+    # The image may still carry history past HEAD, which means the answer can be dug out of git.
+    # Reported, not failed: see below.
+    future = env.execute({"command": "git rev-list --all --not HEAD --count"}, cwd)
+    report["future_commits"] = future["output"].strip()[:12] if future["returncode"] == 0 else "?"
+
+    # A deciding file may not exist at the baseline yet -- test_patch creates it. And pytest
+    # aborts collection entirely on an unknown path, so the two have to be separated first;
+    # otherwise every "new test file" task looks like a broken environment.
+    wanted = test_files(instance)
+    present = []
+    if wanted:
+        probe = env.execute({"command": "for f in " + " ".join(map(shlex.quote, wanted))
+                                        + '; do [ -f "$f" ] && echo "$f"; done'}, cwd)
+        present = [ln.strip() for ln in probe["output"].strip().splitlines() if ln.strip() in wanted]
+    report["test_files"] = f"{len(present)}/{len(wanted)} present at the baseline"
+
+    if present:
+        out = env.execute({"command": "python -m pytest --collect-only -q "
+                                      + " ".join(map(shlex.quote, present))}, cwd, timeout=600)
+        found = re.search(r"(\d+) tests? collected", out["output"])
+        report["collected"] = int(found.group(1)) if found else 0
+    else:
+        report["collected"] = None   # every deciding file is created by test_patch
+finally:
+    env.cleanup()
+
+report["ok"] = bool(report["is_git_repo"] and report["base_commit_match"] is not False
+                    and report["pytest"] and report["collected"] != 0 and wanted)
+print(json.dumps(report, ensure_ascii=False))
+sys.exit(0 if report["ok"] else 1)
+```
+
+```bash
+.venv/bin/python preflight.py
+# {"cwd": "/testbed", "is_git_repo": true, "head": "7f6c9cb1…", "base_commit_match": true,
+#  "pytest": "pytest 8.3.2", "future_commits": "486", "test_files": "1/1 present at the baseline",
+#  "collected": 1, "ok": true}
+```
+
+Three things to watch when reading that output:
+
+- **A deciding file missing at the baseline is normal**, `test_patch` creates it — so "collected 0" is not a verdict of unusable.
+- **`base_commit_match: false`** means the image and this metadata record are not a pair, and the deciding cases do not belong to this repository state.
+- **`future_commits` above zero means the answer may be in the image**: some benchmarks keep the history past `HEAD` (on tags or other branches), and the agent can dig the fix out of git instead of solving anything. Measured: one SWE-Gym moto image carries 237 tags and commits a year and a half newer than `HEAD`, and the class name added by the gold patch can be found with `git grep`; SWE-rebench V2 images report 0. **This inflates scores and is completely invisible** — the same class of problem as a misconfigured working directory, pointing the other way. Scale-SWE's `pre_commands` already strip refs and the reflog during reset; for other benchmarks, either strip them yourself in `env_startup_command` or at least know that the number includes this.
+
 **Acceptance testing must run under exactly the same environment variables as the grader.** Three common misjudgements make a perfectly good image look unusable:
 
 | Cause of misjudgement | Consequence |
@@ -602,13 +772,15 @@ Once an image is onboarded, do not stop acceptance testing at "the sandbox start
 | Go installed in `/usr/local/go/bin`, not on the default PATH | A perfectly good Go repository image is judged to have "no test executor" |
 | Java projects ship `./gradlew` instead of a global mvn/gradle | A perfectly good image is misjudged |
 
+The script above reads the same configuration as `grade.py`, so the first misjudgement cannot happen by construction — which is the reason not to let an acceptance script assemble its own environment variables.
+
 ## Production recommendations
 
 - **Credential management**: inject `E2B_API_KEY` and the model API key through environment variables or a secrets manager; never hard-code them or commit them to a repository. Keep model calls in the orchestration layer and no credentials inside the sandbox.
 - **Restrict outbound traffic**: set `deny_out: ["0.0.0.0/0"]` on the sandbox plus an allowlist, opening only code hosting, image registries, and the model endpoint. Note that domain filtering only applies to the Host header on port 80 and SNI on 443—other ports need CIDRs; `allow` takes precedence over `deny`; and a rejected TCP connection looks successful from inside the sandbox, so judge by the application-layer response.
 - **Two layers of timeout**: distinguish the sandbox TTL from the per-command timeout. Do not use `timeout=0`, since a stuck process will not recover on its own; for long tasks use `on_timeout="pause"` together with `auto_resume`, which neither bills nor holds a concurrency slot while paused.
 - **The patch is the only outbound artifact**: the sandbox needs only read access to the repository. Once the orchestration layer has the patch, it rebuilds a clean repository, verifies it, runs the tests, and only then creates a PR. Do not push or open PRs from inside the sandbox.
-- **Destroy promptly**: call `sandbox.kill()` in `finally`; per-second billing only counts running time.
+- **Destroy promptly**: call `sandbox.kill()` in `finally`; per-second billing only counts running time. But neither `finally` nor `atexit` covers a process cut short by a signal — a batch entry point has to turn `SIGTERM` into a bounded graceful shutdown (the built-in `mini-extra swebench` does), and whatever else you do, set the sandbox TTL to the largest waste you are willing to accept: however the process dies, the platform reclaims the sandbox when the TTL expires, and that is the last line of defence.
 - **Keep it traceable**: record `sandbox_id`, the template name, and the source image address on every trajectory (the built-in `e2b` environment class's `serialize()` already includes all three) for reproduction and troubleshooting.
 - **Cost accounting**: record start and end times in the orchestration layer and read the specification via `get_info()` to compute cost yourself.
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
@@ -71,7 +71,7 @@ flowchart TB
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
 .venv/bin/pip install pyyaml \
-  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@e3644c0384af6da13edafefa9872070e4ecc9509"
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@9611467952032e26b190a2cdde76daff4f37e1ca"
 
 # 云沙箱：SDK 由 domain 推导出接入点（https://api.<domain>），不需要单独配 api_url
 export E2B_API_KEY="<your-e2b-api-key>"

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
@@ -71,7 +71,7 @@ flowchart TB
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
 .venv/bin/pip install pyyaml \
-  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@9611467952032e26b190a2cdde76daff4f37e1ca"
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@571ea037897d8eb332a83c48319926505b4a05a5"
 
 # 云沙箱：SDK 由 domain 推导出接入点（https://api.<domain>），不需要单独配 api_url
 export E2B_API_KEY="<your-e2b-api-key>"
@@ -412,7 +412,7 @@ with (out / "train.jsonl").open("w") as f:
 | 约束 | 状态 |
 | --- | --- |
 | 单实例失败不拖垮整批 | 内置：异常记进该实例的 `exit_status`，其余继续 |
-| 沙箱一定要回收 | 内置：正常结束、Agent 抛异常、启动命令失败、环境对象被丢弃、进程被 `SIGTERM` 终止五条路径都会 `kill`（最后一条接进 `^C` 的优雅退出路径，会等在途实例收尾）。靠 TTL 兜底会额外计费并占用并发 |
+| 沙箱一定要回收 | 内置：正常结束、Agent 抛异常、启动命令失败、环境对象被丢弃、进程被 `SIGTERM` 终止五条路径都会 `kill`。最后一条是**立即释放、不等在途实例** —— 调度器会在自己的窗口之后补 SIGKILL（Kubernetes 默认 30 秒，还不够大仓库跑完一步），先等就可能来不及发出 kill 请求。在途实例的工作会丢，但 `preds.json` 是逐实例写的，重跑同一条命令只补没跑完的那些。靠 TTL 兜底会额外计费并占用并发 |
 | Agent 侧设上限 | 需自己配 `step_limit`、`cost_limit`、`wall_time_limit_seconds`，否则一道难题可能耗掉整批预算。**字段名写错不会报错、会被静默忽略** |
 | 输出截断分档 | 需自己配：终端 15k、单文件 20k、批量 50k 字符，防止上下文被占满 |
 
@@ -763,7 +763,7 @@ sys.exit(0 if report["ok"] else 1)
 - **出网收敛**：沙箱按 `deny_out: ["0.0.0.0/0"]` 加白名单，只放代码托管、镜像源与模型端点。注意域名过滤只对 80 端口的 Host 头与 443 的 SNI 生效，其他端口只能用 CIDR；`allow` 优先于 `deny`；被拒绝的 TCP 从沙箱内部看像是连接成功，需用应用层响应判定。
 - **两层超时**：区分沙箱级 TTL 与命令级超时。不要使用 `timeout=0`，卡住的进程不会自愈；长任务用 `on_timeout="pause"` 配合 `auto_resume`，暂停期间不计费、不占并发。
 - **补丁是唯一出口**：沙箱只需要仓库读权限。编排层拿到补丁后重建干净仓库校验并跑测试，通过再创建 PR。不要在沙箱内 push 或建 PR。
-- **及时销毁**：`finally` 里调用 `sandbox.kill()`，按秒计费仅统计运行中的时间。但 `finally` 与 `atexit` 都盖不住进程被信号打断的情况 —— 批量入口要把 `SIGTERM` 接成优雅退出（内置的 `mini-extra swebench` 已经这么做），并且无论如何都要把沙箱 TTL 设成你能接受的最大浪费：进程无论怎么死，平台都会在 TTL 到点回收，那是最后一道兜底。
+- **及时销毁**：`finally` 里调用 `sandbox.kill()`，按秒计费仅统计运行中的时间。但 `finally` 与 `atexit` 都盖不住进程被信号打断的情况 —— 批量入口要在 `SIGTERM` 上立即释放沙箱（内置的 `mini-extra swebench` 已经这么做），并且无论如何都要把沙箱 TTL 设成你能接受的最大浪费：进程无论怎么死，平台都会在 TTL 到点回收，那是最后一道兜底。
 - **可回溯**：每条轨迹记录 `sandbox_id`、模板名与源镜像地址（内置 `e2b` 环境类的 `serialize()` 已包含），便于复现与排障。
 - **成本核算**：编排层自行记录起止时间，配合 `get_info()` 读取规格自算成本。
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
@@ -13,9 +13,7 @@ SWE Agent（软件工程 Agent）自动完成 Issue 修复、PR 生成这类开�
 
 ## 前置条件
 
-- 已开通云沙箱，并获取目标地域的 `E2B_API_KEY`。本文以华东1（上海）地域为例，对应接入点：
-  - `api_url`：`https://api.cn-shanghai.e2b.fc.aliyuncs.com`
-  - `domain`：`cn-shanghai.e2b.fc.aliyuncs.com`
+- 已开通云沙箱，并获取目标地域的 `E2B_API_KEY`。本文以华东1（上海）地域为例，接入域名为 `cn-shanghai.e2b.fc.aliyuncs.com`（SDK 会据此推导出 API 地址 `https://api.cn-shanghai.e2b.fc.aliyuncs.com`）。
 - 一个可用的模型 API Key（本文用兼容 OpenAI 协议的端点）。
 - Python 3.10 及以上。
 
@@ -72,159 +70,55 @@ flowchart TB
 ```bash
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
-.venv/bin/pip install e2b "mini-swe-agent>=2.4" pyyaml
+.venv/bin/pip install pyyaml \
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@v2.4.6-fc.1"
 
+# 云沙箱：SDK 由 domain 推导出接入点（https://api.<domain>），不需要单独配 api_url
 export E2B_API_KEY="<your-e2b-api-key>"
-export E2B_REGION="cn-shanghai"
+export E2B_DOMAIN="cn-shanghai.e2b.fc.aliyuncs.com"
+# 模型凭据只在编排层使用，不进沙箱
 export MODEL_API_KEY="<your-model-api-key>"
 export MSWEA_CONFIGURED=true MSWEA_SILENT_STARTUP=1
 ```
 
-Agent 循环直接用社区标准实现 [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent)，提示词与提交协议全部沿用官方，只把执行底座替换成云沙箱。它的执行环境协议只有三个方法，实现即可，不需要修改上游代码。
+> 网络受限时可以先 `git clone https://github.com/aliyun-fc/mini-swe-agent`，再 `pip install -e ".[e2b]"`。
 
-## 实现执行环境：`fc_env.py`
+## 执行环境：用内置的 `e2b`
 
-以下是完整实现。注释标出的四处，是与本地 docker 执行环境不同、必须特殊处理的地方。
+Agent 循环直接用社区标准实现 [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent)，提示词与提交协议全部沿用官方，只把执行底座替换成云沙箱。上一步安装的版本内置了 `e2b` 执行环境，在配置里写一行即可，不需要自己实现：
 
-```python
-# fc_env.py
-from __future__ import annotations
-
-import hashlib
-import os
-import platform
-import shlex
-from dataclasses import dataclass, field
-from typing import Any
-
-from e2b import CommandExitException, Sandbox, Template
-from minisweagent.exceptions import Submitted
-
-SUBMIT_SENTINEL = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"
-
-REGIONS = {
-    "cn-shanghai": "https://api.cn-shanghai.e2b.fc.aliyuncs.com",
-    "cn-hangzhou": "https://api.cn-hangzhou.e2b.fc.aliyuncs.com",
-    "cn-beijing": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
-    "cn-hongkong": "https://api.cn-hongkong.e2b.fc.aliyuncs.com",
-    "us-west-1": "https://api.us-west-1.e2b.fc.aliyuncs.com",
-}
-
-
-@dataclass
-class FCSandboxEnvironmentConfig:
-    image: str = ""
-    template: str = ""
-    cwd: str = "/testbed"
-    env: dict[str, str] = field(default_factory=dict)
-    forward_env: list[str] = field(default_factory=list)  # 保持为空：宿主变量不进沙箱
-    timeout: int = 60
-    interpreter: list[str] = field(default_factory=lambda: ["bash", "-c"])
-    sandbox_timeout: int = 1800
-    region: str = field(default_factory=lambda: os.environ.get("E2B_REGION", "cn-shanghai"))
-    run_as_user: str = "root"  # 评测镜像的仓库属主通常是 root，且镜像里往往没有 sudo
-
-
-class FCSandboxEnvironment:
-    def __init__(self, *, config_class=FCSandboxEnvironmentConfig, **kwargs):
-        self.config = config_class(**kwargs)
-        self._conn = {
-            "api_key": os.environ["E2B_API_KEY"],
-            "api_url": REGIONS[self.config.region],
-            "domain": f"{self.config.region}.e2b.fc.aliyuncs.com",
-        }
-        template = self.config.template or self._ensure_template()
-        self.sbx = Sandbox.create(template, timeout=self.config.sandbox_timeout, **self._conn)
-        self.template = template
-
-        # 差异 1：docker 的 -w 会自动创建目录，沙箱不会。目录不存在时报的是
-        # `fork/exec /bin/bash: no such file or directory`，容易误判成 bash 有问题。
-        self._run_raw(f"mkdir -p {shlex.quote(self.config.cwd)}")
-        # 差异 2：跨用户的 git 操作会被拒绝（dubious ownership）
-        self._run_raw(f"git config --global --add safe.directory {shlex.quote(self.config.cwd)}")
-
-    def _ensure_template(self) -> str:
-        """镜像 → 模板，幂等：先用模板名探活，失败才构建。
-
-        模板名用镜像内容哈希、不要带版本号：同名模板只允许构建一次，
-        构建失败后该名字会停留在 CREATE_FAILED，再次构建直接返回 409。
-        """
-        name = "swe-" + hashlib.sha1(self.config.image.encode()).hexdigest()[:16]
-        try:
-            probe = Sandbox.create(name, timeout=60, **self._conn)
-            probe.kill()
-            return name
-        except Exception:
-            pass
-        Template.build(Template().from_image(self.config.image), name=name,
-                       cpu_count=2, memory_mb=8192, **self._conn)
-        return name
-
-    def _run_raw(self, command: str) -> None:
-        try:
-            self.sbx.commands.run(command, user=self.config.run_as_user or None, timeout=30)
-        except Exception:
-            pass  # 探路性质的命令，失败不影响主流程
-
-    def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
-        command = action.get("command", "")
-        limit = timeout or self.config.timeout
-        envs = {k: os.environ[k] for k in self.config.forward_env if k in os.environ}
-        envs.update(self.config.env)
-        cmd = shlex.join([*self.config.interpreter, command])
-        try:
-            r = self.sbx.commands.run(
-                cmd, cwd=cwd or self.config.cwd, envs=envs or None,
-                user=self.config.run_as_user or None,
-                timeout=limit, request_timeout=limit + 60,
-            )
-            out = {"output": (r.stdout or "") + (r.stderr or ""), "returncode": 0,
-                   "exception_info": ""}
-        except CommandExitException as e:
-            # 差异 3：命令非零退出是正常信号（测试失败等），必须转成 returncode，不能外抛
-            out = {"output": (e.stdout or "") + (e.stderr or ""), "returncode": e.exit_code,
-                   "exception_info": ""}
-        except Exception as e:
-            out = {"output": "", "returncode": -1,
-                   "exception_info": f"命令执行异常: {e}",
-                   "extra": {"exception_type": type(e).__name__}}
-        self._check_finished(out)
-        return out
-
-    def _check_finished(self, output: dict) -> None:
-        """差异 4：提交协议必须原样复刻 —— 首行是哨兵且退出码为 0，其余行即补丁。"""
-        lines = output.get("output", "").lstrip().splitlines(keepends=True)
-        if lines and lines[0].strip() == SUBMIT_SENTINEL and output["returncode"] == 0:
-            submission = "".join(lines[1:])
-            raise Submitted({"role": "exit", "content": submission,
-                             "extra": {"exit_status": "Submitted", "submission": submission}})
-
-    def get_template_vars(self, **kwargs) -> dict[str, Any]:
-        return {**self.config.__dict__, **platform.uname()._asdict(), **kwargs}
-
-    def serialize(self) -> dict:
-        # 每条轨迹都要能回溯到具体沙箱与源镜像
-        return {"environment_class": "fc_env.FCSandboxEnvironment",
-                "sandbox_id": self.sbx.sandbox_id, "template": self.template,
-                "image": self.config.image, "cwd": self.config.cwd}
-
-    def cleanup(self) -> None:
-        try:
-            self.sbx.kill()
-        except Exception:
-            pass
+```yaml
+environment:
+  environment_class: e2b
 ```
+
+它做的事：第一次用到某个镜像时，把镜像注册成一个持久模板（`Template.build`），之后复用缓存；每个实例起一个沙箱，命令通过 `commands.run` 下发，补丁按官方提交协议回传。
+
+**云沙箱与本地 docker 有四处行为差异**，内置环境类已经处理，但你需要知道它们存在 —— 自行实现执行底座、或排查异常时都会撞上：
+
+| 差异 | 不处理的后果 | 处理方式 |
+| --- | --- | --- |
+| `docker run -w` 会自动创建工作目录，沙箱不会 | 目录不存在时失败发生在进程创建阶段、**不带退出码**，于是每一条命令都被记成基础设施异常，Agent 空跑一整轮 | 沙箱起来后先 `mkdir -p <cwd>` |
+| 仓库属主与运行用户不一致时 git 拒绝操作 | `fatal: detected dubious ownership`，`git diff` 出不来，等于交不出补丁 | 启动时 `git config --global --add safe.directory <cwd>` |
+| 命令非零退出会被 SDK 抛成异常 | 测试失败、`grep` 无匹配这类**正常信号**被当成执行故障，Agent 收不到真实输出 | 捕获后转成 `returncode`，把 stdout/stderr 原样交还 |
+| 评测镜像的仓库属 root，镜像里通常没有 `sudo` | 用模板默认的非 root 用户跑，Agent 连文件都写不了（Permission denied） | 配 `run_as_user: root`（与官方 docker harness 一致） |
+
+模板构建有两点要注意，接自有镜像时尤其重要：
+
+- **模板名必须由镜像地址与规格共同决定。** 内置实现按「镜像地址 + `cpu_count`/`memory_mb`」取哈希：模板存在就直接复用、不重建，所以名字里不含规格的话，改了内存也只会拿到旧规格的模板。
+- **同一个模板名只允许构建一次。** 构建失败后该名字会停在 `CREATE_FAILED`，再次构建直接返回 409。所以名字要由内容决定，不要带版本号手工递增。
 
 ## 配置：镜像与工作目录成对指定
 
 ```yaml
 # demo.yaml —— 与 mini-SWE-agent 官方 swebench.yaml 叠加，提示词与提交协议沿用官方
 environment:
-  environment_class: fc_env.FCSandboxEnvironment
+  environment_class: e2b
   image: fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510
   cwd: /testbed          # 换题库必须同时更换，见「换题库要改什么」
   run_as_user: root
   timeout: 120
+  memory_mb: 8192        # 评测镜像大，默认的 2048 起不来
 model:
   model_name: openai/<your-model>
   model_kwargs:
@@ -246,10 +140,9 @@ from pathlib import Path
 import yaml
 from minisweagent.agents.default import DefaultAgent
 from minisweagent.config import builtin_config_dir
+from minisweagent.environments import get_environment
 from minisweagent.models.litellm_model import LitellmModel
 from minisweagent.utils.serialize import recursive_merge
-
-from fc_env import FCSandboxEnvironment
 
 p = argparse.ArgumentParser()
 p.add_argument("-c", "--config", type=Path, default=Path("demo.yaml"))
@@ -262,9 +155,7 @@ a = p.parse_args()
 official = yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text())
 cfg = recursive_merge(official, yaml.safe_load(a.config.read_text()))
 
-env_cfg = dict(cfg["environment"])
-env_cfg.pop("environment_class", None)          # 直接实例化，不走注册表
-env = FCSandboxEnvironment(**env_cfg)
+env = get_environment(cfg["environment"])      # environment_class: e2b
 
 model_cfg = dict(cfg["model"])
 model_cfg.setdefault("model_kwargs", {})
@@ -280,7 +171,7 @@ finally:
 patch = result.get("submission") or ""
 a.output.write_text(patch)
 print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(patch),
-                  "model_calls": agent.n_calls, "sandbox_id": env.sbx.sandbox_id},
+                  "model_calls": agent.n_calls, "sandbox_id": env.sandbox.sandbox_id},
                  ensure_ascii=False))
 ```
 
@@ -299,7 +190,7 @@ from collections import Counter
 from pathlib import Path
 
 import yaml
-from fc_env import FCSandboxEnvironment
+from minisweagent.environments.extra.e2b import E2BEnvironment
 
 # 评测镜像的 python/pytest 常装在 conda 环境里，靠 BASH_ENV 激活。
 # 不带这套环境变量，`python -m pytest` 会用到 conda base，报 No module named pytest。
@@ -338,11 +229,11 @@ if not patch.strip():
 image = yaml.safe_load(Path("demo.yaml").read_text())["environment"]["image"]
 f2p, p2p = as_list(inst["FAIL_TO_PASS"]), as_list(inst["PASS_TO_PASS"])
 
-env = FCSandboxEnvironment(image=image, cwd=a.cwd, run_as_user="root",
-                           timeout=900, env=GRADE_ENV)
+env = E2BEnvironment(image=image, cwd=a.cwd, run_as_user="root",
+                     timeout=900, memory_mb=8192, env=GRADE_ENV)
 try:
     # 1) 打被判定的补丁；打不上也是一种结果
-    env.sbx.files.write("/tmp/model.patch", patch)
+    env.sandbox.files.write("/tmp/model.patch", patch)
     out = env.execute({"command": "git apply -v /tmp/model.patch"}, timeout=300)
     if out["returncode"] != 0:
         out = env.execute({"command": "patch -p1 -i /tmp/model.patch"}, timeout=300)
@@ -352,7 +243,7 @@ try:
     tf = patched_files(inst["test_patch"])
     if tf:
         env.execute({"command": f"git checkout -- {' '.join(map(shlex.quote, tf))} || true"})
-    env.sbx.files.write("/tmp/test.patch", inst["test_patch"])
+    env.sandbox.files.write("/tmp/test.patch", inst["test_patch"])
     out = env.execute({"command": "git apply -v /tmp/test.patch"}, timeout=300)
     assert out["returncode"] == 0, f"test_patch 打不上: {out['output'][-200:]}"
 
@@ -422,17 +313,17 @@ finally:
 **先让判分器自检，再跑 Agent。** 用数据集自带的正确补丁走一遍判分，必须 `resolved: true`：
 
 ```bash
-PYTHONPATH=. .venv/bin/python grade.py --gold
+.venv/bin/python grade.py --gold
 # {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.58s"}
 ```
 
 自检不通过，说明判分链路本身有问题（镜像、测试引入方式、用例名匹配），此时 Agent 的得分没有意义。自检通过后跑 Agent 并判分：
 
 ```bash
-PYTHONPATH=. .venv/bin/python run.py
+.venv/bin/python run.py
 # {"exit_status": "Submitted", "patch_bytes": 1839, "model_calls": 31, "sandbox_id": "sbx-…"}
 
-PYTHONPATH=. .venv/bin/python grade.py --patch out.patch
+.venv/bin/python grade.py --patch out.patch
 # {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.76s"}
 ```
 
@@ -440,74 +331,56 @@ PYTHONPATH=. .venv/bin/python grade.py --patch out.patch
 
 ## 扩展到批量评测
 
-从一道题到 N 道题，`fc_env.py` 不用改，增加的是解析层与并发编排。
+从一道题到 N 道题，不用自己写并发编排 —— mini-SWE-agent 自带批量评测入口 `mini-extra swebench`，按实例隔离、并发、写 `preds.json`、跑完回收沙箱都由它负责。你要做的只有一件事：**把每道题的镜像地址喂给它**。
 
-### 解析层：把写死的两行变成查表
+### 解析层：镜像地址必须查表得到
 
-单题时镜像地址与工作目录写在配置里；批量时每道题都不同，必须查表。三件事需要按实例解析：镜像地址（评测镜像的 tag 通常带构建批次信息，**不能由 instance_id 推导**）、工作目录、判分口径。
+评测镜像的 tag 通常带构建批次信息（如 `..._202607231510`），**不能由 instance_id 推导**，所以必须查表。`mini-extra swebench` 会优先读取实例上的 `image_name` 字段，把解析结果写进这个字段即可：
 
 ```python
-# resolve.py
+# prepare.py —— 产出带 image_name 的本地数据集
 import json
-
-IMAGES = dict(l.split("\t") for l in open("images.tsv").read().splitlines())
-REGISTRY = json.load(open("registry.json"))     # family → cwd / run_as_user / grading
-FAMILY = json.load(open("family-index.json"))   # instance_id → family
-
-def resolve(instance: dict) -> dict:
-    spec = REGISTRY[FAMILY[instance["instance_id"]]]
-    cwd = spec["cwd"]
-    if cwd.startswith("$dataset."):             # 某些题库的工作目录每实例不同
-        cwd = instance[cwd.split(".", 1)[1]]    # 取数据集里对应字段
-    return {"image": IMAGES[instance["instance_id"]], "cwd": cwd,
-            "run_as_user": spec["run_as_user"], "grading": spec["grading"]}
-```
-
-解析是纯查表，没有网络与沙箱开销，可以在开跑前一次性完成。解析失败的实例（缺镜像映射、缺元数据）应当在开跑前剔除，而不是跑到一半才失败。
-
-### 并发编排
-
-```python
-# batch.py（骨架）
-import concurrent.futures as cf, json
 from pathlib import Path
 
-from fc_env import FCSandboxEnvironment
-from resolve import resolve
-
-def run_one(inst: dict) -> tuple[str, dict]:
-    spec = resolve(inst)
-    env = FCSandboxEnvironment(image=spec["image"], cwd=spec["cwd"],
-                               run_as_user=spec["run_as_user"], timeout=120)
-    try:
-        agent = build_agent(env)                       # 同前文 run.py
-        result = agent.run(inst["problem_statement"])
-        return inst["instance_id"], {
-            "model_patch": result.get("submission") or "",
-            "exit_status": result.get("exit_status"),
-            "sandbox_id": env.sbx.sandbox_id,          # 保证可回溯
-        }
-    except Exception as e:                             # 单实例失败不拖垮整批
-        return inst["instance_id"], {"model_patch": "", "error": f"{type(e).__name__}: {e}"}
-    finally:
-        env.cleanup()                                  # 跑完即杀，不要等 TTL
-
+IMAGES = json.load(open("image-index.json"))      # instance_id → 镜像地址
 instances = json.loads(Path("instances.json").read_text())
-preds = {}
-with cf.ThreadPoolExecutor(max_workers=6) as ex:
-    for iid, pred in ex.map(run_one, instances):
-        preds[iid] = pred
-Path("preds.json").write_text(json.dumps(preds, ensure_ascii=False, indent=1))
+
+out = Path("dataset"); out.mkdir(exist_ok=True)
+with (out / "train.jsonl").open("w") as f:
+    for inst in instances:
+        if inst["instance_id"] not in IMAGES:     # 缺镜像映射的实例开跑前就剔除
+            continue
+        inst["image_name"] = IMAGES[inst["instance_id"]]
+        f.write(json.dumps(inst, ensure_ascii=False) + "\n")
 ```
 
-四个必须做到的编排约束：
+> `--subset` 认的是**目录**（目录里放 `train.jsonl` 或 parquet），直接给单个文件路径会报 `Couldn't find any data file`。
 
-| 约束 | 做法 |
+解析是纯查表，没有网络与沙箱开销，可以在开跑前一次性完成。解析失败的实例应当在开跑前剔除，而不是跑到一半才失败。
+
+### 跑批
+
+```bash
+.venv/bin/mini-extra swebench \
+    --subset ./dataset --split train \
+    -c swebench.yaml -c demo.yaml \
+    --workers 6 -o ./results
+```
+
+`-c` 是**列表**，给了自定义配置就会顶掉默认值，所以官方 `swebench.yaml` 要显式放在第一个 —— 只写 `-c demo.yaml` 会因为缺提示词报 `ValidationError: system_template Field required`。`demo.yaml` 里的 `image` 这时不用填，按实例注入。
+
+结果落在 `results/preds.json`（`instance_id → model_patch`），每个实例另有一份轨迹，里面记着 `sandbox_id` 与 `template`，便于回溯到具体那次执行。
+
+**同一批只能放同族镜像。** `cwd` 与 `run_as_user` 在配置里是全批共用的，而不同题库的工作目录不同（见「换题库要改什么」），所以要按镜像族分批跑，每族一份 `demo.yaml`。
+
+四个编排约束，前两个内置入口已经做到，后两个仍需你自己设：
+
+| 约束 | 状态 |
 | --- | --- |
-| 单实例失败不拖垮整批 | 每个实例独立捕获异常，记录错误后继续 |
-| 沙箱一定要回收 | `finally` 里调用 `kill()`。靠 TTL 兜底会额外计费并占用并发 |
-| Agent 侧设上限 | `step_limit`、`cost_limit`、`wall_time_limit`，超限即停，否则一道难题可能耗掉整批预算 |
-| 输出截断分档 | 终端 15k、单文件 20k、批量 50k 字符，防止上下文被占满 |
+| 单实例失败不拖垮整批 | 内置：异常记进该实例的 `exit_status`，其余继续 |
+| 沙箱一定要回收 | 内置：正常结束、Agent 抛异常、启动命令失败三条路径都会 `kill`。靠 TTL 兜底会额外计费并占用并发 |
+| Agent 侧设上限 | 需自己配 `step_limit`、`cost_limit`、`wall_time_limit`，否则一道难题可能耗掉整批预算 |
+| 输出截断分档 | 需自己配：终端 15k、单文件 20k、批量 50k 字符，防止上下文被占满 |
 
 **并发建议压在 6 左右。** 大镜像在 10 并发下创建沙箱可能超时，串行重试即可成功；因此创建沙箱失败时应先串行重试一次，再判定实例不可用，否则会把并发压力误记成镜像问题。
 
@@ -676,7 +549,7 @@ for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
 
 把它做成解析层的一个 `auto` 选项，比在配置里逐条枚举更可靠。
 
-镜像地址与工作目录必须**成对**更换。只改一个会报 `fork/exec /bin/bash: no such file or directory` —— 那是工作目录不存在，与 bash 无关。
+镜像地址与工作目录必须**成对**更换，而且这类错误**不会报错**：工作目录不存在时会被自动创建成一个空目录，Agent 在里面跑完一整轮、交出一个空补丁，判分记 0 分。所以换题库后第一件事是确认工作目录下确实是目标仓库（`git rev-parse HEAD` 能出结果）。
 
 两个要避免的做法：
 
@@ -702,7 +575,7 @@ for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
 | 一个模板名只允许构建一次 | 构建失败后重试返回 `409: template build is not allowed in current status CREATE_FAILED`，该名字永久失效 | 重试必须换名。模板名用镜像内容哈希，不要带版本号 |
 | 构建阶段不支持执行步骤 | 声明 `run_cmd` / `set_user` / `set_workdir` 会返回 `400: steps are not supported` | 依赖与环境必须在源镜像里就绪；权限与工作目录只能在运行时用 `user="root"` 解决 |
 | 源镜像不满足 envd 注入条件会构建失败 | 构建阶段平台会向镜像注入 envd。若镜像不满足前置条件，日志里会打出 `template build failed: envd inject failed`，且仍会输出 `Build finished`（实测用 `python:3.11-slim` 直接构建即触发） | 按[构建自定义镜像模板](../04.功能说明/02.模板/03.构建自定义镜像模板.md)核对镜像要求（`linux/amd64`、`/etc/passwd` 与 `/etc/group` 可写、固定路径的 `/bin/bash` 等）。**注意 `Build finished` 不代表成功，要看有没有 `envd inject failed`** |
-| 构建失败时 SDK 可能长时间不返回 | 失败后客户端会持续轮询构建状态，日志量大时可能拖很久才抛 `ReadTimeout` | 在 `Template.build` 外层自行加超时，不要依赖它自己返回 |
+| 构建失败时 SDK 可能长时间不返回 | 失败后客户端会持续轮询构建状态，日志量大时可能拖很久才抛 `ReadTimeout` | 必须在 `Template.build` 外层加超时，不要依赖它自己返回。内置 `e2b` 环境类已经这么做（`build_timeout`，默认 30 分钟）|
 | 大镜像创建沙箱会超时 | 高并发下报 `TimeoutException` | 并发压到 6 左右，失败先串行重试一次 |
 
 镜像接入后，验收不要停在「沙箱起来了」。抽样跑完以下四步，任何一步不过都不算可用：
@@ -727,7 +600,7 @@ for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
 - **两层超时**：区分沙箱级 TTL 与命令级超时。不要使用 `timeout=0`，卡住的进程不会自愈；长任务用 `on_timeout="pause"` 配合 `auto_resume`，暂停期间不计费、不占并发。
 - **补丁是唯一出口**：沙箱只需要仓库读权限。编排层拿到补丁后重建干净仓库校验并跑测试，通过再创建 PR。不要在沙箱内 push 或建 PR。
 - **及时销毁**：`finally` 里调用 `sandbox.kill()`，按秒计费仅统计运行中的时间。
-- **可回溯**：每条轨迹记录 `sandbox_id` 与源镜像地址（前文 `serialize()` 已包含），便于复现与排障。
+- **可回溯**：每条轨迹记录 `sandbox_id`、模板名与源镜像地址（内置 `e2b` 环境类的 `serialize()` 已包含），便于复现与排障。
 - **成本核算**：编排层自行记录起止时间，配合 `get_info()` 读取规格自算成本。
 
 ## 相关功能

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
@@ -71,7 +71,7 @@ flowchart TB
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
 .venv/bin/pip install pyyaml \
-  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@4956102024d6e3b580fa559ef2ab5ecf71495ea9"
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@e3644c0384af6da13edafefa9872070e4ecc9509"
 
 # 云沙箱：SDK 由 domain 推导出接入点（https://api.<domain>），不需要单独配 api_url
 export E2B_API_KEY="<your-e2b-api-key>"

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
@@ -71,42 +71,53 @@ flowchart TB
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
 .venv/bin/pip install pyyaml \
-  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@v2.4.6-fc.1"
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@4956102024d6e3b580fa559ef2ab5ecf71495ea9"
 
 # 云沙箱：SDK 由 domain 推导出接入点（https://api.<domain>），不需要单独配 api_url
 export E2B_API_KEY="<your-e2b-api-key>"
 export E2B_DOMAIN="cn-shanghai.e2b.fc.aliyuncs.com"
-# 模型凭据只在编排层使用，不进沙箱
-export MODEL_API_KEY="<your-model-api-key>"
+# 模型凭据只在编排层使用，不进沙箱。变量名由后面 model_name 的 `openai/` 前缀决定，
+# 值填你那个兼容端点的 key。用 litellm 认的标准变量，单题脚本与批量入口才能共用同一份凭据
+export OPENAI_API_KEY="<your-model-api-key>"
 export MSWEA_CONFIGURED=true MSWEA_SILENT_STARTUP=1
+```
+
+**pin 到完整 commit SHA，不要 pin 分支。** 分支会随后续提交移动，今天装到的和下周装到的
+不是同一份代码，评测结果就不可复现。装完确认一下：
+
+```bash
+.venv/bin/python -c "import minisweagent; print(minisweagent.__version__)"
+# 2.4.6+fc.1
 ```
 
 > 网络受限时可以先 `git clone https://github.com/aliyun-fc/mini-swe-agent`，再 `pip install -e ".[e2b]"`。
 
 ## 执行环境：用内置的 `e2b`
 
-Agent 循环直接用社区标准实现 [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent)，提示词与提交协议全部沿用官方，只把执行底座替换成云沙箱。上一步安装的版本内置了 `e2b` 执行环境，在配置里写一行即可，不需要自己实现：
+Agent 循环用社区标准实现 [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent)，提示词与提交协议沿用官方，只把执行底座换成云沙箱。上一步装的版本内置了 `e2b`，配置写一行即可：
 
 ```yaml
 environment:
   environment_class: e2b
 ```
 
-它做的事：第一次用到某个镜像时，把镜像注册成一个持久模板（`Template.build`），之后复用缓存；每个实例起一个沙箱，命令通过 `commands.run` 下发，补丁按官方提交协议回传。
+它第一次用到某个镜像时注册成持久模板（`Template.build`），之后命中缓存；每个实例起一个沙箱，命令走 `commands.run`，补丁按官方协议回传。
 
-**云沙箱与本地 docker 有四处行为差异**，内置环境类已经处理，但你需要知道它们存在 —— 自行实现执行底座、或排查异常时都会撞上：
+**云沙箱与本地 docker 有五处差异，内置类都处理了。** 自行实现执行底座、或排查异常时会撞上：
 
 | 差异 | 不处理的后果 | 处理方式 |
 | --- | --- | --- |
-| `docker run -w` 会自动创建工作目录，沙箱不会 | 目录不存在时失败发生在进程创建阶段、**不带退出码**，于是每一条命令都被记成基础设施异常，Agent 空跑一整轮 | 沙箱起来后先 `mkdir -p <cwd>` |
-| 仓库属主与运行用户不一致时 git 拒绝操作 | `fatal: detected dubious ownership`，`git diff` 出不来，等于交不出补丁 | 启动时 `git config --global --add safe.directory <cwd>` |
-| 命令非零退出会被 SDK 抛成异常 | 测试失败、`grep` 无匹配这类**正常信号**被当成执行故障，Agent 收不到真实输出 | 捕获后转成 `returncode`，把 stdout/stderr 原样交还 |
-| 评测镜像的仓库属 root，镜像里通常没有 `sudo` | 用模板默认的非 root 用户跑，Agent 连文件都写不了（Permission denied） | 配 `run_as_user: root`（与官方 docker harness 一致） |
+| 沙箱不自动创建工作目录（`docker run -w` 会） | 失败在进程创建阶段、**不带退出码**，每条命令都被记成基础设施异常 | 启动时 `mkdir -p <cwd>`。但要先探测一次并告警 —— 否则配错的工作目录会被静默建成空目录，Agent 交出空补丁、判 0 分；`require_existing_cwd: true` 可升级为启动即失败 |
+| 属主与运行用户不一致时 git 拒绝操作 | `dubious ownership`，`git diff` 出不来，等于交不出补丁 | 启动时 `git config --global --add safe.directory <cwd>` |
+| 非零退出被 SDK 抛成异常 | 测试失败、`grep` 无匹配这类**正常信号**被当成执行故障 | 转成 `returncode`，输出原样交还 |
+| 超时异常不带 stdout/stderr | 超时前的几千行全丢，而最容易超时的正是大仓库的慢测试 | 流式收集，超时后交还已产生的部分并标注超时 |
+| 仓库属 root，镜像通常没有 `sudo` | 非 root 用户连文件都写不了 | `run_as_user: root`（与官方 docker harness 一致） |
 
-模板构建有两点要注意，接自有镜像时尤其重要：
+模板构建还有三点，接自有镜像或自行实现时尤其重要：
 
-- **模板名必须由镜像地址与规格共同决定。** 内置实现按「镜像地址 + `cpu_count`/`memory_mb`」取哈希：模板存在就直接复用、不重建，所以名字里不含规格的话，改了内存也只会拿到旧规格的模板。
-- **同一个模板名只允许构建一次。** 构建失败后该名字会停在 `CREATE_FAILED`，再次构建直接返回 409。所以名字要由内容决定，不要带版本号手工递增。
+- **模板名由镜像地址与规格共同决定。** 内置实现哈希「镜像地址 + `cpu_count`/`memory_mb`」；名字里不含规格，改了内存也只会拿到旧规格的模板。
+- **同一张镜像的并发首建必须互斥。** 否则都发现模板不存在、都去建同一个名字，实测 4 并发 3 个失败（`409 ... resource conflict`），每个失败者还留一条孤儿模板记录。
+- **构建失败的名字不会自愈。** 别名端点不返回状态，于是存在性检查一直说「存在」，而起沙箱被拒、再建报「只允许构建一次」。恢复要按真实状态分流：别人在建就等，`error` 或不存在才删了重建（删除是异步的，要等别名消失）。名字由内容决定，不要带版本号手工递增。
 
 ## 配置：镜像与工作目录成对指定
 
@@ -116,6 +127,7 @@ environment:
   environment_class: e2b
   image: fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510
   cwd: /testbed          # 换题库必须同时更换，见「换题库要改什么」
+  require_existing_cwd: true   # 工作目录不在镜像里就启动即失败，而不是建成空目录静默判 0 分
   run_as_user: root
   timeout: 120
   memory_mb: 8192        # 评测镜像大，默认的 2048 起不来
@@ -126,15 +138,22 @@ model:
     temperature: 0.0
   cost_tracking: ignore_errors   # 自建端点的模型不在价格表里，否则成本计算会抛错
 agent:
-  step_limit: 40
-  cost_limit: 0
+  # 沿用官方 swebench.yaml 的 250。实测压到 40 时 4 个实例 3 个撞上限，其中一个已改好、
+  # 只差一步交卷却记 0 分 —— 上限压低会系统性低估分数
+  step_limit: 250
+  # 步数管不了时间：实测有实例跑到 35 分钟仍未收尾，一直占着并发位与计费沙箱。
+  # 注意字段名是 wall_time_limit_seconds，写错不会报错、会被静默忽略
+  wall_time_limit_seconds: 1800
+  cost_limit: 0     # 自建端点的模型不在价格表里，按成本卡上限没有意义
 ```
+
+`require_existing_cwd` 默认关闭（与上游一致），**基于仓库的题库都应打开** —— 它是这类静默失败唯一的拦网。
 
 ## 驱动 Agent：`run.py`
 
 ```python
 # run.py
-import argparse, json, os
+import argparse, json
 from pathlib import Path
 
 import yaml
@@ -157,11 +176,10 @@ cfg = recursive_merge(official, yaml.safe_load(a.config.read_text()))
 
 env = get_environment(cfg["environment"])      # environment_class: e2b
 
-model_cfg = dict(cfg["model"])
-model_cfg.setdefault("model_kwargs", {})
-model_cfg["model_kwargs"]["api_key"] = os.environ["MODEL_API_KEY"]   # 只在编排层
-
-agent = DefaultAgent(LitellmModel(**model_cfg), env,
+# 不在这里注入 api_key：交给 litellm 从标准环境变量解析（`openai/` 前缀 → OPENAI_API_KEY）。
+# 这样本脚本与官方批量入口用的是同一份凭据；自定义一个只有本脚本认的变量，会让照着配的
+# 批量跑以 Missing credentials 收场。
+agent = DefaultAgent(LitellmModel(**cfg["model"]), env,
                      **recursive_merge(cfg.get("agent", {}), {"output_path": a.traj}))
 try:
     result = agent.run(a.task.read_text())
@@ -171,7 +189,8 @@ finally:
 patch = result.get("submission") or ""
 a.output.write_text(patch)
 print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(patch),
-                  "model_calls": agent.n_calls, "sandbox_id": env.sandbox.sandbox_id},
+                  "model_calls": agent.n_calls, "template": env.template,
+                  "sandbox_id": env.sandbox.sandbox_id},
                  ensure_ascii=False))
 ```
 
@@ -190,12 +209,9 @@ from collections import Counter
 from pathlib import Path
 
 import yaml
-from minisweagent.environments.extra.e2b import E2BEnvironment
-
-# 评测镜像的 python/pytest 常装在 conda 环境里，靠 BASH_ENV 激活。
-# 不带这套环境变量，`python -m pytest` 会用到 conda base，报 No module named pytest。
-GRADE_ENV = {"PAGER": "cat", "MANPAGER": "cat", "PIP_PROGRESS_BAR": "off",
-             "TQDM_DISABLE": "1", "BASH_ENV": "/root/.bashrc"}
+from minisweagent.config import builtin_config_dir
+from minisweagent.environments import get_environment
+from minisweagent.utils.serialize import recursive_merge
 
 def as_list(v):
     if isinstance(v, str):
@@ -216,9 +232,9 @@ def patched_files(diff):    # 补丁触及的文件
 
 p = argparse.ArgumentParser()
 p.add_argument("--instance", type=Path, default=Path("instance.json"))
+p.add_argument("--config", type=Path, default=Path("demo.yaml"))
 p.add_argument("--patch", type=Path)
 p.add_argument("--gold", action="store_true", help="用数据集自带补丁自检")
-p.add_argument("--cwd", default="/testbed")
 a = p.parse_args()
 
 inst = json.loads(a.instance.read_text())[0]
@@ -226,11 +242,16 @@ patch = inst["patch"] if a.gold else a.patch.read_text()
 if not patch.strip():
     raise SystemExit(json.dumps({"resolved": False, "reason": "补丁为空"}))
 
-image = yaml.safe_load(Path("demo.yaml").read_text())["environment"]["image"]
+# 与 run.py 做同一次叠加：镜像、工作目录、环境变量都取自同一处（后文的验收脚本也读它）。
+# 判分器自己拼一份环境就会与 Agent 现场漂移 —— 改了 cwd 而判分器还用旧值是最典型的一种；
+# 漏掉官方配置里的 BASH_ENV 则会报 No module named pytest，被误读成镜像不可用。
+cfg = recursive_merge(
+    yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text()),
+    yaml.safe_load(a.config.read_text()),
+)
 f2p, p2p = as_list(inst["FAIL_TO_PASS"]), as_list(inst["PASS_TO_PASS"])
 
-env = E2BEnvironment(image=image, cwd=a.cwd, run_as_user="root",
-                     timeout=900, memory_mb=8192, env=GRADE_ENV)
+env = get_environment(dict(cfg["environment"], timeout=1800))
 try:
     # 1) 打被判定的补丁；打不上也是一种结果
     env.sandbox.files.write("/tmp/model.patch", patch)
@@ -258,10 +279,13 @@ try:
     report = res["output"]
 
     # 判分命令跑不出东西时，不能判成「测试没过」—— 那是把基础设施故障算进模型分数。
-    # 高并发下命令超时、输出为空是真实场景，必须与「测试失败」区分开。
+    # 高并发下命令超时是真实场景，必须与「测试失败」区分开。超时前已产生的输出会被
+    # 保留下来，据此能看出是卡在收集阶段还是某个用例上。
     if not report.strip() or res["returncode"] == -1:
         raise SystemExit(json.dumps({"resolved": False, "graded": False,
-                                     "reason": "判分未完成（无输出，疑似超时），请降低并发后重跑"},
+                                     "reason": "判分未完成（疑似超时），请降低并发后重跑",
+                                     "exception_info": res.get("exception_info", ""),
+                                     "partial_output": report.strip()[-300:]},
                                     ensure_ascii=False))
 
     passed = Counter(re.findall(r"^PASSED (\S+)", report, flags=re.M))
@@ -310,21 +334,22 @@ finally:
   "patch": "diff --git a/moto/... （数据集自带的正确补丁，仅用于判分器自检）"}]
 ```
 
-**先让判分器自检，再跑 Agent。** 用数据集自带的正确补丁走一遍判分，必须 `resolved: true`：
+**先让判分器自检，再跑 Agent。** 用数据集自带的正确补丁走一遍判分，必须 `resolved: true`，这一步不花模型 token：
 
 ```bash
 .venv/bin/python grade.py --gold
-# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.58s"}
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.64s"}
 ```
 
-自检不通过，说明判分链路本身有问题（镜像、测试引入方式、用例名匹配），此时 Agent 的得分没有意义。自检通过后跑 Agent 并判分：
+自检不通过，说明这条链路本身有问题（镜像、工作目录、测试引入方式、用例名匹配），此时 Agent 的得分没有意义。自检通过后跑 Agent 并判分：
 
 ```bash
 .venv/bin/python run.py
-# {"exit_status": "Submitted", "patch_bytes": 1839, "model_calls": 31, "sandbox_id": "sbx-…"}
+# {"exit_status": "Submitted", "patch_bytes": 1843, "model_calls": 32,
+#  "template": "fc-e2b-registry-…-46a01131", "sandbox_id": "sbx-…"}
 
 .venv/bin/python grade.py --patch out.patch
-# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.76s"}
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.75s"}
 ```
 
 首次运行会把镜像注册成模板（幂等，之后命中缓存 1~2 秒）。模型有随机性，`model_calls` 与 `patch_bytes` 会浮动。
@@ -342,7 +367,8 @@ finally:
 import json
 from pathlib import Path
 
-IMAGES = json.load(open("image-index.json"))      # instance_id → 镜像地址
+# 清单是制表符分隔的文本，前两列是 instance_id 与镜像地址（见「镜像清单获取」）
+IMAGES = dict(l.rstrip("\n").split("\t")[:2] for l in open("swegym-images.tsv"))
 instances = json.loads(Path("instances.json").read_text())
 
 out = Path("dataset"); out.mkdir(exist_ok=True)
@@ -369,6 +395,14 @@ with (out / "train.jsonl").open("w") as f:
 
 `-c` 是**列表**，给了自定义配置就会顶掉默认值，所以官方 `swebench.yaml` 要显式放在第一个 —— 只写 `-c demo.yaml` 会因为缺提示词报 `ValidationError: system_template Field required`。`demo.yaml` 里的 `image` 这时不用填，按实例注入。
 
+两处容易踩到：
+
+- **凭据必须用 litellm 认的标准变量名。** 批量入口不注入 api_key，由 litellm 按 provider 解析
+  （`openai/...` → `OPENAI_API_KEY`）。名字不对会**先重试 3 次、每次等 60 秒**才报 `Missing credentials`。
+- **整批的退出码恒为 0**，即使每个实例都失败 —— 异常记进各实例的 `exit_status`、整批照常走完（见下方约束表）。
+  所以外层要查 `preds.json` 里 `model_patch` 是否为空，别看退出码。实测三个实例全因凭据错误失败时，
+  退出码仍是 0、`preds.json` 条目齐全但补丁全空。
+
 结果落在 `results/preds.json`（`instance_id → model_patch`），每个实例另有一份轨迹，里面记着 `sandbox_id` 与 `template`，便于回溯到具体那次执行。
 
 **同一批只能放同族镜像。** `cwd` 与 `run_as_user` 在配置里是全批共用的，而不同题库的工作目录不同（见「换题库要改什么」），所以要按镜像族分批跑，每族一份 `demo.yaml`。
@@ -378,11 +412,13 @@ with (out / "train.jsonl").open("w") as f:
 | 约束 | 状态 |
 | --- | --- |
 | 单实例失败不拖垮整批 | 内置：异常记进该实例的 `exit_status`，其余继续 |
-| 沙箱一定要回收 | 内置：正常结束、Agent 抛异常、启动命令失败三条路径都会 `kill`。靠 TTL 兜底会额外计费并占用并发 |
-| Agent 侧设上限 | 需自己配 `step_limit`、`cost_limit`、`wall_time_limit`，否则一道难题可能耗掉整批预算 |
+| 沙箱一定要回收 | 内置：正常结束、Agent 抛异常、启动命令失败、环境对象被丢弃、进程被 `SIGTERM` 终止五条路径都会 `kill`（最后一条接进 `^C` 的优雅退出路径，会等在途实例收尾）。靠 TTL 兜底会额外计费并占用并发 |
+| Agent 侧设上限 | 需自己配 `step_limit`、`cost_limit`、`wall_time_limit_seconds`，否则一道难题可能耗掉整批预算。**字段名写错不会报错、会被静默忽略** |
 | 输出截断分档 | 需自己配：终端 15k、单文件 20k、批量 50k 字符，防止上下文被占满 |
 
-**并发建议压在 6 左右。** 大镜像在 10 并发下创建沙箱可能超时，串行重试即可成功；因此创建沙箱失败时应先串行重试一次，再判定实例不可用，否则会把并发压力误记成镜像问题。
+**并发建议压在 6 左右。** 同一张镜像的并发首次构建已由内置环境类按模板名互斥（见前文「模板构建」），
+不需要你处理；压并发的理由只剩一个 —— 大镜像在 10 并发下创建沙箱可能超时，串行重试即可成功。
+因此创建沙箱失败时应先串行重试一次，再判定实例不可用，否则会把并发压力误记成镜像问题。
 
 ### 判分与 Agent 解耦
 
@@ -541,15 +577,22 @@ awk -F'\t' 'NR>1{print $4"  "$1}' MANIFEST.tsv > sums && sha256sum -c sums
 | 单一应用目录 | `/app` | 固定值 |
 | 根目录下以仓库原名命名 | 如 `/OpenTripPlanner`、`/ApplicationInsights-node.js` | **无法从镜像 tag 推导**（tag 是小写、目录保留原始大小写），需运行时探测 |
 
-最后一种要在容器里探测，例如：
+最后一种要在沙箱内探测：
 
 ```bash
-for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
+for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done   # 例如探出 /cfn-lint
 ```
 
-把它做成解析层的一个 `auto` 选项，比在配置里逐条枚举更可靠。
+**把探到的值填回 `demo.yaml`。** 解析只做一次，`run.py` 与 `grade.py` 只认具体值 —— 批量评测时这一步属于解析层，开跑前一次性完成，不要每个实例现探。后文的验收脚本支持把 `cwd` 写成 `auto`，由它探测并打印。
 
-镜像地址与工作目录必须**成对**更换，而且这类错误**不会报错**：工作目录不存在时会被自动创建成一个空目录，Agent 在里面跑完一整轮、交出一个空补丁，判分记 0 分。所以换题库后第一件事是确认工作目录下确实是目标仓库（`git rev-parse HEAD` 能出结果）。
+镜像地址与工作目录必须**成对**更换。配了 `require_existing_cwd: true` 时改错会启动即失败：
+
+```
+RuntimeError: Working directory /testbed was not in the image and has been created empty.
+For a repository-based task this means it is misconfigured: …
+```
+
+**没配这个开关，这类错误完全不报**：工作目录不存在时会被自动创建成一个空目录，Agent 在里面跑完一整轮、交出一个空补丁，判分记 0 分。所以换题库后第一件事是用数据集自带补丁跑一遍 `grade.py --gold`，它会连带确认工作目录下确实是目标仓库。
 
 两个要避免的做法：
 
@@ -585,6 +628,112 @@ for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
 3. 该语言的测试执行器可用。
 4. 能真正收集到用例（如 `pytest --collect-only -q`）。
 
+下面这份脚本是这四步的实现：一个沙箱跑完，不花模型 token。抽样几十上百张镜像时它比 `grade.py --gold` 便宜一个数量级 —— 后者要打补丁、跑完整测试文件。`cwd` 写 `auto` 时它会在沙箱内探测仓库目录（见「换题库要改什么」）。
+
+```python
+# preflight.py
+import json, re, shlex, sys
+from pathlib import Path
+
+import yaml
+from minisweagent.config import builtin_config_dir
+from minisweagent.environments import get_environment
+from minisweagent.utils.serialize import recursive_merge
+
+PROBE = 'for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done'
+
+def test_files(instance):
+    """判定用例所在的文件。只取带文件前缀的名字，规则与 grade.py 一致。"""
+    names = []
+    for key in ("FAIL_TO_PASS", "PASS_TO_PASS"):
+        v = instance.get(key)
+        names += json.loads(v) if isinstance(v, str) else list(v or [])
+    return sorted({n.strip().strip("'\"").split("::")[0] for n in names
+                   if "::" in n or n.strip().strip("'\"").endswith(".py")})
+
+# 与 run.py、grade.py 做同一次叠加，环境变量因此天然一致
+cfg = recursive_merge(
+    yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text()),
+    yaml.safe_load(Path("demo.yaml").read_text()),
+)
+instance = json.loads(Path("instance.json").read_text())[0]
+env_cfg = cfg["environment"]
+report = {}
+
+# cwd 写 auto 时沙箱先落在 /（必然存在），探到仓库目录后每条命令再带 cwd 覆盖，只花一个沙箱。
+# 写具体值时则交给 require_existing_cwd 在构造阶段就把配错拦下来。
+auto = env_cfg.get("cwd") == "auto"
+env = get_environment(dict(env_cfg, cwd="/" if auto else env_cfg["cwd"], timeout=600))
+report |= {"template": env.template, "sandbox_id": env.sandbox.sandbox_id}
+try:
+    cwd = env_cfg["cwd"]
+    if auto:
+        found = env.execute({"command": PROBE})["output"].strip().splitlines()
+        cwd = found[-1].strip() if found else ""
+        report["probed_cwd"] = cwd or "(根目录下没有 git 仓库)"
+        if not cwd:
+            raise SystemExit(json.dumps(report | {"ok": False}, ensure_ascii=False))
+    report["cwd"] = cwd
+
+    head = env.execute({"command": "git rev-parse HEAD"}, cwd)
+    report["is_git_repo"] = head["returncode"] == 0
+    report["head"] = head["output"].strip()[:40]
+
+    # 字段缺失要显式说出来。静默跳过会让读者以为这一项通过了，而镜像与元数据配不配对
+    # 恰恰是「判分全 0 却不报错」的常见原因。
+    expected = instance.get("base_commit") or ""
+    report["base_commit_match"] = report["head"] == expected if expected else "(元数据里没有基线 commit，未校验)"
+
+    ver = env.execute({"command": "python -m pytest --version"}, cwd)
+    report["pytest"] = ver["output"].strip().splitlines()[0][:60] if ver["returncode"] == 0 else ""
+
+    # 镜像里可能留着 HEAD 之后的历史，那意味着答案能从 git 里翻出来。只报告不判失败。
+    future = env.execute({"command": "git rev-list --all --not HEAD --count"}, cwd)
+    report["future_commits"] = future["output"].strip()[:12] if future["returncode"] == 0 else "?"
+
+    # 判定文件可能在基线上还不存在 —— test_patch 会新建它。而 pytest 一旦收到不存在的
+    # 路径就整个中止收集，所以必须先分开，否则「新增测试文件」的题目会被误判成环境坏了。
+    wanted = test_files(instance)
+    present = []
+    if wanted:
+        probe = env.execute({"command": "for f in " + " ".join(map(shlex.quote, wanted))
+                                        + '; do [ -f "$f" ] && echo "$f"; done'}, cwd)
+        present = [ln.strip() for ln in probe["output"].strip().splitlines() if ln.strip() in wanted]
+    report["test_files"] = f"{len(present)}/{len(wanted)} 在基线存在"
+
+    if present:
+        out = env.execute({"command": "python -m pytest --collect-only -q "
+                                      + " ".join(map(shlex.quote, present))}, cwd, timeout=600)
+        found = re.search(r"(\d+) tests? collected", out["output"])
+        report["collected"] = int(found.group(1)) if found else 0
+    else:
+        report["collected"] = None   # 判定文件全由 test_patch 新建，基线上无从收集
+finally:
+    env.cleanup()
+
+report["ok"] = bool(report["is_git_repo"] and report["base_commit_match"] is not False
+                    and report["pytest"] and report["collected"] != 0 and wanted)
+print(json.dumps(report, ensure_ascii=False))
+sys.exit(0 if report["ok"] else 1)
+```
+
+```bash
+.venv/bin/python preflight.py
+# {"cwd": "/testbed", "is_git_repo": true, "head": "7f6c9cb1…", "base_commit_match": true,
+#  "pytest": "pytest 8.3.2", "future_commits": "486", "test_files": "1/1 在基线存在",
+#  "collected": 1, "ok": true}
+```
+
+读这份输出有三处要留意：
+
+- **判定文件在基线上不存在是正常的**，`test_patch` 会新建它 —— 所以不能拿「收集到 0 个」当不可用。
+- **`base_commit_match` 为 false** 说明镜像与这条元数据不是一对，判定用例不属于这个仓库现场。
+- **`future_commits` 非 0 意味着答案可能就在镜像里**：部分题库保留了 `HEAD` 之后的历史（挂在 tag 或其他分支上），
+  Agent 直接从 git 里翻就能拿到修复。实测 SWE-Gym 的一张 moto 镜像有 237 个 tag、未来提交比 `HEAD` 晚一年半，
+  gold 补丁新增的类名可以直接 `git grep` 到；SWE-rebench V2 的镜像是 0。**这让分数偏高且完全不可见** ——
+  与「工作目录配错」同类，只是方向相反。Scale-SWE 的 `pre_commands` 已在复位时剥掉 refs 与 reflog；
+  其他题库要么自己在 `env_startup_command` 里剥，要么至少知道分数含这个成分。
+
 **验收必须在与判分器完全相同的环境变量下进行。** 三类常见误判会让正常镜像被判为不可用：
 
 | 误判原因 | 后果 |
@@ -593,13 +742,15 @@ for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done
 | Go 装在 `/usr/local/go/bin`，不在默认 PATH | 正常的 Go 仓库镜像被判「没有测试执行器」 |
 | Java 项目不装全局 mvn/gradle，而是带 `./gradlew` | 正常镜像被误判 |
 
+上面的脚本与 `grade.py` 读同一份配置，所以第一类误判从结构上就不会发生 —— 这也是不要让验收脚本自己拼一份环境变量的原因。
+
 ## 上线建议
 
 - **凭据管理**：`E2B_API_KEY` 与模型 API Key 通过环境变量或密钥管理服务注入，不要硬编码或提交进代码仓库。模型调用放在编排层，沙箱内不放任何凭据。
 - **出网收敛**：沙箱按 `deny_out: ["0.0.0.0/0"]` 加白名单，只放代码托管、镜像源与模型端点。注意域名过滤只对 80 端口的 Host 头与 443 的 SNI 生效，其他端口只能用 CIDR；`allow` 优先于 `deny`；被拒绝的 TCP 从沙箱内部看像是连接成功，需用应用层响应判定。
 - **两层超时**：区分沙箱级 TTL 与命令级超时。不要使用 `timeout=0`，卡住的进程不会自愈；长任务用 `on_timeout="pause"` 配合 `auto_resume`，暂停期间不计费、不占并发。
 - **补丁是唯一出口**：沙箱只需要仓库读权限。编排层拿到补丁后重建干净仓库校验并跑测试，通过再创建 PR。不要在沙箱内 push 或建 PR。
-- **及时销毁**：`finally` 里调用 `sandbox.kill()`，按秒计费仅统计运行中的时间。
+- **及时销毁**：`finally` 里调用 `sandbox.kill()`，按秒计费仅统计运行中的时间。但 `finally` 与 `atexit` 都盖不住进程被信号打断的情况 —— 批量入口要把 `SIGTERM` 接成优雅退出（内置的 `mini-extra swebench` 已经这么做），并且无论如何都要把沙箱 TTL 设成你能接受的最大浪费：进程无论怎么死，平台都会在 TTL 到点回收，那是最后一道兜底。
 - **可回溯**：每条轨迹记录 `sandbox_id`、模板名与源镜像地址（内置 `e2b` 环境类的 `serialize()` 已包含），便于复现与排障。
 - **成本核算**：编排层自行记录起止时间，配合 `get_info()` 读取规格自算成本。
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
@@ -51,7 +51,7 @@ flowchart TB
     style SBX stroke-width:3px
 ```
 
-**模型跑在编排层，沙箱只执行 bash。** 这样模型 Key 与代码仓库凭据都不进沙箱：Agent 读到的仓库内容即使包含恶意指令，最坏也只能提交一个无效补丁，拿不到任何凭据。
+模型跑在编排层，沙箱只执行 bash，模型 Key 与代码仓库凭据都不进沙箱。Agent 读到的仓库内容即使包含恶意指令，最坏也只能提交一个无效补丁，拿不到任何凭据。
 
 ## 一道题由三部分组成
 
@@ -63,7 +63,7 @@ flowchart TB
 | 任务 | 问题描述 `problem_statement` | 上游数据集 |
 | 判定 | `FAIL_TO_PASS`（修好后应通过）、`PASS_TO_PASS`（不能回归）、`test_patch` | 上游数据集 |
 
-**镜像只是环境，题目与判定在元数据里。** 只有镜像、没有元数据，题是跑不了的。
+镜像只是环境，题目与判定在元数据里。只有镜像没有元数据，题跑不了。
 
 ## 装依赖与配置凭据
 
@@ -71,7 +71,7 @@ flowchart TB
 mkdir swe-demo && cd swe-demo
 python -m venv .venv
 .venv/bin/pip install pyyaml \
-  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@571ea037897d8eb332a83c48319926505b4a05a5"
+  "mini-swe-agent[e2b] @ git+https://github.com/aliyun-fc/mini-swe-agent@v2.4.6-fc.1"
 
 # 云沙箱：SDK 由 domain 推导出接入点（https://api.<domain>），不需要单独配 api_url
 export E2B_API_KEY="<your-e2b-api-key>"
@@ -82,15 +82,14 @@ export OPENAI_API_KEY="<your-model-api-key>"
 export MSWEA_CONFIGURED=true MSWEA_SILENT_STARTUP=1
 ```
 
-**pin 到完整 commit SHA，不要 pin 分支。** 分支会随后续提交移动，今天装到的和下周装到的
-不是同一份代码，评测结果就不可复现。装完确认一下：
+装完确认一下：
 
 ```bash
 .venv/bin/python -c "import minisweagent; print(minisweagent.__version__)"
 # 2.4.6+fc.1
 ```
 
-> 网络受限时可以先 `git clone https://github.com/aliyun-fc/mini-swe-agent`，再 `pip install -e ".[e2b]"`。
+> 网络受限时可以先 `git clone https://github.com/aliyun-fc/mini-swe-agent`，`git checkout v2.4.6-fc.1`，再 `pip install -e ".[e2b]"`。
 
 ## 执行环境：用内置的 `e2b`
 
@@ -103,7 +102,7 @@ environment:
 
 它第一次用到某个镜像时注册成持久模板（`Template.build`），之后命中缓存；每个实例起一个沙箱，命令走 `commands.run`，补丁按官方协议回传。
 
-**云沙箱与本地 docker 有五处差异，内置类都处理了。** 自行实现执行底座、或排查异常时会撞上：
+云沙箱与本地 docker 有五处差异，内置类都处理了。自行实现执行底座或排查异常时会撞上这些：
 
 | 差异 | 不处理的后果 | 处理方式 |
 | --- | --- | --- |
@@ -139,7 +138,7 @@ model:
   cost_tracking: ignore_errors   # 自建端点的模型不在价格表里，否则成本计算会抛错
 agent:
   # 沿用官方 swebench.yaml 的 250。实测压到 40 时 4 个实例 3 个撞上限，其中一个已改好、
-  # 只差一步交卷却记 0 分 —— 上限压低会系统性低估分数
+  # 只差一步交卷却记 0 分。上限压低会整体低估分数
   step_limit: 250
   # 步数管不了时间：实测有实例跑到 35 分钟仍未收尾，一直占着并发位与计费沙箱。
   # 注意字段名是 wall_time_limit_seconds，写错不会报错、会被静默忽略
@@ -147,7 +146,7 @@ agent:
   cost_limit: 0     # 自建端点的模型不在价格表里，按成本卡上限没有意义
 ```
 
-`require_existing_cwd` 默认关闭（与上游一致），**基于仓库的题库都应打开** —— 它是这类静默失败唯一的拦网。
+`require_existing_cwd` 这个配置项默认关闭（与上游一致），但批量入口 `mini-extra swebench` 跑 e2b 时会自动打开；单题脚本要自己写上。**基于仓库的题库都应打开** —— 它是这类静默失败唯一的拦网。
 
 ## 驱动 Agent：`run.py`
 
@@ -200,7 +199,7 @@ print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(p
 
 判定口径与 SWE-bench 官方一致：`FAIL_TO_PASS` 全部通过，且 `PASS_TO_PASS` 没有回归。
 
-**判分在全新沙箱里做，不复用 Agent 的工作沙箱。** Agent 跑完后那个沙箱已经不是原始现场了 —— 它可能装过额外的包（测试可能因此意外通过）、改过测试文件或 `conftest.py`、留下临时文件。云沙箱的镜像是不可变的，所以只要用同一镜像新建一个沙箱，仓库就自动回到原始状态，不需要清理 Agent 的痕迹。模板已缓存，第二个沙箱起来只要几秒。
+判分要在全新沙箱里做，不能复用 Agent 的工作沙箱。Agent 跑完后那个沙箱已经不是原始现场：可能装过额外的包（测试可能因此意外通过）、改过测试文件或 `conftest.py`、留下临时文件。云沙箱的镜像是不可变的，所以只要用同一镜像新建一个沙箱，仓库就自动回到原始状态，不需要清理 Agent 的痕迹。模板已缓存，第二个沙箱起来只要几秒。
 
 ```python
 # grade.py
@@ -338,7 +337,7 @@ finally:
 
 ```bash
 .venv/bin/python grade.py --gold
-# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.64s"}
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed, 21 warnings in 0.71s"}
 ```
 
 自检不通过，说明这条链路本身有问题（镜像、工作目录、测试引入方式、用例名匹配），此时 Agent 的得分没有意义。自检通过后跑 Agent 并判分：
@@ -349,14 +348,14 @@ finally:
 #  "template": "fc-e2b-registry-…-46a01131", "sandbox_id": "sbx-…"}
 
 .venv/bin/python grade.py --patch out.patch
-# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed in 0.75s"}
+# {"resolved": true, "FAIL_TO_PASS": "1/1", "PASS_TO_PASS": "1/1", "summary": "2 passed, 21 warnings in 0.76s"}
 ```
 
 首次运行会把镜像注册成模板（幂等，之后命中缓存 1~2 秒）。模型有随机性，`model_calls` 与 `patch_bytes` 会浮动。
 
 ## 扩展到批量评测
 
-从一道题到 N 道题，不用自己写并发编排 —— mini-SWE-agent 自带批量评测入口 `mini-extra swebench`，按实例隔离、并发、写 `preds.json`、跑完回收沙箱都由它负责。你要做的只有一件事：**把每道题的镜像地址喂给它**。
+从一道题到 N 道题不用自己写并发编排：mini-SWE-agent 自带批量评测入口 `mini-extra swebench`，按实例隔离、并发、写 `preds.json`、跑完回收沙箱都由它负责。你要做的只有一件事：**把每道题的镜像地址喂给它**。
 
 ### 解析层：镜像地址必须查表得到
 
@@ -405,19 +404,19 @@ with (out / "train.jsonl").open("w") as f:
 
 结果落在 `results/preds.json`（`instance_id → model_patch`），每个实例另有一份轨迹，里面记着 `sandbox_id` 与 `template`，便于回溯到具体那次执行。
 
-**同一批只能放同族镜像。** `cwd` 与 `run_as_user` 在配置里是全批共用的，而不同题库的工作目录不同（见「换题库要改什么」），所以要按镜像族分批跑，每族一份 `demo.yaml`。
+同一批只能放同族镜像：`cwd` 与 `run_as_user` 在配置里是全批共用的，而不同题库的工作目录不同（见「换题库要改什么」），所以要按镜像族分批跑，每族一份 `demo.yaml`。
 
 四个编排约束，前两个内置入口已经做到，后两个仍需你自己设：
 
 | 约束 | 状态 |
 | --- | --- |
 | 单实例失败不拖垮整批 | 内置：异常记进该实例的 `exit_status`，其余继续 |
-| 沙箱一定要回收 | 内置：正常结束、Agent 抛异常、启动命令失败、环境对象被丢弃、进程被 `SIGTERM` 终止五条路径都会 `kill`。最后一条是**立即释放、不等在途实例** —— 调度器会在自己的窗口之后补 SIGKILL（Kubernetes 默认 30 秒，还不够大仓库跑完一步），先等就可能来不及发出 kill 请求。在途实例的工作会丢，但 `preds.json` 是逐实例写的，重跑同一条命令只补没跑完的那些。靠 TTL 兜底会额外计费并占用并发 |
+| 沙箱一定要回收 | 内置：正常结束、Agent 抛异常、启动命令失败、环境对象被丢弃、进程被 `SIGTERM` 终止五条路径都会 `kill`。最后一条是**立即释放、不等在途实例** —— 调度器会在自己的窗口之后补 SIGKILL（Kubernetes 默认 30 秒，还不够大仓库跑完一步），先等就可能来不及发出 kill 请求。kill 请求并发下发、总计 20 秒上限，据此设置你的优雅停机窗口。在途实例的工作会丢，但 `preds.json` 是逐实例写的，重跑同一条命令只补没跑完的那些。靠 TTL 兜底会额外计费并占用并发 |
 | Agent 侧设上限 | 需自己配 `step_limit`、`cost_limit`、`wall_time_limit_seconds`，否则一道难题可能耗掉整批预算。**字段名写错不会报错、会被静默忽略** |
 | 输出截断分档 | 需自己配：终端 15k、单文件 20k、批量 50k 字符，防止上下文被占满 |
 
-**并发建议压在 6 左右。** 同一张镜像的并发首次构建已由内置环境类按模板名互斥（见前文「模板构建」），
-不需要你处理；压并发的理由只剩一个 —— 大镜像在 10 并发下创建沙箱可能超时，串行重试即可成功。
+并发压在 6 左右。同一张镜像的并发首次构建已由内置环境类按模板名互斥（见前文「模板构建」），
+不需要你处理；压并发只剩一个理由：大镜像在 10 并发下创建沙箱可能超时，串行重试即可成功。
 因此创建沙箱失败时应先串行重试一次，再判定实例不可用，否则会把并发压力误记成镜像问题。
 
 ### 判分与 Agent 解耦
@@ -434,13 +433,13 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 | 用例名当命令行参数传给 pytest | 名字含空格括号，报 not found，最终 no tests ran | 跑整个测试文件，再从报告按名字匹配 |
 | 判分命令超时、输出为空被当成「测试未通过」 | 大测试集在高并发下超时，实例被记为 0 通过；串行重跑则全过 | 输出为空或退出码异常时标记为**判分未完成**，不计入分母，降并发重跑 |
 
-最后一类最容易被忽略，也最有害：它把基础设施故障读成模型能力差，而且越是测试用例多的大仓库越容易触发 —— 结果是评测结论被系统性压低，却看不出任何报错。
+最后一类最容易漏。它把基础设施故障读成模型能力差，而且测试用例越多的大仓库越容易触发，结果是分数被整体压低，却看不出任何报错。
 
 ## 上海地域现成的评测镜像
 
 华东1（上海）地域已预置一批开源评测集的镜像，仓库现场与依赖都已就绪，拿到镜像地址构建模板即可使用，无需自行搬运。镜像前缀统一为 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`。
 
-**镜像只解决「环境」。** 一道题能进评测，要三件套齐全：镜像能起、拿得到题目元信息（问题描述与判定用例）、判定方式已实现。按这三件套，这批镜像分三类：
+镜像只解决「环境」。一道题能进评测要三样都齐：镜像能起、拿得到题目元信息（问题描述与判定用例）、判定方式已实现。按这三样，这批镜像分三类：
 
 | 分类 | 镜像数 | 状态 | 你需要做什么 |
 | --- | --- | --- | --- |
@@ -449,7 +448,7 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 | 三、仅提供镜像 | **20,755** | 镜像能起，但题目与镜像的对应关系无法建立 | 只能当预置好依赖的仓库环境用；要做判分需自行找元数据 |
 | 合计 | **77,704** | | |
 
-**只想先跑通，取第一类。** 第二类给出来是因为镜像与题面都是完备的，缺的只是判分实现；第三类给出来是为了完整披露，但它无法自动判分。
+只想先跑通就取第一类。列出第二类是因为镜像与题面都完备，缺的只是判分实现；列出第三类是为了完整披露，它无法自动判分。
 
 > 元数据数据集托管在 HuggingFace 上，**沙箱内不一定能直接访问**。建议在能出网的环境先把需要的字段（`problem_statement` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch`）导出成本地文件，再随评测任务下发；不要在批量评测过程中现拉，一旦拉取失败会把整批拖住。
 
@@ -468,7 +467,7 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 - **SWE-Gym、SWE-rebench V2（python）**：与本文 `grade.py` 完全一致 —— 打 `test_patch` 引入用例，再跑 pytest。SWE-rebench V2 的 python 子集测试命令统一是 `pytest --no-header`，所以口径能直接对上；换库只需换镜像地址，工作目录改为运行时探测。
 - **Scale-SWE**：**没有 `test_patch`**。`FAIL_TO_PASS` 指向一个注入的新测试文件，内容在 `f2p_script` 字段（或打在已有测试文件上的 `f2p_patch`）；复位靠 `pre_commands`。要改 `grade.py` 里引入用例的那一段，顺序也不能反 —— `pre_commands` 里的 `git clean -fd` 会删掉未跟踪文件，先写测试再复位等于白写。
 
-**仓库多样性差别很大**：Scale-SWE 覆盖 1,180 个仓库，SWE-rebench V2 的 python 子集 689 个，而 SWE-Gym 只有 11 个（pandas、moto 等占大头）。做跨仓库泛化的基线要看「仓库数」这一列 —— 只用 SWE-Gym 会有天花板，题目再多也集中在同几个仓库上。
+仓库多样性差别很大：Scale-SWE 覆盖 1,180 个仓库，SWE-rebench V2 的 python 子集 689 个，而 SWE-Gym 只有 11 个（pandas、moto 等占大头）。做跨仓库泛化的基线要看「仓库数」这一列。只用 SWE-Gym 会有天花板，题目再多也集中在同几个仓库上。
 
 ### 二、元数据齐备，判定需自行实现：27,837 张
 
@@ -484,9 +483,9 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 | Terminal-Bench 2.x | **89** | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | 任务目录名即镜像 tag | 跑任务自带的 `tests/test.sh`，**判分不用自己写**；但 Agent 循环要换 —— 它不产出补丁 |
 | SWE-Atlas QnA | **11** | 仓库问答，不产补丁 | [ScaleAI/SWE-Atlas-QnA](https://huggingface.co/datasets/ScaleAI/SWE-Atlas-QnA) | `docker_image` | 按 rubric 打分，需要模型评判而非跑测试 |
 
-其中 SWE-smith 值得单独一提：**它的「镜像数」和「题量」不是一回事**。363 张是环境镜像（一个仓库一张），背后挂着上游 79,418 道题，靠切分支选题 —— 接好选题机制后，它是这批资产里题量最大的一个来源。
+SWE-smith 的「镜像数」和「题量」不是一回事。363 张是环境镜像，一个仓库一张，背后挂着上游 79,418 道题，靠切分支选题。接好选题机制后，它是这批资产里题量最大的来源。
 
-**多语言题库要按语言分流判定。** 以 SWE-rebench V2 为例，用例名的形态随测试框架而变：python 是 pytest 的 node id（`tests/test_x.py::TestA::test_b`），TS / JS 是 jest、mocha 的用例描述，Java 是测试类名。用一套 pytest 的解析逻辑套所有语言，非 python 的实例会**全部判为失败**。清单里的 `swerebenchv2-languages.tsv`（id → 语言）可用于筛选。测试命令的形态比语言集中：Go 全是 `go test`、Rust 全是 `cargo test`、Java 是 Maven 与 Gradle 两种、JS / TS 是 npm 系的 jest / mocha / vitest 等 —— 按四到五组实现解析器即可覆盖大部分。SWE-bench Pro 同理，按 `repo_language` 分流。
+多语言题库要按语言分流判定。以 SWE-rebench V2 为例，用例名的形态随测试框架而变：python 是 pytest 的 node id（`tests/test_x.py::TestA::test_b`），TS / JS 是 jest、mocha 的用例描述，Java 是测试类名。用一套 pytest 的解析逻辑套所有语言，非 python 的实例会**全部判为失败**。清单里的 `swerebenchv2-languages.tsv`（id → 语言）可用于筛选。测试命令的形态比语言集中：Go 全是 `go test`、Rust 全是 `cargo test`、Java 是 Maven 与 Gradle 两种、JS / TS 是 npm 系的 jest / mocha / vitest 等 —— 按四到五组实现解析器即可覆盖大部分。SWE-bench Pro 同理，按 `repo_language` 分流。
 
 ### 三、仅提供镜像：元数据需自行匹配，20,755 张
 
@@ -583,7 +582,7 @@ awk -F'\t' 'NR>1{print $4"  "$1}' MANIFEST.tsv > sums && sha256sum -c sums
 for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done   # 例如探出 /cfn-lint
 ```
 
-**把探到的值填回 `demo.yaml`。** 解析只做一次，`run.py` 与 `grade.py` 只认具体值 —— 批量评测时这一步属于解析层，开跑前一次性完成，不要每个实例现探。后文的验收脚本支持把 `cwd` 写成 `auto`，由它探测并打印。
+把探到的值填回 `demo.yaml`。解析只做一次，`run.py` 与 `grade.py` 只认具体值。批量评测时这一步属于解析层，开跑前一次性完成，不要每个实例现探。后文的验收脚本支持把 `cwd` 写成 `auto`，由它探测并打印。
 
 镜像地址与工作目录必须**成对**更换。配了 `require_existing_cwd: true` 时改错会启动即失败：
 
@@ -630,7 +629,7 @@ For a repository-based task this means it is misconfigured: …
 
 下面这份脚本是这四步的实现：一个沙箱跑完，不花模型 token。抽样几十上百张镜像时它比 `grade.py --gold` 便宜一个数量级 —— 后者要打补丁、跑完整测试文件。`cwd` 写 `auto` 时它会在沙箱内探测仓库目录（见「换题库要改什么」）。
 
-**它只适用于 Python 题库** —— 测试执行器写死 `python -m pytest`、用例名按 pytest node id 解析。换 Go / Java / JS 题库要同时改这两处，判分器同理（见前文「多语言题库要按语言分流判定」）。
+它只适用于 Python 题库：测试执行器写死 `python -m pytest`、用例名按 pytest node id 解析。换 Go / Java / JS 题库要同时改这两处，判分器同理（见前文「多语言题库要按语言分流判定」）。
 
 ```python
 # preflight.py
@@ -755,7 +754,7 @@ sys.exit(0 if report["ok"] else 1)
 | Go 装在 `/usr/local/go/bin`，不在默认 PATH | 正常的 Go 仓库镜像被判「没有测试执行器」 |
 | Java 项目不装全局 mvn/gradle，而是带 `./gradlew` | 正常镜像被误判 |
 
-上面的脚本与 `grade.py` 读同一份配置，所以第一类误判从结构上就不会发生 —— 这也是不要让验收脚本自己拼一份环境变量的原因。
+上面的脚本与 `grade.py` 读同一份配置，所以第一类误判不会发生。这就是不要让验收脚本自己拼环境变量的原因。
 
 ## 上线建议
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
@@ -587,7 +587,7 @@ for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done   # 例如探�
 
 镜像地址与工作目录必须**成对**更换。配了 `require_existing_cwd: true` 时改错会启动即失败：
 
-```
+```text
 RuntimeError: Working directory /testbed was not in the image and has been created empty.
 For a repository-based task this means it is misconfigured: …
 ```
@@ -630,9 +630,11 @@ For a repository-based task this means it is misconfigured: …
 
 下面这份脚本是这四步的实现：一个沙箱跑完，不花模型 token。抽样几十上百张镜像时它比 `grade.py --gold` 便宜一个数量级 —— 后者要打补丁、跑完整测试文件。`cwd` 写 `auto` 时它会在沙箱内探测仓库目录（见「换题库要改什么」）。
 
+**它只适用于 Python 题库** —— 测试执行器写死 `python -m pytest`、用例名按 pytest node id 解析。换 Go / Java / JS 题库要同时改这两处，判分器同理（见前文「多语言题库要按语言分流判定」）。
+
 ```python
 # preflight.py
-import json, re, shlex, sys
+import argparse, json, re, shlex, sys
 from pathlib import Path
 
 import yaml
@@ -642,21 +644,32 @@ from minisweagent.utils.serialize import recursive_merge
 
 PROBE = 'for d in /*/; do [ -d "$d/.git" ] && echo "${d%/}" && break; done'
 
+def as_list(v):
+    """与 grade.py 同一条规则：字段可能是 JSON 字符串，也可能就是一条普通字符串。"""
+    if isinstance(v, str):
+        try:
+            return json.loads(v)
+        except json.JSONDecodeError:
+            return [v] if v else []
+    return list(v or [])
+
 def test_files(instance):
     """判定用例所在的文件。只取带文件前缀的名字，规则与 grade.py 一致。"""
-    names = []
-    for key in ("FAIL_TO_PASS", "PASS_TO_PASS"):
-        v = instance.get(key)
-        names += json.loads(v) if isinstance(v, str) else list(v or [])
+    names = as_list(instance.get("FAIL_TO_PASS")) + as_list(instance.get("PASS_TO_PASS"))
     return sorted({n.strip().strip("'\"").split("::")[0] for n in names
                    if "::" in n or n.strip().strip("'\"").endswith(".py")})
+
+p = argparse.ArgumentParser("preflight")
+p.add_argument("-c", "--config", type=Path, default=Path("demo.yaml"))
+p.add_argument("--instance", type=Path, default=Path("instance.json"))
+a = p.parse_args()
 
 # 与 run.py、grade.py 做同一次叠加，环境变量因此天然一致
 cfg = recursive_merge(
     yaml.safe_load((builtin_config_dir / "benchmarks" / "swebench.yaml").read_text()),
-    yaml.safe_load(Path("demo.yaml").read_text()),
+    yaml.safe_load(a.config.read_text()),
 )
-instance = json.loads(Path("instance.json").read_text())[0]
+instance = json.loads(a.instance.read_text())[0]
 env_cfg = cfg["environment"]
 report = {}
 


### PR DESCRIPTION
## 这个 PR 做什么

把「构建 SWE Agent」里的执行环境从**读者自己粘 126 行代码**改成**装一个包 + 写一行配置**。

| | 改前（main） | 改后 |
| --- | --- | --- |
| 装依赖 | `pip install e2b "mini-swe-agent>=2.4" pyyaml`（上游版，不含云沙箱执行环境） | `pip install pyyaml "mini-swe-agent[e2b] @ git+…@<SHA>"` |
| 执行环境 | 正文内联 `fc_env.py`，**126 行**，读者必须整段复制 | 配置里一行 `environment_class: e2b` |
| 批量编排 | 正文给 `batch.py（骨架）`，30 行，读者自己补并发/回收/汇总 | 用官方入口 `mini-extra swebench` |
| 正文 python 代码 | 334 行 | 255 行，且**没有一行是基础设施代码** |

改前那 126 行不是可选的 —— 不复制就跑不起来。而它一旦被复制进读者的项目，就与我们脱钩了：
后续任何修复都到不了他们手里。现在这份实现在
[aliyun-fc/mini-swe-agent#1](https://github.com/aliyun-fc/mini-swe-agent/pull/1) 里维护，
读者升级 pin 即可拿到修复。类名 `E2BEnvironment`、注册键 `e2b`、配置字段都与上游
[SWE-agent/mini-swe-agent#792](https://github.com/SWE-agent/mini-swe-agent/pull/792) 对齐，
上游合并后把 pin 换成上游版就能退役这个 fork。

剩下的 255 行全是评测业务本身：驱动 agent、判分、解析镜像、验收 —— 那些本来就该由读者掌握。

## 顺带修正的地方

全部代码块都从本文抽出、在上海地域真实镜像上跑过：判分器自检 `resolved: true` →
Agent `Submitted` → 判分 `resolved: true`；批量入口 2/2 `Submitted`、沙箱残留 0。
过程中发现并修掉：

**两处照着跑必然失败**

- `prepare.py` 读一个 `image-index.json`，而清单发布的是 TSV，全文没交代这个 json 从哪来
  → `FileNotFoundError`。改为直接读清单前两列。
- 约束表里的 `wall_time_limit` 字段名不存在（真名 `wall_time_limit_seconds`），而且
  **写错不报错、会被静默忽略** —— 读者会配一个不生效的时间上限还以为有保护。

**两处会让分数失真**

- `step_limit` 回到官方 `swebench.yaml` 的 250。实测压到 40 时 4 个实例 3 个撞上限，
  其中一个已经改好、测试全过，只差一步交卷却记 0 分。同时补 `wall_time_limit_seconds`
  —— 250 步没有时间约束时，实测有实例跑到 35 分钟仍未收尾，一直占着并发位与计费沙箱。
- 新增一项验收检查：镜像若保留了 `HEAD` 之后的历史，答案能直接从 git 里翻出来。实测
  SWE-Gym 的一张 moto 镜像有 237 个 tag、未来提交比 `HEAD` 晚一年半，gold 补丁新增的类名
  可以 `git grep` 到；SWE-rebench V2 的镜像是 0。这让分数偏高且完全不可见。

**其余**：依赖 pin 到 commit SHA（tag 尚未打，pin 分支则结果不可复现）；凭据统一到 litellm
认的 `OPENAI_API_KEY`，原先那个自定义变量只有文中 `run.py` 认，照着配批量会重试三次各
60 秒后报 `Missing credentials`；执行环境层补两处差异（超时丢输出、工作目录被静默创建）
与模板构建的并发约束；原有那份四步验收清单第一次有了可运行的实现。

## 待办

en-US 版本尚未同步本轮修正。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 文档范围

- 涉及阿里云函数计算的“云沙箱”产品文档。
- 涉及“最佳实践 > 构建 SWE Agent”章节。
- 同时修改 `zh-CN` 和 `en-US` 版本。
- 更新 SWE Agent 的 E2B 执行环境、批量评测、配置、并发限制、验收流程和沙箱回收说明。

## 页面与资源变更

- 未新增页面。
- 未删除页面。
- 未改动图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->