### PR TITLE
docs(agenticfs): 更新 Access Point 子目录挂载说明

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md
@@ -151,6 +151,18 @@ python 08_create_agenticfs_volume.py
 
 Successful creation only means that the Volume metadata has been created. See [Mount an AgenticFS Volume](../12.Volumes/02.Mount%20an%20AgenticFS%20Volume.md) to mount the Volume into a sandbox and verify the mount by reading and writing files.
 
+## Specify a subdirectory under an Access Point
+
+`server_addr` can directly specify a subdirectory under an Access Point. For example:
+
+```text
+ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/project-a
+```
+
+`CreateVolume` only creates Volume metadata. If the remote subdirectory does not exist, it is automatically created when the Volume is first mounted to a sandbox. The subdirectory path cannot contain whitespace, control characters, repeated separators, `.` or `..`, and cannot end with `/`.
+
+Next, see [Mount an AgenticFS Volume](../12.Volumes/02.Mount%20an%20AgenticFS%20Volume.md) to create a sandbox, mount the Volume, and verify the mount by reading and writing files.
+
 ## Manage Volumes
 
 Use [ListVolumes](https://api.aliyun.com/api/FCSandbox/2026-05-09/ListVolumes) to list Volumes, [GetVolume](https://api.aliyun.com/api/FCSandbox/2026-05-09/GetVolume) to view details, and [DeleteVolume](https://api.aliyun.com/api/FCSandbox/2026-05-09/DeleteVolume) to delete a Volume that is no longer needed.
@@ -184,19 +196,3 @@ Check the Access Point address and request parameters against the `CreateVolume`
 ### The API returns the `VolumeConflict` error code
 
 A Volume with the same name already exists in the same Team. You can list Volumes with [ListVolumes](https://api.aliyun.com/api/FCSandbox/2026-05-09/ListVolumes) and view details with [GetVolume](https://api.aliyun.com/api/FCSandbox/2026-05-09/GetVolume). After confirming that the Volume is no longer needed, delete it with [DeleteVolume](https://api.aliyun.com/api/FCSandbox/2026-05-09/DeleteVolume), or use a different Volume name.
-
-### How to mount a subdirectory under an Access Point
-
-Follow these steps:
-
-1. Create a temporary Volume using the Access Point root address and mount it into a sandbox.
-2. Run `mkdir` inside the sandbox to create the subdirectory.
-3. Create the target Volume using the subdirectory address. After confirming it works, delete the temporary Volume.
-
-Example `server_addr` for the target Volume:
-
-```text
-ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/project-a
-```
-
-`CreateVolume` does not create subdirectories. Paths cannot contain whitespace, control characters, repeated separators, `.`, `..`, or a trailing `/`.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/02.Mount an AgenticFS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/02.Mount an AgenticFS Volume.md
@@ -130,6 +130,142 @@ Run the example:
 python 02_mount_agenticfs_volume.py
 ```
 
+## Mount a subdirectory under an Access Point
+
+`server_addr` can directly specify a subdirectory under an Access Point.
+
+1. Call `CreateVolume` with the subdirectory address to create the target Volume.
+2. Create a sandbox and mount the Volume by name. If the remote subdirectory does not exist, it is automatically created on the first mount.
+3. Read and write files directly in the mount directory to verify that the Volume is available.
+
+Example `server_addr` for the target Volume:
+
+```text
+ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/project-a
+```
+
+`CreateVolume` only creates Volume metadata. The AgenticFS data plane is available only after the Volume is successfully mounted and file read/write operations succeed. The subdirectory path cannot contain whitespace, control characters, repeated separators, `.` or `..`, and cannot end with `/`.
+
+The following example mounts a subdirectory under an Access Point and verifies file read/write operations.
+
+Before running the example, follow [Create an AgenticFS Volume](../07.FC%20Extensions/08.Create%20an%20AgenticFS%20Volume.md) to install the FC Agent Sandbox OpenAPI SDK and set the environment variables listed in that topic. Also set the sandbox environment variables listed above. The example generates a unique subdirectory under the Access Point root specified by `AGENTICFS_SERVER_ADDR`.
+
+Save the following code as `02_mount_agenticfs_subdir.py`:
+
+```python
+import json
+import os
+import uuid
+
+from alibabacloud_fcsandbox20260509 import models
+from alibabacloud_fcsandbox20260509.client import Client as FCSandboxClient
+from alibabacloud_tea_openapi import models as open_api_models
+from e2b import Sandbox
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Missing environment variable: {name}")
+    return value
+
+
+access_point_addr = require_env("AGENTICFS_SERVER_ADDR")
+if not access_point_addr.endswith(":/"):
+    raise RuntimeError("AGENTICFS_SERVER_ADDR must be an Access Point root address ending in :/")
+
+suffix = uuid.uuid4().hex[:12]
+subdir = f"project-a-{suffix}"
+volume_name = f"agenticfs-subdir-{suffix}"
+server_addr = f"{access_point_addr}{subdir}"
+mount_dir = "/mnt/agenticfs"
+marker_path = f"{mount_dir}/hello-agenticfs.txt"
+
+config = open_api_models.Config(
+    access_key_id=require_env("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+    access_key_secret=require_env("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+    security_token=os.environ.get("ALIBABA_CLOUD_SECURITY_TOKEN"),
+    region_id=require_env("FCSANDBOX_REGION_ID"),
+)
+if os.environ.get("FCSANDBOX_ENDPOINT"):
+    config.endpoint = os.environ["FCSANDBOX_ENDPOINT"]
+
+pop_client = FCSandboxClient(config)
+team_id = require_env("FCSANDBOX_TEAM_ID")
+volume = None
+sandbox = None
+marker_written = False
+
+try:
+    response = pop_client.create_volume(
+        models.CreateVolumeRequest(
+            body=models.CreateVolumeInput(
+                team_id=team_id,
+                volume_name=volume_name,
+                agentic_fsvolume_config=models.AgenticFSVolumeConfig(
+                    server_addr=server_addr,
+                    user_id=int(require_env("AGENTICFS_USER_ID")),
+                    group_id=int(require_env("AGENTICFS_GROUP_ID")),
+                ),
+            )
+        )
+    )
+    if response.body is None or response.body.volume is None:
+        raise RuntimeError("CreateVolume did not return a Volume")
+
+    volume = response.body.volume
+    print(
+        f"Volume metadata created: volume_name={volume.volume_name}, "
+        f"server_addr={server_addr}; the AgenticFS data plane has not been accessed yet"
+    )
+
+    vpc_config = {
+        "vpcId": require_env("FCSANDBOX_VPC_ID"),
+        "securityGroupId": require_env("FCSANDBOX_SECURITY_GROUP_ID"),
+        "vSwitchIds": [require_env("FCSANDBOX_VSWITCH_ID")],
+    }
+    sandbox = Sandbox.create(
+        template=require_env("E2B_TEMPLATE"),
+        timeout=300,
+        api_key=require_env("E2B_API_KEY"),
+        api_url=require_env("E2B_API_URL"),
+        domain=require_env("E2B_DOMAIN"),
+        volume_mounts={mount_dir: volume_name},
+        metadata={
+            "fc.sandbox.network.vpc": json.dumps(vpc_config),
+            "fc.sandbox.auth.role": require_env("FCSANDBOX_ROLE_ARN"),
+        },
+    )
+
+    sandbox.files.write(marker_path, "hello agenticfs\n")
+    marker_written = True
+    content = sandbox.files.read(marker_path)
+    if content != "hello agenticfs\n":
+        raise RuntimeError(f"File content mismatch: {content!r}")
+
+    print(f"AgenticFS subdirectory mount read/write verification succeeded: {server_addr}")
+finally:
+    try:
+        if sandbox is not None:
+            try:
+                if marker_written:
+                    sandbox.files.remove(marker_path)
+            finally:
+                sandbox.kill()
+    finally:
+        if volume is not None:
+            pop_client.delete_volume(
+                volume.volume_id,
+                models.DeleteVolumeRequest(team_id=team_id),
+            )
+```
+
+Run the example:
+
+```bash
+python 02_mount_agenticfs_subdir.py
+```
+
 ## Behavior
 
 - `volume_mounts` uses the `{mount directory: Volume name}` format, not a Volume ID.

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md
@@ -149,7 +149,19 @@ print("AgenticFS Volume 创建成功")
 python 08_create_agenticfs_volume.py
 ```
 
-创建成功仅表示 Volume 元数据创建成功。参见[挂载 AgenticFS Volume](../12.卷/02.挂载%20AgenticFS%20Volume.md)将该 Volume 挂载到 Sandbox，并通过实际读写确认挂载可用。
+创建成功仅表示 Volume 元数据创建成功。参见 [挂载 AgenticFS Volume](../12.卷/02.挂载%20AgenticFS%20Volume.md) 以创建 Sandbox、挂载该 Volume，并通过实际读写确认挂载可用。
+
+## 指定 Access Point 下的子目录
+
+`server_addr` 可以直接指定 Access Point 下的子目录。例如：
+
+```text
+ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/project-a
+```
+
+`CreateVolume` 仅创建 Volume 元数据。若远端子目录不存在，系统会在首次挂载 Sandbox 时自动创建。子目录路径不能包含空白字符、控制字符、重复分隔符、`.` 或 `..`，也不能以 `/` 结尾。
+
+下一步，参见 [挂载 AgenticFS Volume](../12.卷/02.挂载%20AgenticFS%20Volume.md) 以创建 Sandbox、挂载该 Volume，并通过实际读写确认挂载可用。
 
 ## 管理 Volume
 
@@ -184,19 +196,3 @@ python 08_create_agenticfs_volume.py
 ### 返回 `VolumeConflict` 错误码
 
 同一 Team 中已存在同名 Volume。可通过 [ListVolumes](https://api.aliyun.com/api/FCSandbox/2026-05-09/ListVolumes) 查询 Volume 列表，通过 [GetVolume](https://api.aliyun.com/api/FCSandbox/2026-05-09/GetVolume) 查看详情。确认不再使用后，通过 [DeleteVolume](https://api.aliyun.com/api/FCSandbox/2026-05-09/DeleteVolume) 删除，或更换 Volume 名称。
-
-### 如何挂载 Access Point 下的子目录
-
-操作步骤如下：
-
-1. 使用 Access Point 根目录地址创建一个临时 Volume，并挂载到 Sandbox。
-2. 在 Sandbox 中执行 `mkdir` 创建子目录。
-3. 使用子目录地址创建目标 Volume，确认可用后删除临时 Volume。
-
-目标 Volume 的 `server_addr` 示例：
-
-```text
-ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/project-a
-```
-
-`CreateVolume` 不会创建子目录。路径不能包含空白字符、控制字符、重复分隔符、`.`、`..` 或多余的结尾 `/`。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/02.挂载 AgenticFS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/02.挂载 AgenticFS Volume.md
@@ -130,6 +130,142 @@ print("AgenticFS Volume 挂载读写验证成功")
 python 02_mount_agenticfs_volume.py
 ```
 
+## 挂载 Access Point 下的子目录
+
+`server_addr` 可以直接指定 Access Point 下的子目录。
+
+1. 使用子目录地址调用 `CreateVolume` 创建目标 Volume。
+2. 创建 Sandbox 并按 Volume 名称挂载。若远端子目录不存在，系统会在首次挂载时自动创建。
+3. 直接在挂载目录中读写文件，确认 Volume 可用。
+
+目标 Volume 的 `server_addr` 示例：
+
+```text
+ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/project-a
+```
+
+`CreateVolume` 仅创建 Volume 元数据；挂载成功并完成读写后，才表示 AgenticFS 数据面可用。子目录路径不能包含空白字符、控制字符、重复分隔符、`.` 或 `..`，也不能以 `/` 结尾。
+
+以下示例挂载 Access Point 下的子目录并验证文件读写。
+
+运行前，请先按照 [创建 AgenticFS Volume](../07.FC%20扩展/08.创建%20AgenticFS%20Volume.md) 安装云沙箱 OpenAPI SDK，并设置其中列出的环境变量。同时设置本篇上文列出的 Sandbox 环境变量。示例会在 `AGENTICFS_SERVER_ADDR` 指定的 Access Point 根目录下生成唯一子目录。
+
+将以下代码保存为 `02_mount_agenticfs_subdir.py`：
+
+```python
+import json
+import os
+import uuid
+
+from alibabacloud_fcsandbox20260509 import models
+from alibabacloud_fcsandbox20260509.client import Client as FCSandboxClient
+from alibabacloud_tea_openapi import models as open_api_models
+from e2b import Sandbox
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"缺少环境变量: {name}")
+    return value
+
+
+access_point_addr = require_env("AGENTICFS_SERVER_ADDR")
+if not access_point_addr.endswith(":/"):
+    raise RuntimeError("AGENTICFS_SERVER_ADDR 必须是以 :/ 结尾的 Access Point 根目录地址")
+
+suffix = uuid.uuid4().hex[:12]
+subdir = f"project-a-{suffix}"
+volume_name = f"agenticfs-subdir-{suffix}"
+server_addr = f"{access_point_addr}{subdir}"
+mount_dir = "/mnt/agenticfs"
+marker_path = f"{mount_dir}/hello-agenticfs.txt"
+
+config = open_api_models.Config(
+    access_key_id=require_env("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+    access_key_secret=require_env("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+    security_token=os.environ.get("ALIBABA_CLOUD_SECURITY_TOKEN"),
+    region_id=require_env("FCSANDBOX_REGION_ID"),
+)
+if os.environ.get("FCSANDBOX_ENDPOINT"):
+    config.endpoint = os.environ["FCSANDBOX_ENDPOINT"]
+
+pop_client = FCSandboxClient(config)
+team_id = require_env("FCSANDBOX_TEAM_ID")
+volume = None
+sandbox = None
+marker_written = False
+
+try:
+    response = pop_client.create_volume(
+        models.CreateVolumeRequest(
+            body=models.CreateVolumeInput(
+                team_id=team_id,
+                volume_name=volume_name,
+                agentic_fsvolume_config=models.AgenticFSVolumeConfig(
+                    server_addr=server_addr,
+                    user_id=int(require_env("AGENTICFS_USER_ID")),
+                    group_id=int(require_env("AGENTICFS_GROUP_ID")),
+                ),
+            )
+        )
+    )
+    if response.body is None or response.body.volume is None:
+        raise RuntimeError("CreateVolume 未返回 Volume")
+
+    volume = response.body.volume
+    print(
+        f"Volume 元数据创建成功: volume_name={volume.volume_name}, "
+        f"server_addr={server_addr}; 此时尚未访问 AgenticFS 数据面"
+    )
+
+    vpc_config = {
+        "vpcId": require_env("FCSANDBOX_VPC_ID"),
+        "securityGroupId": require_env("FCSANDBOX_SECURITY_GROUP_ID"),
+        "vSwitchIds": [require_env("FCSANDBOX_VSWITCH_ID")],
+    }
+    sandbox = Sandbox.create(
+        template=require_env("E2B_TEMPLATE"),
+        timeout=300,
+        api_key=require_env("E2B_API_KEY"),
+        api_url=require_env("E2B_API_URL"),
+        domain=require_env("E2B_DOMAIN"),
+        volume_mounts={mount_dir: volume_name},
+        metadata={
+            "fc.sandbox.network.vpc": json.dumps(vpc_config),
+            "fc.sandbox.auth.role": require_env("FCSANDBOX_ROLE_ARN"),
+        },
+    )
+
+    sandbox.files.write(marker_path, "hello agenticfs\n")
+    marker_written = True
+    content = sandbox.files.read(marker_path)
+    if content != "hello agenticfs\n":
+        raise RuntimeError(f"文件内容不一致: {content!r}")
+
+    print(f"AgenticFS 子目录挂载读写验证成功: {server_addr}")
+finally:
+    try:
+        if sandbox is not None:
+            try:
+                if marker_written:
+                    sandbox.files.remove(marker_path)
+            finally:
+                sandbox.kill()
+    finally:
+        if volume is not None:
+            pop_client.delete_volume(
+                volume.volume_id,
+                models.DeleteVolumeRequest(team_id=team_id),
+            )
+```
+
+运行示例：
+
+```bash
+python 02_mount_agenticfs_subdir.py
+```
+
 ## 行为说明
 
 - `volume_mounts` 使用 `{挂载目录: Volume 名称}` 格式，不使用 Volume ID。


### PR DESCRIPTION
## 变更说明

修正函数计算（FC）Agent Sandbox / 云沙箱中《创建 AgenticFS Volume》文档的 Access Point 子目录挂载说明。

原文要求用户先挂载 Access Point 根目录、创建临时 Volume 并执行 `mkdir`。本次修改明确支持在 `server_addr` 中直接指定子目录；远端子目录不存在时，会在首次挂载 Sandbox 时自动创建。

同时补充以下说明：

- 创建 Sandbox 时按 Volume 名称挂载目标 Volume，并通过实际文件读写验证数据面可用。
- `CreateVolume` 成功仅表示 Volume 元数据创建成功，不代表数据面已经挂载成功。
- 保留并明确子目录的路径格式和约束。
- 中英文示例统一使用可配置的 Volume 名称。

## 变更类型

- [x] 修正文档内容
- [ ] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [x] 已运行 `make check`
- [x] 已检查新增或修改的链接和图片
- [x] 未提交真实凭证或敏感信息

## 相关 Issue

无

## 文档范围

产品范围：函数计算（FC）Agent Sandbox / 云沙箱。

更新页面：

- 中文：`04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md`
- 英文：`04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md`

更新章节：

- 中文：`创建 AgenticFS Volume`—`挂载 Access Point 下的子目录`
- 英文：`Create an AgenticFS Volume`—`Mount a subdirectory under an Access Point`

主要内容：删除临时 Volume 和手动创建子目录的前置流程，补充直接配置子目录地址、创建 Volume、挂载 Sandbox 和实际读写验证的说明，并明确元数据创建与数据面访问的语义边界。

页面变更：修改 2 个页面，未新增或删除页面。

图片资源：未改动。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 文档范围

- 更新 FC Agent Sandbox（云沙箱）文档。
- 涉及《创建 AgenticFS Volume》和《挂载 AgenticFS Volume》的中英文页面。
- 修正 Access Point 子目录挂载说明。
- 补充通过 `server_addr` 直接指定子目录、自动创建远端子目录、按 Volume 名称挂载及读写验证的流程。
- 删除临时 Volume 和手动执行 `mkdir` 的前置流程。
- 说明 `CreateVolume` 成功仅表示 Volume 元数据创建成功，不代表数据面挂载成功。

本次修改涉及中文和英文页面各 2 个。未新增或删除页面，未修改图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->