### PR TITLE
docs(sandbox): 构建自定义镜像模板官方镜像 v0.0.44 升级为 v0.0.47

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -163,14 +163,14 @@ FC Agent Sandbox provides official images that do not require your own ACR EE in
 Reuse the Python script from the quick start section and use the following image address:
 
 ```bash
-FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.44"
+FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.47"
 ```
 
 The current official FC Agent Sandbox image addresses for the Beijing region are:
 
 ```bash
-fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.44
-fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.44
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.47
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.47
 ```
 
 ### Use CLI to view templates and create sandboxes

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
@@ -163,14 +163,14 @@ try {
 复用快速开始的 Python 脚本，直接使用以下镜像地址：
 
 ```bash
-FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.44"
+FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.47"
 ```
 
 目前北京地域的云沙箱官方镜像地址列表为：
 
 ```bash
-fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.44
-fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.44
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.47
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.47
 ```
 
 ### 使用 CLI 查看模板并创建沙箱


### PR DESCRIPTION
## Summary
- 「构建自定义镜像模板」官方镜像版本号由 `v0.0.44` 更新为 `v0.0.47`，覆盖 zh-CN 与 en-US 两个文件各三处（FROM_IMAGE 示例 + 北京官方镜像列表 base、code-interpreter-v1）
- 北京官方仓库已通过 skopeo 确认 `runtime/base:v0.0.47` 与 `runtime/code-interpreter-v1:v0.0.47` 均存在（digest 分别为 `sha256:7fc0a62b...`、`sha256:79be1ad7...`）
- 修复 AOne 缺陷 85985158：用户按文档使用 `v0.0.44` 旧镜像导致 run_code 报错 404

## Test plan
- [x] `make check` 全过（test + check-docs + mkdocs strict build）
- [ ] 按「使用云沙箱官方镜像」小节使用 `code-interpreter-v1:v0.0.47` 构建模板并创建沙箱验证 `run_code`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本次 PR 修改函数计算云沙箱（FC Agent Sandbox）文档，涉及“模板”章节中的“构建自定义镜像模板”页面。

- 更新 zh-CN 和 en-US 文档中的官方镜像版本，将 `v0.0.44` 更新为 `v0.0.47`。
- 更新 `FROM_IMAGE` 示例，以及北京地域官方镜像列表中的 `base` 和 `code-interpreter-v1` 镜像。
- 未新增或删除页面。
- 未修改图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->