### PR TITLE
docs(sandbox): add large file transfer best practice

### DIFF
--- a/docs/zh-CN/01.云沙箱/04.功能说明/04.文件系统/03.上传和下载文件.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/04.文件系统/03.上传和下载文件.md
@@ -2,6 +2,8 @@
 
 上传和下载地址适合浏览器直传、把结果文件交给未持有 SDK 鉴权信息的环境，或把文件交给后续系统处理。小文件、二进制内容、流式内容和 Agent 生成代码优先使用 `sandbox.files.write()` 和 `sandbox.files.read()`。
 
+> **大文件说明**：单个 HTTP 请求正文最大为 32 MiB。上传接近或超过该大小的文件时，请使用 OSS 中转或分块直传；完整方案和示例参见[FC 云沙箱大文件上传最佳实践：OSS 中转与分块直传](../../05.最佳实践/13.大文件上传最佳实践.md)。
+
 > **注意**：如果要使用 `sandbox.downloadUrl()` 和 `sandbox.uploadUrl()` 返回的 URL 上传和下载文件，确保在创建 Sandbox 时显式设置了 `secure=false`。否则，通过 URL 上传和下载文件仍需要请求方携带 `X-Access-Token`。
 
 Python 示例：
@@ -113,4 +115,5 @@ console.log(result.stdout.trim());
 
 - 小文件、文本文件、二进制内容、流式内容和 Agent 生成代码：使用 `sandbox.files.write()` 和 `sandbox.files.read()`。
 - 浏览器直传、下载结果文件或把文件交给未持有 SDK 鉴权信息的环境：使用 `sandbox.uploadUrl()` 和 `sandbox.downloadUrl()`，并在创建 Sandbox 时设置 `secure=false`。
+- 接近或超过 32 MiB 的文件：使用 [OSS 中转或分块直传](../../05.最佳实践/13.大文件上传最佳实践.md)。
 - 目录遍历、重命名或删除：使用 Filesystem API。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/04.文件系统/03.上传和下载文件.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/04.文件系统/03.上传和下载文件.md
@@ -3,7 +3,7 @@
 上传和下载地址适合浏览器直传、把结果文件交给未持有 SDK 鉴权信息的环境，或把文件交给后续系统处理。小文件、二进制内容、流式内容和 Agent 生成代码优先使用 `sandbox.files.write()` 和 `sandbox.files.read()`。
 
 > **大文件说明**：单个 HTTP 请求正文最大为 32 MiB。上传接近或超过该大小的文件时，请使用 OSS 中转或分块直传；完整方案和示例参见[FC 云沙箱大文件上传最佳实践：OSS 中转与分块直传](../../05.最佳实践/13.大文件上传最佳实践.md)。
-
+>
 > **注意**：如果要使用 `sandbox.downloadUrl()` 和 `sandbox.uploadUrl()` 返回的 URL 上传和下载文件，确保在创建 Sandbox 时显式设置了 `secure=false`。否则，通过 URL 上传和下载文件仍需要请求方携带 `X-Access-Token`。
 
 Python 示例：

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/13.大文件上传最佳实践.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/13.大文件上传最佳实践.md
@@ -1,0 +1,336 @@
+# FC 云沙箱大文件上传最佳实践：OSS 中转与分块直传
+
+云沙箱的文件上传接口经过函数计算 HTTP 网关，单个请求正文最大为 32 MiB（33,554,432 字节）。当文件接近或超过该限制时，直接调用 `sandbox.files.write()` 或向 `sandbox.uploadUrl()` 返回的地址上传，可能返回以下错误：
+
+```text
+400 EntityTooLarge: payload size exceeds maximum allowed size (33554432 bytes)
+```
+
+Python SDK `e2b==2.31.0` 会把该响应抛为 `InvalidArgumentException`，异常消息中的 `Code` 仍为 `EntityTooLarge`。
+
+大文件可通过 OSS 中转或分块直传进入 Sandbox。本文说明两种方案的取舍和实现方式。小于 25 MiB 的文件仍建议直接使用 Filesystem API；25 MiB 为给 HTTP 请求头和 multipart 编码预留空间后的保守值。
+
+## 方案选择
+
+| 维度 | OSS 中转 | 分块直传 |
+| --- | --- | --- |
+| 数据路径 | 客户端 → OSS → Sandbox | 客户端 → Sandbox |
+| 额外依赖 | OSS Bucket、OSS SDK | 仅 E2B SDK |
+| 推荐规模 | 生产环境、数百 MiB 至 TiB 级文件 | 偶发的中等文件，建议不超过 500 MiB |
+| 并发和断点续传 | OSS SDK 原生支持 | 需要业务侧实现 |
+| 多 Sandbox 共享 | 支持，同一 OSS 对象可生成多个签名 URL | 不适合 |
+| Sandbox 磁盘占用 | 下载时约为一个文件的大小 | 合并期间约为文件大小的两倍 |
+| 大文件下载 | 支持，Sandbox 可把结果上传到 OSS | 需要反向切块，建议改用 OSS |
+
+可按以下规则选择：
+
+- 文件小于 25 MiB：调用 `sandbox.files.write()` 一次上传。
+- 文件为 25～500 MiB，且希望减少外部依赖：按 25 MiB 分块上传，在 Sandbox 内合并。
+- 文件大于 500 MiB，或需要断点续传、并发传输、跨 Sandbox 共享、长期保存：使用 OSS 中转。
+- Sandbox 生成的大文件需要下载到客户端：优先上传到 OSS，再向客户端返回 OSS 签名 URL。
+
+500 MiB 是便于初始选型的建议值，不是产品限制。应根据客户端带宽、失败重试成本、Sandbox 磁盘容量和任务时限调整阈值。
+
+## 前置条件
+
+本文 Python 示例使用仓库统一的 E2B SDK 版本：
+
+```bash
+pip install e2b==2.31.0
+```
+
+配置 API Key 和目标地域的 Endpoint：
+
+```bash
+export E2B_API_KEY="<your-api-key>"
+export E2B_API_URL="https://api.<region>.e2b.fc.aliyuncs.com"
+export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
+```
+
+`E2B_API_URL` 包含 `api.` 前缀，`E2B_DOMAIN` 不包含。两者的 `<region>` 必须与 Sandbox 所在地域一致。
+
+## 方案一：通过 OSS 中转
+
+OSS 中转把传输拆为两段：客户端使用 OSS SDK 分片上传，Sandbox 再通过同地域 OSS 内网 Endpoint 下载。处理完成后，Sandbox 也可以通过预签名 PUT URL 把结果写回 OSS。
+
+```text
+客户端 ──分片上传──> OSS ──内网下载──> Sandbox
+客户端 <──签名下载地址── OSS <──结果上传── Sandbox
+```
+
+该方案把重试、并发和断点续传交给 OSS，适合生产环境和超大文件。Bucket 应与 Sandbox 位于同一地域，并保持私有读写权限。
+
+### 准备 OSS
+
+安装 OSS Python SDK：
+
+```bash
+pip install e2b==2.31.0 oss2
+```
+
+以下环境变量以杭州地域为例：
+
+```bash
+export OSS_ACCESS_KEY_ID="<your-access-key-id>"
+export OSS_ACCESS_KEY_SECRET="<your-access-key-secret>"
+# 使用 STS 临时凭证时再设置该变量
+export OSS_SECURITY_TOKEN="<your-security-token>"
+
+export OSS_BUCKET="<your-private-bucket>"
+export OSS_PUBLIC_ENDPOINT="https://oss-cn-hangzhou.aliyuncs.com"
+export OSS_INTERNAL_ENDPOINT="https://oss-cn-hangzhou-internal.aliyuncs.com"
+export LOCAL_FILE="/path/to/large-file.bin"
+```
+
+生产环境应使用 RAM 角色签发的 STS 临时凭证，并按对象前缀授予最小权限。AK、SK 和 STS Token 只用于可信业务服务生成签名 URL，不要传入 Sandbox。
+
+### 上传、处理并回传结果
+
+以下示例完成四个步骤：把本地文件分片上传到 OSS、生成内网签名 URL、在 Sandbox 内下载并计算 SHA-256、把校验结果上传回 OSS。
+
+```python
+import hashlib
+import os
+import shlex
+from pathlib import Path
+
+import oss2
+from e2b import Sandbox
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"缺少环境变量: {name}")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for block in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def run_checked(sandbox: Sandbox, command: str, timeout: int = 300):
+    result = sandbox.commands.run(command, timeout=timeout)
+    if result.exit_code != 0:
+        raise RuntimeError(result.stderr or f"命令执行失败: {command}")
+    return result
+
+
+local_file = Path(require_env("LOCAL_FILE")).expanduser()
+bucket_name = require_env("OSS_BUCKET")
+object_key = f"sandbox-input/{local_file.name}"
+result_key = f"sandbox-result/{local_file.name}.sha256"
+remote_file = f"/tmp/{local_file.name}"
+remote_result = f"{remote_file}.sha256"
+
+access_key_id = require_env("OSS_ACCESS_KEY_ID")
+access_key_secret = require_env("OSS_ACCESS_KEY_SECRET")
+security_token = os.environ.get("OSS_SECURITY_TOKEN", "").strip()
+if security_token:
+    auth = oss2.StsAuth(access_key_id, access_key_secret, security_token)
+else:
+    auth = oss2.Auth(access_key_id, access_key_secret)
+
+public_bucket = oss2.Bucket(
+    auth,
+    require_env("OSS_PUBLIC_ENDPOINT"),
+    bucket_name,
+)
+internal_bucket = oss2.Bucket(
+    auth,
+    require_env("OSS_INTERNAL_ENDPOINT"),
+    bucket_name,
+)
+
+# 1. 客户端到 OSS：大于 10 MiB 时启用分片和并发上传。
+oss2.resumable_upload(
+    public_bucket,
+    object_key,
+    str(local_file),
+    multipart_threshold=10 * 1024 * 1024,
+    part_size=10 * 1024 * 1024,
+    num_threads=4,
+)
+
+# 2. URL 中使用内网 Endpoint，供同地域 Sandbox 访问。
+download_url = internal_bucket.sign_url("GET", object_key, 3600, slash_safe=True)
+upload_url = internal_bucket.sign_url("PUT", result_key, 3600, slash_safe=True)
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=require_env("E2B_API_KEY"),
+    api_url=require_env("E2B_API_URL"),
+    domain=require_env("E2B_DOMAIN"),
+    timeout=600,
+)
+
+try:
+    # 3. OSS 到 Sandbox：使用签名 URL 下载，无需在 Sandbox 内保存 OSS 凭证。
+    run_checked(
+        sandbox,
+        "curl --fail --location --silent --show-error "
+        f"{shlex.quote(download_url)} --output {shlex.quote(remote_file)}",
+    )
+    run_checked(
+        sandbox,
+        f"sha256sum {shlex.quote(remote_file)} > {shlex.quote(remote_result)}",
+    )
+
+    # 此处执行实际文件处理逻辑。
+
+    # 4. Sandbox 到 OSS：通过预签名 PUT URL 回传结果。
+    run_checked(
+        sandbox,
+        "curl --fail --silent --show-error --request PUT "
+        f"--upload-file {shlex.quote(remote_result)} {shlex.quote(upload_url)}",
+    )
+finally:
+    sandbox.kill()
+
+remote_digest = public_bucket.get_object(result_key).read().decode().split()[0]
+local_digest = sha256_file(local_file)
+if remote_digest != local_digest:
+    raise RuntimeError(f"文件校验失败: local={local_digest}, sandbox={remote_digest}")
+
+print(f"上传和校验完成: oss://{bucket_name}/{object_key}")
+```
+
+在正式业务中，还应记录 OSS Upload ID 或使用 `oss2.resumable_upload()` 的断点信息，并为网络错误添加带退避的重试。签名 URL 的有效期应覆盖 Sandbox 排队、下载和处理时间。
+
+## 方案二：分块直传
+
+分块直传把本地文件切成多个不超过 25 MiB 的块，逐块调用 `sandbox.files.write()`，最后在 Sandbox 内按编号合并。该方案不依赖 OSS，但任何一块失败都需要业务侧决定从头重传还是记录进度后续传。
+
+```text
+客户端 ──chunk_000000──> Sandbox
+       ──chunk_000001──> Sandbox ──按编号合并──> 目标文件
+       ──chunk_000002──> Sandbox
+```
+
+以下代码使用 `use_octet_stream=True` 减少二进制上传的编码开销。SDK 会根据 Sandbox 的 envd 版本判断是否支持该模式；不支持时会自动回退到 `multipart/form-data`。无论使用哪种编码，单块都保持为 25 MiB。
+
+```python
+import hashlib
+import os
+import shlex
+import uuid
+from pathlib import Path
+
+from e2b import Sandbox
+
+
+CHUNK_SIZE = 25 * 1024 * 1024
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"缺少环境变量: {name}")
+    return value
+
+
+def run_checked(sandbox: Sandbox, command: str, timeout: int = 300):
+    result = sandbox.commands.run(command, timeout=timeout)
+    if result.exit_code != 0:
+        raise RuntimeError(result.stderr or f"命令执行失败: {command}")
+    return result
+
+
+local_file = Path(require_env("LOCAL_FILE")).expanduser()
+remote_file = f"/tmp/{local_file.name}"
+remote_dir = f"/tmp/upload-{uuid.uuid4().hex}"
+
+sandbox = Sandbox.create(
+    template="code-interpreter-v1",
+    api_key=require_env("E2B_API_KEY"),
+    api_url=require_env("E2B_API_URL"),
+    domain=require_env("E2B_DOMAIN"),
+    timeout=600,
+)
+
+digest = hashlib.sha256()
+chunk_count = 0
+
+try:
+    with local_file.open("rb") as file:
+        while chunk := file.read(CHUNK_SIZE):
+            digest.update(chunk)
+            chunk_path = f"{remote_dir}/chunk_{chunk_count:06d}"
+            sandbox.files.write(
+                chunk_path,
+                chunk,
+                use_octet_stream=True,
+                request_timeout=300,
+            )
+            chunk_count += 1
+
+    if chunk_count == 0:
+        sandbox.files.write(remote_file, b"")
+    else:
+        run_checked(
+            sandbox,
+            f"cat {shlex.quote(remote_dir)}/chunk_* > {shlex.quote(remote_file)}",
+        )
+
+    result = run_checked(
+        sandbox,
+        f"sha256sum {shlex.quote(remote_file)} | cut -d' ' -f1",
+    )
+    sandbox_digest = result.stdout.strip()
+    local_digest = digest.hexdigest()
+    if sandbox_digest != local_digest:
+        raise RuntimeError(
+            f"文件校验失败: local={local_digest}, sandbox={sandbox_digest}"
+        )
+
+    # 校验通过后再删除分块；此处可继续处理 remote_file。
+    run_checked(sandbox, f"rm -rf -- {shlex.quote(remote_dir)}")
+    print(f"上传完成: {remote_file}, chunks={chunk_count}, sha256={local_digest}")
+finally:
+    sandbox.kill()
+```
+
+示例中的临时目录使用随机名称，避免并发任务互相覆盖。分块名称采用固定宽度数字，确保 shell 按字典序展开时顺序正确。若要支持断点续传，可在业务侧持久化 Sandbox ID、分块编号、分块大小和文件摘要，重试前先用 `sandbox.files.exists()` 检查已上传的分块。
+
+## 处理大文件下载
+
+大文件不适合通过一次 `sandbox.files.read()` 或单个下载请求返回：客户端需要一次接收完整响应，失败后通常也要从头重试。推荐通过 OSS 回传：
+
+1. 可信业务服务为目标 OSS 对象生成短期 PUT 签名 URL。
+2. Sandbox 使用 `curl --upload-file` 把结果上传到 OSS。
+3. 业务服务校验对象大小和摘要，再向客户端签发 GET URL。
+
+如果不能使用 OSS，可先在 Sandbox 内用 `split` 把结果切成不超过 25 MiB 的分块，再通过 `sandbox.files.read(..., format="bytes")` 逐块读取并在客户端合并。该方式同样需要记录分块顺序并校验完整文件摘要，且不具备 OSS 原生的并发和断点续传能力。
+
+## 生产环境检查清单
+
+- 容量：分块直传合并期间会同时保留分块和目标文件，应预留约两倍文件大小的磁盘空间。
+- 完整性：上传前后比较 SHA-256；不要只检查文件是否存在。
+- 安全：Bucket 保持私有，使用最小权限的 STS 凭证和短期签名 URL，不在日志中记录完整 URL。
+- 路径：业务侧生成 Sandbox 内路径，不直接拼接未经校验的用户输入。
+- 重试：OSS 使用分片上传和断点续传；分块直传记录已成功的块，并采用指数退避。
+- 清理：校验成功后删除临时分块，任务结束后调用 `sandbox.kill()`，按生命周期规则清理 OSS 临时对象。
+- 超时：签名 URL、SDK 请求、Sandbox 生命周期和命令执行超时应覆盖最慢链路。
+- 可观测性：记录文件大小、分块数量、耗时、重试次数和摘要，但不要记录凭证或完整签名 URL。
+
+## 性能参考
+
+参考测试在 2026 年 7 月 9 日于杭州地域上传 100 MiB 文件，得到以下结果：
+
+| 方案 | 客户端上传 | OSS 到 Sandbox | 端到端耗时 |
+| --- | --- | --- | --- |
+| OSS 中转 | 约 10.27 MiB/s | 约 99.87 MiB/s | 约 14 秒 |
+| 4 × 25 MiB 分块直传 | 约 10.87 MiB/s | 不适用 | 约 13 秒 |
+
+测试结果只用于展示两种方案在该环境下的数量级，不构成性能承诺。实际速度取决于客户端上行带宽、地域、OSS 配置、文件大小和并发参数。生产选型应使用真实文件和目标网络重新压测。
+
+## 相关文档
+
+- [上传和下载文件](../04.功能说明/04.文件系统/03.上传和下载文件.md)
+- [读写文件](../04.功能说明/04.文件系统/02.读写文件.md)
+- [挂载 OSS Volume](../04.功能说明/12.卷/01.挂载%20OSS%20Volume.md)
+- [E2B SDK 接入参数说明](../07.开发参考/02.E2B%20SDK%20接入参数说明.md)

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/13.大文件上传最佳实践.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/13.大文件上传最佳实践.md
@@ -33,7 +33,7 @@ Python SDK `e2b==2.31.0` 会把该响应抛为 `InvalidArgumentException`，异�
 
 ## 前置条件
 
-本文 Python 示例使用仓库统一的 E2B SDK 版本：
+本文 Python 示例要求 Python 3.10 或更高版本，并使用仓库统一的 E2B SDK 版本。其他版本约束参见[使用约束](../01.开始使用/06.使用约束.md)。
 
 ```bash
 pip install e2b==2.31.0
@@ -80,6 +80,7 @@ export OSS_BUCKET="<your-private-bucket>"
 export OSS_PUBLIC_ENDPOINT="https://oss-cn-hangzhou.aliyuncs.com"
 export OSS_INTERNAL_ENDPOINT="https://oss-cn-hangzhou-internal.aliyuncs.com"
 export LOCAL_FILE="/path/to/large-file.bin"
+export TRANSFER_ID="<stable-unique-transfer-id>"
 ```
 
 生产环境应使用 RAM 角色签发的 STS 临时凭证，并按对象前缀授予最小权限。AK、SK 和 STS Token 只用于可信业务服务生成签名 URL，不要传入 Sandbox。
@@ -122,8 +123,9 @@ def run_checked(sandbox: Sandbox, command: str, timeout: int = 300):
 
 local_file = Path(require_env("LOCAL_FILE")).expanduser()
 bucket_name = require_env("OSS_BUCKET")
-object_key = f"sandbox-input/{local_file.name}"
-result_key = f"sandbox-result/{local_file.name}.sha256"
+transfer_id = require_env("TRANSFER_ID")
+object_key = f"sandbox-transfer/{transfer_id}/input/{local_file.name}"
+result_key = f"sandbox-transfer/{transfer_id}/result/{local_file.name}.sha256"
 remote_file = f"/tmp/{local_file.name}"
 remote_result = f"{remote_file}.sha256"
 
@@ -199,7 +201,7 @@ if remote_digest != local_digest:
 print(f"上传和校验完成: oss://{bucket_name}/{object_key}")
 ```
 
-在正式业务中，还应记录 OSS Upload ID 或使用 `oss2.resumable_upload()` 的断点信息，并为网络错误添加带退避的重试。签名 URL 的有效期应覆盖 Sandbox 排队、下载和处理时间。
+业务侧应为每个传输任务生成唯一且持久化的 `TRANSFER_ID`（例如 UUID），同一任务重试时复用该值。这样可以隔离同名文件的并发任务，并让重试继续访问原 OSS 对象。在正式业务中，还应记录 OSS Upload ID 或使用 `oss2.resumable_upload()` 的断点信息，并为网络错误添加带退避的重试。签名 URL 的有效期应覆盖 Sandbox 排队、下载和处理时间。
 
 ## 方案二：分块直传
 
@@ -294,7 +296,7 @@ finally:
     sandbox.kill()
 ```
 
-示例中的临时目录使用随机名称，避免并发任务互相覆盖。分块名称采用固定宽度数字，确保 shell 按字典序展开时顺序正确。若要支持断点续传，可在业务侧持久化 Sandbox ID、分块编号、分块大小和文件摘要，重试前先用 `sandbox.files.exists()` 检查已上传的分块。
+示例中的临时目录使用随机名称，避免并发任务互相覆盖。分块名称采用固定宽度数字，确保 shell 按字典序展开时顺序正确。该基础示例在 `finally` 中终止 Sandbox，因此任一分块失败后需要重新上传。若要支持断点续传，业务侧必须在受控的恢复窗口内保留 Sandbox，持久化 Sandbox ID、分块编号、分块大小和文件摘要，重连后用 `sandbox.files.exists()` 检查已上传的分块；上传成功或明确放弃任务时再终止 Sandbox。
 
 ## 处理大文件下载
 


### PR DESCRIPTION
## 变更说明

本次修改涉及云沙箱的“文件系统”和“最佳实践”章节：

- 新增大文件上传最佳实践，说明 32 MiB 请求限制、OSS 中转和 25 MiB 分块直传方案。
- 补充 SDK 版本、完整性校验、任务隔离、重试、资源清理和生产选型建议。
- 在“上传和下载文件”页面增加最佳实践入口。

## 变更类型

- [x] 修正文档内容
- [x] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [x] 已运行 `make check`
- [x] 已检查新增或修改的链接和图片
- [x] 未提交真实凭证或敏感信息

补充验证：使用 `e2b==2.31.0` 验证 33 MiB 单次直传返回 `EntityTooLarge`，40 MiB 分块直传及 OSS 中转后的 SHA-256 均一致。

## 相关 Issue

无。