### PR TITLE
docs(agentbay): 修正 VNC 鉴权说明

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/14.Migration/2.AgentBay Linux Desktop Migration Guide.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/14.Migration/2.AgentBay Linux Desktop Migration Guide.md
@@ -185,7 +185,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       bash ca-certificates curl git python3 sudo dbus-x11 systemd \
       xvfb x11-utils x11-apps xauth x11vnc xdotool scrot \
       gnome-session gnome-shell gnome-terminal nautilus \
-      hicolor-icon-theme librsvg2-common \
+      hicolor-icon-theme librsvg2-common gtk-update-icon-cache \
       fonts-liberation fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
       novnc websockify \
     && rm -rf /var/lib/apt/lists/* \
@@ -665,8 +665,8 @@ if __name__ == "__main__":
     import RFB from 'https://cdn.jsdelivr.net/gh/novnc/noVNC@v1.6.0/core/rfb.js';
 
     async function initVNC() {
-      // The API key and sandbox lifecycle stay in the backend. The browser receives only
-      // the ephemeral stream URL for the current session.
+      // The API key and sandbox lifecycle stay in the backend. The browser receives the
+      // ephemeral streamUrl and authKey for the current session to establish VNC.
       const resp = await fetch('/api/sandbox/vnc-url');
       const { streamUrl, authKey } = await resp.json();
 
@@ -707,7 +707,7 @@ E2B_DESKTOP_IMAGE=fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/desktop:v0.
 
 ```
 Browser (index.html, noVNC CDN ESM)
-  │  GET /api/sandbox/vnc-url ──→ demo.py (returns only streamUrl)
+  │  GET /api/sandbox/vnc-url ──→ demo.py (returns temporary streamUrl and authKey)
   │  RFB connects directly to wss://{sandbox-host}/vnc.html ──→ websockify ──→ x11vnc ──→ Xvfb desktop
   └─ Rendering + mouse/keyboard input (data plane does not go through the backend)
 ```
@@ -724,7 +724,7 @@ python demo.py
 
 ### Verification records
 
-- Backend API: `/api/sandbox/vnc-url` returns a streamUrl that starts with `https://` and contains `/vnc.html`; `/` returns the page normally.
+- Backend API: `/api/sandbox/vnc-url` returns temporary `streamUrl` and `authKey`; `streamUrl` starts with `https://` and contains `/vnc.html`, and `/` returns the page normally.
 - Exit: SIGTERM/Ctrl-C stops the VNC stream and destroys the sandbox automatically.
 - Frontend: RFB connection, screen rendering, and live desktop refresh verified in a real Chrome.
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/14.迁移/2.AgentBay Linux 桌面迁移指南.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/14.迁移/2.AgentBay Linux 桌面迁移指南.md
@@ -183,7 +183,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       bash ca-certificates curl git python3 sudo dbus-x11 systemd \
       xvfb x11-utils x11-apps xauth x11vnc xdotool scrot \
       gnome-session gnome-shell gnome-terminal nautilus \
-      hicolor-icon-theme librsvg2-common \
+      hicolor-icon-theme librsvg2-common gtk-update-icon-cache \
       fonts-liberation fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
       novnc websockify \
     && rm -rf /var/lib/apt/lists/* \
@@ -652,7 +652,8 @@ if __name__ == "__main__":
     import RFB from 'https://cdn.jsdelivr.net/gh/novnc/noVNC@v1.6.0/core/rfb.js';
 
     async function initVNC() {
-      // API Key 和沙箱生命周期保留在后端；浏览器仅接收当前会话的临时流地址。
+      // API Key 和沙箱生命周期保留在后端；浏览器接收当前会话的临时
+      // streamUrl 和 authKey，用于建立 VNC 连接。
       const resp = await fetch('/api/sandbox/vnc-url');
       const { streamUrl, authKey } = await resp.json();
 
@@ -689,7 +690,7 @@ E2B_DESKTOP_IMAGE=fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/desktop:v0.
 ### 数据流
 ```
 浏览器 (index.html, noVNC CDN ESM)
-  │  GET /api/sandbox/vnc-url ──→ demo.py（仅返回 streamUrl）
+  │  GET /api/sandbox/vnc-url ──→ demo.py（返回临时 streamUrl 和 authKey）
   │  RFB 直连 wss://{sandbox-host}/vnc.html ──→ websockify ──→ x11vnc ──→ Xvfb 桌面
   └─ 渲染 + 键鼠输入（数据面不经后端）
 ```
@@ -704,7 +705,7 @@ python demo.py
 ```
 
 ### 验证记录
-- 后端 API：`/api/sandbox/vnc-url` 返回以 `https://` 开头且含 `/vnc.html` 的 streamUrl；`/` 正常返回页面。
+- 后端 API：`/api/sandbox/vnc-url` 返回临时 `streamUrl` 和 `authKey`，其中 `streamUrl` 以 `https://` 开头且含 `/vnc.html`；`/` 正常返回页面。
 - 退出：SIGTERM/Ctrl-C 后自动停止 VNC 流并销毁沙箱。
 - 前端：已在真实 Chrome 中验证 RFB 连接、画面渲染、桌面变化实时刷新。
 


### PR DESCRIPTION
## 改动说明

- 明确 noVNC 会话需使用临时 `streamUrl` 与 `authKey` 建立连接。
- 在中英文 Dockerfile 示例中显式安装 `gtk-update-icon-cache`。

## 验证

- `make check-docs`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 更新 AgentBay 产品文档，涉及中英文两份“Linux 桌面迁移指南”，归属“迁移”章节。

主要改动：
- 更新 noVNC 集成说明，明确使用临时 `streamUrl` 和 `authKey` 建立连接。
- 更新 `/api/sandbox/vnc-url` 返回参数说明。
- 在中英文 Dockerfile 示例中新增 `gtk-update-icon-cache` 依赖。
- 同步更新数据流图说明和验证记录。

本 PR 未新增或删除文档页面，未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->