### PR TITLE
docs(sandbox): 补充自动暂停与恢复说明

### DIFF
--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.沙箱/06.暂停与恢复.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.沙箱/06.暂停与恢复.md
@@ -6,6 +6,41 @@
 
 暂停用于在一段时间内保留 Sandbox 状态，后续通过连接同一个 Sandbox 继续使用。
 
+## 配置自动暂停与自动恢复
+
+创建 Sandbox 时，可以通过 `lifecycle` 配置超时后的处理方式，以及已暂停的 Sandbox 是否在收到请求时自动恢复。
+
+- `on_timeout`(Python)/`onTimeout`(TypeScript)：默认值为 `kill`，Sandbox 超时后会被终止。设置为 `pause` 后，Sandbox 超时时会自动暂停并保留当前状态。
+- `auto_resume`(Python)/`autoResume`(TypeScript)：默认值为 `False`/`false`。设置为 `True`/`true` 后，对已暂停 Sandbox 的 SDK 操作或进入 Sandbox 内服务的 HTTP 请求会触发自动恢复，无需先调用 `Sandbox.connect()`。该选项需要与 `on_timeout="pause"`/`onTimeout: "pause"` 配合使用。
+
+Python 示例：
+
+```python
+from e2b_code_interpreter import Sandbox
+
+sandbox = Sandbox.create(
+    timeout=10 * 60,
+    lifecycle={
+        "on_timeout": "pause",
+        "auto_resume": True,
+    },
+)
+```
+
+TypeScript 示例：
+
+```typescript
+const sandbox = await Sandbox.create({
+  timeoutMs: 10 * 60 * 1000,
+  lifecycle: {
+    onTimeout: "pause",
+    autoResume: true,
+  },
+});
+```
+
+`lifecycle` 配置在 Sandbox 恢复后仍然生效。Sandbox 再次超时时会继续自动暂停；后续活动到达时，会再次自动恢复。如果未开启自动恢复，仍可以通过 `Sandbox.connect()` 手动恢复已暂停的 Sandbox。
+
 ## 暂停 Sandbox
 
 暂停当前 Sandbox：


### PR DESCRIPTION
## 变更说明

- 补充 lifecycle 中自动暂停与自动恢复的配置项及默认行为
- 说明 SDK 操作和 HTTP 请求触发自动恢复的条件
- 增加 Python 与 TypeScript 配置示例
- 说明 lifecycle 配置跨暂停/恢复周期持续生效

## 验证

- [x] `git diff --check origin/main...HEAD`
- [x] 确认仅修改暂停与恢复文档

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 文档范围

- 产品：云沙箱（Sandbox）。
- 章节：沙箱功能说明下的“暂停与恢复”章节。
- 内容：补充自动暂停与自动恢复的配置说明、默认行为、触发条件、跨暂停与恢复周期的生效语义，以及 Python 和 TypeScript 配置示例。

## 页面与资源变更

- 新增页面：否。
- 删除页面：否。
- 图片资源：未修改。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->