### PR TITLE
docs: add API Key IP access control guide

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/01.Getting Started/03.Create an API Key.md
+++ b/docs/en-US/01.FC Agent Sandbox/01.Getting Started/03.Create an API Key.md
@@ -23,10 +23,147 @@ Before you create an API key, make sure that:
    - **Description**: identifies the purpose of the API key, such as development, production, a specific application, or a specific team. Use a traceable name instead of a generic value such as `test` or `default`.
    - **Team**: required. Select the Team to bind to the API key. If no Team exists under the current resource group, click **Create Team**.
    - **Expiration time**: you can choose no expiration or define a custom expiration time. For production, set an explicit expiration and establish a rotation mechanism.
+   - **IP access control**: optional. Configure an allowlist or blocklist based on the caller's fixed egress IPv4 address. Leave both lists empty if source IP restrictions are not required. You cannot configure an allowlist and a blocklist at the same time.
 5. Click **OK**.
 6. After the key is created, copy the full API key value and store it securely. You cannot rebind an API key to another Team after creation.
 
 **Important**: Do not put API keys in source repositories, images, templates, logs, screenshots, support tickets, or frontend pages. If a key is exposed, disable or reset it immediately.
+
+## Configure an IP allowlist or blocklist
+
+An IP allowlist or blocklist limits the source IPv4 addresses from which an API key can access FC Agent Sandbox control-plane APIs. These APIs include Sandbox, Template, Volume, and other APIs that use API key authentication.
+
+- **Allowlist**: only IP addresses and CIDR blocks in the list are allowed. Requests from other addresses return HTTP `403` with the `AccessDenied` error code.
+- **Blocklist**: IP addresses and CIDR blocks in the list are denied. Requests from other addresses are allowed.
+- **Not configured**: when both lists are empty, requests are not restricted by source IP.
+
+This feature only checks FC Agent Sandbox control-plane requests that carry an API key. It does not restrict the following traffic:
+
+- Management requests that call FCSandbox OpenAPI by using Alibaba Cloud AccessKey credentials, STS credentials, or other Alibaba Cloud credentials.
+- Application traffic that accesses a service in a Sandbox through an exposed port or a custom domain name.
+- Outbound traffic from applications in a Sandbox to external services. For outbound network controls, see [Network Access Control](../04.Features/06.Network/05.Network%20Access%20Control.md).
+
+### Configuration rules
+
+| Rule | Description |
+|------|-------------|
+| Address format | Only individual IPv4 addresses and IPv4 CIDR blocks are supported, such as `203.0.113.10` and `203.0.113.0/24`. IPv6 addresses, domain names, URLs, and addresses with ports are not supported. |
+| Relationship between lists | `ipWhitelist` and `ipBlacklist` are mutually exclusive and cannot both be non-empty. |
+| Maximum entries | The allowlist or blocklist can contain up to 50 entries. |
+| Description | `description` is optional, can contain up to 128 characters, and cannot contain control characters. |
+| Normalization | An individual IPv4 address is stored with a `/32` prefix. CIDR blocks are normalized to their network addresses. For example, `203.0.113.10` is returned as `203.0.113.10/32`. |
+| Update behavior | An update replaces the entire IP policy. When you update a policy, pass both `ipWhitelist` and `ipBlacklist`. To remove IP restrictions, set both fields to `[]`. Do not pass `null`. |
+
+Before you configure an allowlist, confirm the actual egress IPv4 addresses used by applications, office networks, CI/CD systems, and emergency operations. An incorrect allowlist immediately blocks requests that use the API key. In an allowlist, `0.0.0.0/0` allows all IPv4 addresses. In a blocklist, it denies all IPv4 addresses. Do not use `0.0.0.0/0` in production policies.
+
+### Configure the policy by using the Python SDK
+
+Install a version of the FCSandbox Python SDK that includes the IP access control models:
+
+```bash
+python -m pip install --upgrade "alibabacloud-fcsandbox20260509>=1.3.1"
+```
+
+Provide the Alibaba Cloud credentials, region, service endpoint, and Team ID through environment variables. Do not hard-code an AccessKey ID or AccessKey secret in your application.
+
+```bash
+export ALIBABA_CLOUD_ACCESS_KEY_ID="<your-access-key-id>"
+export ALIBABA_CLOUD_ACCESS_KEY_SECRET="<your-access-key-secret>"
+# If you use temporary STS credentials, also set:
+# export ALIBABA_CLOUD_SECURITY_TOKEN="<your-security-token>"
+
+export FCSANDBOX_REGION_ID="cn-chengdu"
+export FCSANDBOX_ENDPOINT="fcsandbox.cn-chengdu.aliyuncs.com"
+export FCSANDBOX_TEAM_ID="<team-id>"
+export FCSANDBOX_ALLOWED_CIDR="<caller-egress-ip>/32"
+```
+
+The following example creates an API key that only accepts requests from the specified egress CIDR block:
+
+```python
+import os
+
+from alibabacloud_fcsandbox20260509 import models
+from alibabacloud_fcsandbox20260509.client import Client as FCSandboxClient
+from alibabacloud_tea_openapi import models as open_api_models
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Missing environment variable: {name}")
+    return value
+
+
+config = open_api_models.Config(
+    access_key_id=require_env("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+    access_key_secret=require_env("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+    security_token=os.environ.get("ALIBABA_CLOUD_SECURITY_TOKEN"),
+    region_id=require_env("FCSANDBOX_REGION_ID"),
+    endpoint=require_env("FCSANDBOX_ENDPOINT"),
+)
+client = FCSandboxClient(config)
+
+response = client.create_api_key(
+    models.CreateApiKeyRequest(
+        body=models.CreateApiKeyInput(
+            team_id=require_env("FCSANDBOX_TEAM_ID"),
+            api_key_name="production-app",
+            ip_whitelist=[
+                models.IPConfig(
+                    ip_address=require_env("FCSANDBOX_ALLOWED_CIDR"),
+                    description="Fixed application egress",
+                )
+            ],
+            ip_blacklist=[],
+        )
+    )
+)
+
+api_key = response.body.api_key
+if api_key is None or not api_key.api_key_value:
+    raise RuntimeError("CreateApiKey did not return an API key")
+
+print(f"request_id={response.body.request_id}")
+print(f"api_key_id={api_key.api_key_id}")
+print(f"api_key_mask={api_key.api_key_mask}")
+print("The API key was created. Store api_key_value in a secret manager and do not write it to logs.")
+```
+
+To change the same API key to blocklist mode, call `UpdateApiKey` and pass both lists:
+
+```python
+response = client.update_api_key(
+    "<api-key-id>",
+    models.UpdateApiKeyRequest(
+        body=models.UpdateApiKeyInput(
+            ip_whitelist=[],
+            ip_blacklist=[
+                models.IPConfig(
+                    ip_address="198.51.100.0/24",
+                    description="Temporarily blocked CIDR block",
+                )
+            ],
+        )
+    ),
+)
+```
+
+To remove the IP restriction, clear both lists:
+
+```python
+response = client.update_api_key(
+    "<api-key-id>",
+    models.UpdateApiKeyRequest(
+        body=models.UpdateApiKeyInput(
+            ip_whitelist=[],
+            ip_blacklist=[],
+        )
+    ),
+)
+```
+
+For complete request parameters, see [CreateApiKey](https://api.aliyun.com/api/FCSandbox/2026-05-09/CreateApiKey), [DescribeApiKey](https://api.aliyun.com/api/FCSandbox/2026-05-09/DescribeApiKey), and [UpdateApiKey](https://api.aliyun.com/api/FCSandbox/2026-05-09/UpdateApiKey).
 
 ## Use the API key with SDKs and the CLI
 
@@ -48,13 +185,14 @@ On the API keys page, you can view the masked API key value, description, accoun
 
 Supported management operations:
 
-- **Edit**: update the description or expiration time, or enable or disable the API key.
-- **Reset**: generate a new API key value. After a reset, the old value stops working and applications that still use it will fail authentication.
+- **Edit**: update the description, expiration time, or IP allowlist or blocklist, or enable or disable the API key. Updating the IP policy replaces the previous policy in its entirety.
+- **Reset**: generate a new API key value. After a reset, the old value stops working and applications that still use it will fail authentication. The Team, expiration time, and IP policy remain unchanged.
 - **Delete**: disable the API key before deleting it. Disable it first, observe for a period of time, and delete it only after confirming that no application still depends on it.
 
 ## Security recommendations
 
 - Separate API keys by application, environment, team, or tenant. Do not share one long-lived key across multiple people or systems.
+- Configure an IP allowlist for production applications that have fixed egress addresses, and reserve a verified emergency operations egress address.
 - In production, prefer custom expiration times and rotate keys regularly.
 - Before you reset or delete a key, confirm that the application has already switched to a replacement key.
 - If you suspect a leak, disable or reset the key first, and then investigate the source of the exposure.

--- a/docs/zh-CN/01.云沙箱/01.开始使用/03.创建 API Key.md
+++ b/docs/zh-CN/01.云沙箱/01.开始使用/03.创建 API Key.md
@@ -23,10 +23,147 @@
   - **描述**：用于标识 API Key 的用途，例如开发环境、生产环境、某个应用或某个团队。建议使用可追溯的命名，不要只写“test”或“default”。
   - **Team**：必选。选择 API Key 要绑定的 Team。若当前资源组下没有 Team，可单击**创建 Team**。
   - **过期时间**：可选择永不过期或自定义过期时间。生产环境建议设置明确的过期时间，并建立轮换机制。
+  - **IP 访问控制**：可选。根据调用方的固定出口 IPv4 地址配置白名单或黑名单；不需要限制来源时保持为空。黑白名单不能同时配置。
 5. 单击**确定**。
 6. 创建成功后，复制完整 API Key 并妥善保存。创建后不能把 API Key 改绑到其他 Team。
 
 **重要**：不要把 API Key 写入代码仓库、镜像、模板、日志、截图、工单或前端页面。API Key 泄露后，应立即禁用或重置。
+
+## 配置 IP 黑白名单
+
+IP 黑白名单用于限制 API Key 可以从哪些源 IPv4 地址访问云沙箱控制面 API，包括 Sandbox、Template 和 Volume 等使用 API Key 认证的接口。
+
+- **白名单**：只允许名单中的 IP 地址或 CIDR 网段访问；未命中的请求返回 HTTP `403` 和错误码 `AccessDenied`。
+- **黑名单**：拒绝名单中的 IP 地址或 CIDR 网段访问；未命中的请求正常放行。
+- **不配置**：白名单和黑名单均为空，不根据源 IP 限制请求。
+
+该能力只检查携带 API Key 的云沙箱控制面请求，不限制以下流量：
+
+- 使用阿里云 AK、STS 等凭证调用 FCSandbox OpenAPI 的管理请求；
+- 通过 Sandbox 暴露端口或自定义域名访问 Sandbox 内服务的业务流量；
+- Sandbox 内应用主动访问外部服务的出站流量。出站网络控制参见[网络访问控制](../04.功能说明/06.网络/05.网络访问控制.md)。
+
+### 配置规则
+
+| 规则 | 说明 |
+|------|------|
+| 地址格式 | 仅支持 IPv4 单地址或 IPv4 CIDR，例如 `203.0.113.10`、`203.0.113.0/24`；暂不支持 IPv6、域名、URL 或带端口的地址。 |
+| 黑白名单关系 | `ipWhitelist` 和 `ipBlacklist` 互斥，不能同时为非空。 |
+| 条目数量 | 白名单或黑名单单侧最多 50 条。 |
+| 备注 | `description` 可选，最多 128 个字符，不能包含控制字符。 |
+| 归一化 | 单个 IPv4 地址保存后显示为 `/32`；CIDR 会按网络地址归一化。例如 `203.0.113.10` 显示为 `203.0.113.10/32`。 |
+| 更新语义 | IP 策略按整组替换。更新时建议同时传入 `ipWhitelist` 和 `ipBlacklist`；清空限制时将两者都设为 `[]`。不要传入 `null`。 |
+
+配置白名单前，应确认应用、办公网络、CI/CD 和应急运维入口的实际出口 IPv4 地址。错误的白名单会立即阻断该 API Key 的请求。`0.0.0.0/0` 在白名单中等同于允许所有 IPv4，在黑名单中等同于拒绝所有 IPv4，不建议作为生产配置。
+
+### 通过 Python SDK 配置
+
+安装包含 IP 黑白名单模型的 FCSandbox Python SDK：
+
+```bash
+python -m pip install --upgrade "alibabacloud-fcsandbox20260509>=1.3.1"
+```
+
+通过环境变量提供阿里云访问凭证、地域、服务接入点和 Team ID。不要把 AK/SK 写入代码。
+
+```bash
+export ALIBABA_CLOUD_ACCESS_KEY_ID="<your-access-key-id>"
+export ALIBABA_CLOUD_ACCESS_KEY_SECRET="<your-access-key-secret>"
+# 使用 STS 临时凭证时还需要设置：
+# export ALIBABA_CLOUD_SECURITY_TOKEN="<your-security-token>"
+
+export FCSANDBOX_REGION_ID="cn-chengdu"
+export FCSANDBOX_ENDPOINT="fcsandbox.cn-chengdu.aliyuncs.com"
+export FCSANDBOX_TEAM_ID="<team-id>"
+export FCSANDBOX_ALLOWED_CIDR="<caller-egress-ip>/32"
+```
+
+以下示例创建一个只允许指定出口网段访问的 API Key：
+
+```python
+import os
+
+from alibabacloud_fcsandbox20260509 import models
+from alibabacloud_fcsandbox20260509.client import Client as FCSandboxClient
+from alibabacloud_tea_openapi import models as open_api_models
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"缺少环境变量: {name}")
+    return value
+
+
+config = open_api_models.Config(
+    access_key_id=require_env("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+    access_key_secret=require_env("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+    security_token=os.environ.get("ALIBABA_CLOUD_SECURITY_TOKEN"),
+    region_id=require_env("FCSANDBOX_REGION_ID"),
+    endpoint=require_env("FCSANDBOX_ENDPOINT"),
+)
+client = FCSandboxClient(config)
+
+response = client.create_api_key(
+    models.CreateApiKeyRequest(
+        body=models.CreateApiKeyInput(
+            team_id=require_env("FCSANDBOX_TEAM_ID"),
+            api_key_name="production-app",
+            ip_whitelist=[
+                models.IPConfig(
+                    ip_address=require_env("FCSANDBOX_ALLOWED_CIDR"),
+                    description="应用固定出口",
+                )
+            ],
+            ip_blacklist=[],
+        )
+    )
+)
+
+api_key = response.body.api_key
+if api_key is None or not api_key.api_key_value:
+    raise RuntimeError("CreateApiKey 未返回 API Key")
+
+print(f"request_id={response.body.request_id}")
+print(f"api_key_id={api_key.api_key_id}")
+print(f"api_key_mask={api_key.api_key_mask}")
+print("API Key 创建成功；请将 api_key_value 写入密钥管理系统，不要输出到日志。")
+```
+
+如需将同一个 API Key 改为黑名单模式，调用 `UpdateApiKey` 并同时传入两侧名单：
+
+```python
+response = client.update_api_key(
+    "<api-key-id>",
+    models.UpdateApiKeyRequest(
+        body=models.UpdateApiKeyInput(
+            ip_whitelist=[],
+            ip_blacklist=[
+                models.IPConfig(
+                    ip_address="198.51.100.0/24",
+                    description="临时封禁网段",
+                )
+            ],
+        )
+    ),
+)
+```
+
+如需取消 IP 限制，将两侧名单同时清空：
+
+```python
+response = client.update_api_key(
+    "<api-key-id>",
+    models.UpdateApiKeyRequest(
+        body=models.UpdateApiKeyInput(
+            ip_whitelist=[],
+            ip_blacklist=[],
+        )
+    ),
+)
+```
+
+创建、查询和更新接口的完整参数说明参见 [CreateApiKey](https://api.aliyun.com/api/FCSandbox/2026-05-09/CreateApiKey)、[DescribeApiKey](https://api.aliyun.com/api/FCSandbox/2026-05-09/DescribeApiKey) 和 [UpdateApiKey](https://api.aliyun.com/api/FCSandbox/2026-05-09/UpdateApiKey)。
 
 ## 在 SDK 和 CLI 中使用
 
@@ -48,13 +185,14 @@ export E2B_DOMAIN="<region>.e2b.fc.aliyuncs.com"
 
 API Key 支持以下管理操作：
 
-- **编辑**：修改描述、过期时间，或启用 / 禁用 API Key。
-- **重置**：生成新的 API Key 值。重置后旧值失效，使用旧值的应用会认证失败。
+- **编辑**：修改描述、过期时间、IP 黑白名单，或启用 / 禁用 API Key。更新 IP 策略时，新策略会整组替换旧策略。
+- **重置**：生成新的 API Key 值。重置后旧值失效，使用旧值的应用会认证失败；Team、过期时间和 IP 黑白名单保持不变。
 - **删除**：删除前需要先禁用 API Key。建议禁用后观察一段时间，确认没有业务继续使用，再执行删除。
 
 ## 安全建议
 
 - 按应用、环境、团队或租户拆分 API Key，不要多人、多系统共用一个长期 Key。
+- 对具有固定出口地址的生产应用配置 IP 白名单，并预留经过验证的应急运维出口。
 - 生产环境优先使用自定义过期时间，并定期轮换。
 - 重置或删除前，先确认业务侧已切换到新 Key。
 - 发现泄露风险时，先禁用或重置 API Key，再排查泄露来源。


### PR DESCRIPTION
## 变更说明

- 为“创建 API Key”文档补充 IP 白名单与黑名单的语义、作用范围和安全边界
- 说明 IPv4/CIDR 格式、黑白名单互斥、条目上限、归一化和整组替换行为
- 增加基于 FCSandbox Python SDK 1.3.1 的创建、切换与清空示例
- 补充重置 API Key 时 IP 策略保持不变等管理说明

## 变更类型

- [x] 修正文档内容
- [ ] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [x] 已运行 `python3 scripts/check-docs.py`
- [x] 已运行 `python3 -m unittest discover -s tests -v`
- [x] 已运行 `mkdocs build --strict --config-file mkdocs.generated.yml`
- [x] 已检查新增或修改的链接和图片
- [x] 未提交真实凭证或敏感信息
- [x] 已在成都线上验证白名单放行/拒绝、黑名单放行/拒绝，以及策略清空
- [x] 已使用 `alibabacloud-fcsandbox20260509==1.3.1` 验证文档中的创建、更新和清空模型

线上测试创建的临时 API Key 已全部清理。

## 相关 Issue

无。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 文档范围

- 产品：函数计算云沙箱（FCSandbox）。
- 页面：中文和英文的“创建 API Key”指南。
- 内容：新增 IP 白名单和黑名单的配置说明、适用范围、规则限制、Python SDK 示例，以及编辑和重置 API Key 时的策略说明。

## 页面与资源变更

- 未新增页面。
- 未删除页面。
- 未改动图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->