### PR TITLE
docs(sandbox): 构建自定义镜像模板官方镜像版本 v0.0.47 升级为 v0.0.48

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/03.Build Custom Image Templates.md
@@ -163,14 +163,14 @@ FC Agent Sandbox provides official images that do not require your own ACR EE in
 Reuse the Python script from the quick start section and use the following image address:
 
 ```bash
-FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.47"
+FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.48"
 ```
 
 The current official FC Agent Sandbox image addresses for the Beijing region are:
 
 ```bash
-fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.47
-fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.47
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.48
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.48
 ```
 
 ### Use CLI to view templates and create sandboxes

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.构建自定义镜像模板.md
@@ -163,14 +163,14 @@ try {
 复用快速开始的 Python 脚本，直接使用以下镜像地址：
 
 ```bash
-FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.47"
+FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.48"
 ```
 
 目前北京地域的云沙箱官方镜像地址列表为：
 
 ```bash
-fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.47
-fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.47
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.48
+fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.48
 ```
 
 ### 使用 CLI 查看模板并创建沙箱


### PR DESCRIPTION
## Summary
- 中英文《构建自定义镜像模板》中的官方镜像版本由 `v0.0.47` 升级为 `v0.0.48`，共 6 处（每份文档 3 处：FROM_IMAGE 示例 + 北京地域官方镜像地址列表）
- 与上次 v0.0.44 -> v0.0.47 升级（#133）同一模式

## Test plan
- [ ] 确认 `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.48` 与 `code-interpreter-v1:v0.0.48` 已发布
- [ ] Pages build 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 文档范围

- 涉及阿里云函数计算（FC）Agent Sandbox／云沙箱产品。
- 更新中文和英文“构建自定义镜像模板（Build Custom Image Templates）”章节。
- 将官方镜像版本从 `v0.0.47` 更新为 `v0.0.48`。
- 更新 `FROM_IMAGE` 示例，以及北京地域的 `base` 和 `code-interpreter-v1` 镜像地址。

## 页面和资源

- 未新增页面。
- 未删除页面。
- 未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->