### PR TITLE
docs(sandbox): 说明 keepMemory 暂不支持

### DIFF
--- a/docs/zh-CN/01.云沙箱/04.功能说明/01.沙箱/06.暂停与恢复.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/01.沙箱/06.暂停与恢复.md
@@ -13,6 +13,8 @@
 - `on_timeout`(Python)/`onTimeout`(TypeScript)：默认值为 `kill`，Sandbox 超时后会被终止。设置为 `pause` 后，Sandbox 超时时会自动暂停并保留当前状态。
 - `auto_resume`(Python)/`autoResume`(TypeScript)：默认值为 `False`/`false`。设置为 `True`/`true` 后，对已暂停 Sandbox 的 SDK 操作或进入 Sandbox 内服务的 HTTP 请求会触发自动恢复，无需先调用 `Sandbox.connect()`。该选项需要与 `on_timeout="pause"`/`onTimeout: "pause"` 配合使用。
 
+> 当前暂不支持通过 `keep_memory`(Python)/`keepMemory`(TypeScript) 配置仅保留文件系统的暂停方式。
+
 Python 示例：
 
 ```python


### PR DESCRIPTION
## 变更说明

- 明确云沙箱暂不支持 `keep_memory`（Python）/`keepMemory`（TypeScript）
- 避免用户直接套用 E2B filesystem-only pause 配置

## 验证

- [x] `git diff --check origin/main...HEAD`
- [x] 确认仅修改暂停与恢复文档