### PR TITLE
docs(sandbox): 更新 SWE 镜像清单与判分边界

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
+++ b/docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md
@@ -59,11 +59,11 @@ The example task in this guide is `getmoto__moto-7365`: moto's DynamoDB `update_
 
 | Part | Content | Source |
 | --- | --- | --- |
-| Environment | Image `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510`, with the repository already at the defect commit and dependencies installed | Ready-made evaluation image |
-| Task | The problem statement (`problem_statement`) | Upstream dataset |
+| Environment | Image `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510`, with the repository and dependencies installed | Ready-made evaluation image |
+| Task | The problem statement (`problem_statement`) and defect baseline (`base_commit`) | Upstream dataset |
 | Grading | `FAIL_TO_PASS` (must pass after the fix), `PASS_TO_PASS` (must not regress), `test_patch` | Upstream dataset |
 
-The image is only the environment; the task and its test cases live in the metadata. With the image alone and no metadata, there is no task to run.
+The image is only the environment; the task, correct baseline, and test cases live in the metadata. With the image alone and no metadata, there is no task to run. The image's `HEAD` must also match `base_commit`; image immutability alone does not prove that the baseline is correct.
 
 ## Install dependencies and configure credentials
 
@@ -205,7 +205,7 @@ print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(p
 
 The grading criteria match SWE-bench upstream: every `FAIL_TO_PASS` case passes and no `PASS_TO_PASS` case regresses.
 
-Grade in a brand-new sandbox, never in the agent's worker sandbox. After the agent finishes, that sandbox is no longer the original scene: it may have installed extra packages (which can make tests pass by accident), modified test files or `conftest.py`, or left temporary files behind. Sandbox images are immutable, so simply creating a new sandbox from the same image brings the repository back to its original state, with no need to clean up after the agent. The template is already cached, so the second sandbox starts in a few seconds.
+Grade in a brand-new sandbox, never in the agent's worker sandbox. After the agent finishes, that sandbox is no longer the original scene: it may have installed extra packages (which can make tests pass by accident), modified test files or `conftest.py`, or left temporary files behind. Starting from the same immutable image removes those traces, but **does not guarantee that the image's `HEAD` is the task's `base_commit`**; explicitly reset and verify the metadata baseline before grading. The template is already cached, so the second sandbox starts in a few seconds.
 
 ```python
 # grade.py
@@ -261,14 +261,21 @@ f2p, p2p = as_list(inst["FAIL_TO_PASS"]), as_list(inst["PASS_TO_PASS"])
 
 env = get_environment(dict(cfg["environment"], timeout=1800))
 try:
-    # 1) Apply the patch under evaluation; failing to apply is itself a result
+    # 1) Do not trust the image's current HEAD; reset to the task's unique defect baseline
+    base_commit = inst.get("base_commit") or ""
+    assert base_commit, "metadata is missing base_commit"
+    out = env.execute({"command": f"git reset --hard {shlex.quote(base_commit)} && git clean -fd"},
+                      timeout=300)
+    assert out["returncode"] == 0, f"cannot reset to base_commit: {out['output'][-200:]}"
+
+    # 2) Apply the patch under evaluation; failing to apply is itself a result
     env.sandbox.files.write("/tmp/model.patch", patch)
     out = env.execute({"command": "git apply -v /tmp/model.patch"}, timeout=300)
     if out["returncode"] != 0:
         out = env.execute({"command": "patch -p1 -i /tmp/model.patch"}, timeout=300)
         assert out["returncode"] == 0, f"patch does not apply: {out['output'][-200:]}"
 
-    # 2) Restore test files to the baseline first, then apply test_patch — test content
+    # 3) Restore test files to the baseline first, then apply test_patch — test content
     #    must not be tamperable by the agent
     tf = patched_files(inst["test_patch"])
     if tf:
@@ -277,7 +284,7 @@ try:
     out = env.execute({"command": "git apply -v /tmp/test.patch"}, timeout=300)
     assert out["returncode"] == 0, f"test_patch does not apply: {out['output'][-200:]}"
 
-    # 3) Run whole test files, then match by name against the -rA report.
+    # 4) Run whole test files, then match by name against the -rA report.
     # Do not pass case names as pytest command-line arguments: parameterized names may contain
     # spaces and brackets, which leads to "not found".
     # Do not truncate the report with tail either: large repositories emit thousands of lines,
@@ -344,6 +351,7 @@ finally:
 ```json
 [{"instance_id": "getmoto__moto-7365",
   "problem_statement": "DynamoDB's `update_item` performs floating-point arithmetic …",
+  "base_commit": "7f6c9cb1…",
   "FAIL_TO_PASS": ["tests/test_dynamodb/test_dynamodb_update_expressions.py::test_update_item_add_float"],
   "PASS_TO_PASS": ["tests/test_dynamodb/test_dynamodb_update_expressions.py::test_update_different_map_elements_in_single_request"],
   "test_patch": "diff --git a/tests/... (verbatim from the upstream dataset)",
@@ -450,26 +458,28 @@ The agent stage only produces `preds.json`; the grading stage reads it and grade
 | Grading evidence truncated by `tail -N` | Large repositories emit thousands of report lines, passing cases get dropped, and the score comes out low | Filter the verdict lines first, then take the summary tail separately |
 | Parameterized case names contain spaces or newlines | The pytest report truncates names at the first whitespace, so exact matching misses everything | Match on the truncated prefix and satisfy by count |
 | Case names passed to pytest as command-line arguments | Names contain spaces and brackets, giving "not found" and ultimately "no tests ran" | Run whole test files, then match by name against the report |
+| Image `HEAD` differs from metadata `base_commit` | The patch can be applied to the wrong code state, making the result unrelated to the task | Run `git reset --hard <base_commit>` and `git clean -fd` before grading; stop if the reset fails |
+| Pytest remains unavailable after the environment is correctly activated | A repository-native test harness is mistaken for a broken image; representative Django and SymPy images are examples | Read the benchmark's or repository's real test command instead of hard-coding pytest for every Python repository |
 | A grading command that timed out with empty output scored as "tests failed" | A large test suite times out under high concurrency and the instance is recorded as zero passes; a serial re-run passes everything | When output is empty or the exit code is abnormal, mark it as **grading not completed**, exclude it from the denominator, and retry at lower concurrency |
 
-The last one is the easiest to miss. It reads an infrastructure failure as poor model capability, and the more test cases a repository has the more likely it is to trigger, so scores come out lower across the board without any error surfacing.
+The last three are especially easy to miss: a wrong baseline or executor produces evidence for the wrong task, while a timeout charges an infrastructure failure to the model. None should be recorded as an ordinary zero score.
 
 ## Ready-made evaluation images in the Shanghai region
 
-The China (Shanghai) region comes preloaded with images for a range of open-source evaluation sets, with the repository scene and dependencies already in place: take the image address, build a template, and use it—no need to move anything yourself. All image addresses share the prefix `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`.
+The China (Shanghai) region comes preloaded with 80,298 open-source evaluation images across 19 image families, with the repository scene and dependencies already in place: take the image address, build a template, and use it—no need to move anything yourself. All image addresses share the prefix `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`.
 
-The image solves only the environment. For a task to enter evaluation, three things must all be present: the image starts, the task metadata (problem statement and test cases) is obtainable, and the grading method is implemented. By those three, these images fall into three categories:
+The image solves only the environment. For a task to enter trustworthy evaluation, three things must all be present: the image starts, the task metadata (problem statement, correct baseline, and deciding cases) is obtainable, and the grading pipeline passes gold self-checks in the real runtime. By those three, these images fall into three categories:
 
 | Category | Images | State | What you need to do |
 | --- | --- | --- | --- |
 | 1. Grading criteria verified | **29,112** | All three present, and grading self-checks pass with the dataset's own correct patches | Swap the image address and working directory and start running (Scale-SWE also needs a different way of introducing test cases, see below) |
-| 2. Metadata complete, grading to be implemented | **27,837** | Sandbox starts, problem statement is obtainable, join keys verified—but the grading method differs from this guide's example | Implement grading for that benchmark's method |
+| 2. Metadata complete; grading pipeline or runtime incomplete | **30,431** | Sandbox starts, problem statement is obtainable, and join keys are verified, but the grader, repository test entry point, baseline reset, or full gold self-check is incomplete | Complete the benchmark's real execution recipe and gold validation |
 | 3. Images only | **20,755** | Images start, but the task-to-image correspondence cannot be established | Usable only as repository environments with dependencies preinstalled; grading requires finding metadata yourself |
-| Total | **77,704** | | |
+| Total | **80,298** | | |
 
-If you just want to get something running, take category 1. Category 2 is listed because the images and problem statements are complete and only the grading implementation is missing; category 3 is listed for full disclosure, and it cannot be graded automatically.
+If you just want to get something running, take category 1. Category 2 has complete images and task metadata, but its outputs are not yet trustworthy scores: some families lack a grader, while others already have one but still need repository-native commands, the correct baseline, or enough gold validation. Category 3 cannot automatically join images to tasks.
 
-> The metadata datasets are hosted on HuggingFace, which **may not be reachable from inside the sandbox**. Export the fields you need (`problem_statement` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch`) to local files from an environment with outbound access, then ship them with the evaluation task. Do not fetch them on the fly during batch evaluation—one fetch failure stalls the whole batch.
+> The metadata datasets are hosted on HuggingFace, which **may not be reachable from inside the sandbox**. Export the fields you need (`problem_statement` / `base_commit` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch` / gold `patch`) to local files from an environment with outbound access, then ship them with the evaluation task. Do not fetch them on the fly during batch evaluation—one fetch failure stalls the whole batch.
 
 ### 1. Grading criteria verified: 29,112 images
 
@@ -488,15 +498,17 @@ All three grade on `FAIL_TO_PASS` + `PASS_TO_PASS`, but **they introduce test ca
 
 Repository diversity varies a lot: Scale-SWE covers 1,180 repositories and the SWE-rebench V2 python subset 689, while SWE-Gym has only 11 (dominated by pandas, moto, and a few others). Look at the "Repos" column when picking a baseline for cross-repository generalization. SWE-Gym alone has a ceiling, since no matter how many tasks there are they concentrate in the same few repositories.
 
-### 2. Metadata complete, grading to be implemented: 27,837 images
+### 2. Metadata complete; grading pipeline or runtime incomplete: 30,431 images
 
-The images below start, the problem statements are obtainable, and the join keys have been verified to 100% (99.7% for `SWE-smith`). What is missing is only the grading implementation—their grading methods differ from this guide's example.
+The images below start, the problem statements are obtainable, and the join keys have been verified to 100% (99.7% for `SWE-smith`), but at least one of the grader, repository test entry point, baseline reset, or full gold self-check is incomplete.
 
 | Benchmark | Count | Task type | Metadata dataset | Join key | Grading method and what is missing |
 | --- | --- | --- | --- | --- | --- |
+| SWE-bench (complete official test set) | **2,294** | Real issue fixes across 12 Python repositories | The `test` split of [princeton-nlp/SWE-bench](https://huggingface.co/datasets/princeton-nlp/SWE-bench) | `instance_id`; the 2,294 images and 2,294 official tasks have zero differences in either direction | The existing `test_patch` + F2P/P2P grader is reusable, but this family is not ready for category 1: Shanghai Template Build, sandbox startup, `/testbed`, git, and Python checks pass 12/12; pytest is available in 10/12 after the correct `BASH_ENV`; `HEAD == base_commit` holds for 9/12; representative gold passes 7/12. Django and SymPy need repository-native commands; Requests, Xarray, and Pytest must first reset to the official `base_commit`; a full gold self-check is still required afterward |
 | SWE-rebench V2 (the 19 languages other than python) | **24,836** | Real PR fixes, the broadest repository coverage (3,614 repositories across the whole family) | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` is the original image address | Also `FAIL_TO_PASS` + `PASS_TO_PASS`, but case-name shapes vary by test framework, so **grading must be routed per language**. The dataset's `install_config.test_cmd` and `log_parser` give the run command and the parsing method per instance |
 | CyberGym | **1,507** | Vulnerability discovery: trigger and fix a known vulnerability in a real OSS project (from OSS-Fuzz / ARVO) | [sunblaze-ucb/cybergym](https://huggingface.co/datasets/sunblaze-ucb/cybergym) | `task_id`, equal to the image tag with the trailing `-vul` removed | Does not use `FAIL_TO_PASS`; the verdict is whether the vulnerability can be triggered and whether it stops triggering after the fix, which needs a fuzz reproduction pipeline |
 | SWE-bench Pro | **731** | Enterprise-repository issue fixes, longer context, includes Go / Node and other languages | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro), or [AweAI-Team/AweAgent-Meta-SWE-Bench-Pro](https://huggingface.co/datasets/AweAI-Team/AweAgent-Meta-SWE-Bench-Pro) | `dockerhub_tag` | Also `FAIL_TO_PASS` + `PASS_TO_PASS`, routed by `repo_language`. **Prefer the AweAI one**: same row count but it additionally carries `run_script_sh` / `parser_py`, so both the run and the parsing scripts are provided |
+| SWE-bench Multilingual | **300** | Real issue fixes across 41 repositories and nine non-Python languages: C, C++, Go, Java, JavaScript, TypeScript, PHP, Ruby, and Rust | [SWE-bench/SWE-bench_Multilingual](https://huggingface.co/datasets/SWE-bench/SWE-bench_Multilingual) | `instance_id`; the 300 images and 300 official tasks have zero differences in either direction | Also `FAIL_TO_PASS` + `PASS_TO_PASS`, with `/testbed` as the working directory, but the pytest grader does not apply. Run the official per-instance `eval.sh`, then parse the real test log using `log_parser` / `eval_type` from `task.yaml`; the script exit code alone is not a verdict. A Rust gold run passes, while Go is blocked by dependency-network access and some Maven tasks require unavailable SNAPSHOT artifacts, so this stays in category 2 until the full gold self-check is complete |
 | SWE-smith | **363 environment images** (covering **79,418 upstream tasks**) | Synthetic defect fixes; one image carries many tasks for the same repository | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) and the other 6 language subsets (py / java / js / ts / rs / cpp / php, 7 in total). Upstream also has a go subset, for which there is **no corresponding image** | `image_name` | Grading evidence is the same as SWE-bench, but **task selection has to be wired up yourself**: run `git checkout <instance_id>` inside the image's `/testbed` to move to the matching defect state |
 | SEC-bench | **300** | Security vulnerability reproduction and fixing (CVEs) | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | Does not use `FAIL_TO_PASS`; it reads the sanitizer report and the exit code. The dataset ships `work_dir` / `build_sh` / `secb_sh`, so both the run and the verdict scripts are provided |
 | Terminal-Bench 2.x | **89** | Terminal tasks (not code fixes): complete an instruction in a shell; no git repository and no patch | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | The task directory name is the image tag | Runs the task's own `tests/test.sh`, so **you do not write the grader**; but the agent loop has to change—these tasks produce no patch |
@@ -504,7 +516,11 @@ The images below start, the problem statements are obtainable, and the join keys
 
 SWE-smith's image count and its task count are not the same thing. The 363 are environment images, one per repository, and they carry 79,418 upstream tasks selected by checking out branches. Once task selection is wired up, it is the largest source of tasks in this collection.
 
+Although the complete official SWE-bench family is entirely Python, "Python" does not imply "pytest." One representative image from each of its 12 repositories built and started successfully, but only 10 provide pytest after correct environment activation; Django and SymPy use repository-native harnesses. Three images also have a `HEAD` different from the official `base_commit`, so the generic pytest grader completes only 7/12 representative gold checks and cannot establish that the whole family is ready to run.
+
 Multi-language benchmarks must route grading per language. Take SWE-rebench V2: case-name shapes follow the test framework. Python uses pytest node ids (`tests/test_x.py::TestA::test_b`), TS / JS use jest and mocha case descriptions, and Java uses test class names. Applying one pytest parsing path to every language marks **every non-python instance as failed**. The `swerebenchv2-languages.tsv` list (id → language) can be used to filter. Test commands are more concentrated than languages: Go is always `go test`, Rust always `cargo test`, Java is either Maven or Gradle, and JS / TS are npm-based jest / mocha / vitest and friends, so four or five groups of parsers cover most of it. The same applies to SWE-bench Pro, routed by `repo_language`.
+
+For SWE-bench Multilingual, follow each task's `eval.sh` and the `log_parser` / `eval_type` fields in `task.yaml`. Merge the image's PID 1 `PATH` so preinstalled toolchains such as Cargo remain visible; do not unconditionally set the Python-image convention `BASH_ENV=/root/.bashrc`. Parse the real test log rather than trusting the script exit code, which can hide test failures.
 
 ### 3. Images only: metadata must be matched yourself, 20,755 images
 
@@ -523,49 +539,41 @@ The images below are equally usable (building templates, creating sandboxes, and
 
 ### Getting the image lists
 
-Whichever category you use, you need a mapping from `instance_id` (or image tag) to image address: **image tags carry build-batch information and cannot be derived from `instance_id`**. The lists are tab-separated text files, one `instance_id<TAB>image address` per line, ready for `grep` or `cut -f2` in a script.
+Whichever category you use, you need a mapping from `instance_id` (or image tag) to image address: **image tags carry build-batch information and cannot be derived from `instance_id`**.
 
-**By the three categories above** (these three files correspond one-to-one with the three sections above):
+To avoid maintaining many download links whenever images are added, each batch publishes only one complete
+`swe-images-<release-date>.tar.gz` archive. Tier, benchmark, and language-specific lists remain inside the archive for scripts to select as needed, but are no longer documented as separate downloads.
 
-| Category | List file | Lines | Download |
-| --- | --- | --- | --- |
-| 1. Grading criteria verified | `tier-A-images.tsv` | 29,112 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-A-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-A-images.tsv.gz)) |
-| 2. Metadata complete, grading to be implemented | `tier-B-images.tsv` | 27,837 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-B-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-B-images.tsv.gz)) |
-| 3. Images only | `tier-C-images.tsv` | 20,755 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv.gz)) |
+| Current batch | Images | Complete archive | Status |
+| --- | ---: | --- | --- |
+| 20260903 | 80,298 | [`swe-images-20260903.tar.gz`](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260903.tar.gz) | Published |
 
-All three files have three columns: `instance_id` / image address / benchmark name, so the third column is enough to slice out a single benchmark.
+The archive has a stable internal layout:
 
-**By individual benchmark**:
+| File inside archive | Content |
+| --- | --- |
+| `all-images.tsv` | Complete four-column list: `instance_id` / image address / benchmark / category |
+| `tier-{A,B,C}-images.tsv` | One file per category above; the third column can still select one benchmark |
+| `<family>-images.tsv` | Per-benchmark `instance_id<TAB>image address` lists, including `swebench-images.tsv` and `swebmultilingual-images.tsv` |
+| `swerebenchv2-languages.tsv` | SWE-rebench V2 language routing table |
+| `image-registry.json` | Working directory, run-as user, grading method, and metadata source for runners |
+| `MANIFEST.tsv` | Line count, byte size, and SHA-256 for every file in the archive |
+| `README.md` | Batch totals, benchmark joins, and known boundaries |
 
-| Benchmark | List file | Lines | Download |
-| --- | --- | --- | --- |
-| SWE-rebench V2 (whole family) | `swerebenchv2-images.tsv` | 32,074 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv.gz)) |
-| SWE-rebench V2 (python subset) | `swerebenchv2-python-images.tsv` | 7,238 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv.gz)) |
-| SWE-rebench V2 (id → language map) | `swerebenchv2-languages.tsv` | 32,074 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv.gz)) |
-| Scale-SWE | `scaleswe-images.tsv` | 19,473 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv.gz)) |
-| SWE-Gym | `swegym-images.tsv` | 2,401 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv.gz)) |
-| CyberGym | `cybergym-images.tsv` | 1,507 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/cybergym-images.tsv) |
-| SWE-bench Pro | `swebpro-images.tsv` | 731 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv.gz)) |
-| SWE-smith | `swesmith-images.tsv` | 363 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swesmith-images.tsv) |
-| SEC-bench | `secbench-images.tsv` | 300 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/secbench-images.tsv) |
-| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tb21-images.tsv) |
-| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/sweatlas-images.tsv) |
+```bash
+tar -xzf swe-images-20260903.tar.gz
+cd swe-images-20260903
+```
 
-Companion files:
-
-| File | Content | Download |
-| --- | --- | --- |
-| `all-images.tsv` | All 77,704 images, four columns: `instance_id` / image address / benchmark / category | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv) ([gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv.gz)) |
-| `image-registry.json` | Per-benchmark working directory, run-as user, grading method, and metadata source, for a runner to read | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/image-registry.json) |
-| `MANIFEST.tsv` | Line count, byte size, and **sha256** for each file; verifying after download is recommended | [Download](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/MANIFEST.tsv) |
-
-Lists larger than 200 KB also come as `.gz`, with identical content. Lists are never updated in place: a new batch of images is published to a new directory, and already-published files keep their content.
+Every new batch uses a new dated filename and never overwrites a published archive. Future releases only upload the complete archive, then update the single row above.
 
 **The shape of `instance_id` differs per benchmark.** Look at the actual content before writing a filter, and do not reuse one regular expression across benchmarks:
 
 | Benchmark | `instance_id` shape | Example |
 | --- | --- | --- |
+| SWE-bench (official test set) | `owner__repo-number` | `django__django-11099` |
 | SWE-Gym | `owner__repo-number` | `getmoto__moto-7365` |
+| SWE-bench Multilingual | `owner__repo-number` | `apache__druid-13704` |
 | Scale-SWE | `user_repo_prNumber` | `geopandas_geopandas_pr2027` |
 | SWE-rebench V2 | `owner-repo:PR-commit prefix` | `keras-team-keras:19955-ca9519b` |
 
@@ -590,7 +598,8 @@ Evaluation images from different sources are **not homogeneous**, starting with 
 
 | Image shape | Working directory | How to get it |
 | --- | --- | --- |
-| Standard SWE-bench shape | `/testbed` | Fixed value; the python environment often lives in conda's `testbed`, activated via `BASH_ENV` |
+| Python standard shape such as SWE-bench / SWE-Gym | `/testbed` | Fixed value; first activate conda `testbed` with `BASH_ENV=/root/.bashrc`, then select the repository's real test command. Django and SymPy still do not provide pytest after correct activation and must not be classified as broken images |
+| SWE-bench Multilingual | `/testbed` | Fixed value; use the non-Python toolchains by merging PID 1's `PATH`, do not assume `/root/.bashrc` exists, and do not route to pytest |
 | One directory per repository | `/workspace/<repo>` | From the dataset's `workdir` field, different for each instance |
 | Single application directory | `/app` | Fixed value |
 | Original repository name at the root | For example `/OpenTripPlanner`, `/ApplicationInsights-node.js` | **Cannot be derived from the image tag** (tags are lowercase, directories keep their original case); must be probed at runtime |
@@ -636,16 +645,17 @@ On top of that, evaluation scenarios have five more things to watch:
 | The SDK may hang for a long time on a failed build | After a failure the client keeps polling the build status, and with large logs it can take a long time before raising `ReadTimeout` | A timeout around `Template.build` is mandatory; do not rely on it to return. The built-in `e2b` environment class already does this (`build_timeout`, 30 minutes by default) |
 | Large images time out on sandbox creation | High concurrency reports `TimeoutException` | Keep concurrency around 6 and retry once serially on failure |
 
-Once an image is onboarded, do not stop acceptance testing at "the sandbox started". Sample some instances and run all four steps below; failing any one means it is not usable:
+Once an image is onboarded, do not stop acceptance testing at "the sandbox started". Sample some instances and run all five steps below; failing any one means it is not ready for direct evaluation:
 
 1. Building the template and creating the sandbox succeed.
 2. The repository directory exists, is a git repository, and `HEAD` resolves.
-3. The test executor for that language is available.
-4. Test cases can actually be collected (for example `pytest --collect-only -q`).
+3. `HEAD` matches the instance metadata's `base_commit`; if not, the grader must be able to reset explicitly.
+4. The repository's real test executor is available instead of one guessed from the language.
+5. The deciding cases can actually be collected or executed (`pytest --collect-only -q` for pytest benchmarks).
 
-The script below implements those four steps: one sandbox, no model tokens. When sampling tens or hundreds of images it is an order of magnitude cheaper than `grade.py --gold`, which has to apply a patch and run whole test files. With `cwd: auto` it probes the repository directory inside the sandbox (see "What to change for another benchmark").
+The script below implements the pytest path: one sandbox, no model tokens. When sampling tens or hundreds of images it is an order of magnitude cheaper than `grade.py --gold`, which has to apply a patch and run whole test files. With `cwd: auto` it probes the repository directory inside the sandbox (see "What to change for another benchmark").
 
-It only fits Python benchmarks: the test executor is hard-coded to `python -m pytest` and case names are parsed as pytest node ids. A Go / Java / JS benchmark needs both changed, and so does the grader (see "Multi-language benchmarks need per-language grading").
+It is a **preflight for the pytest grading path**, not a universal acceptance tool for every Python benchmark: the executor is hard-coded to `python -m pytest` and case names are parsed as pytest node ids. On one representative image from each of the complete official SWE-bench set's 12 repositories, only 7/12 simultaneously satisfy pytest, the correct `base_commit`, and representative gold; Django and SymPy need repository-native harnesses, while Requests, Xarray, and Pytest need a baseline reset first. Go / Java / JS benchmarks likewise need different execution and parsing. **Do not use it to accept SWE-bench Multilingual**; that benchmark must run each task's `eval.sh` and matching `log_parser` / `eval_type`.
 
 ```python
 # preflight.py
@@ -762,15 +772,16 @@ Three things to watch when reading that output:
 - **`base_commit_match: false`** means the image and this metadata record are not a pair, and the deciding cases do not belong to this repository state.
 - **`future_commits` above zero means the answer may be in the image**: some benchmarks keep the history past `HEAD` (on tags or other branches), and the agent can dig the fix out of git instead of solving anything. Measured: one SWE-Gym moto image carries 237 tags and commits a year and a half newer than `HEAD`, and the class name added by the gold patch can be found with `git grep`; SWE-rebench V2 images report 0. **This inflates scores and is completely invisible** — the same class of problem as a misconfigured working directory, pointing the other way. Scale-SWE's `pre_commands` already strip refs and the reflog during reset; for other benchmarks, either strip them yourself in `env_startup_command` or at least know that the number includes this.
 
-**Acceptance testing must run under exactly the same environment variables as the grader.** Three common misjudgements make a perfectly good image look unusable:
+**Acceptance testing must run under exactly the same environment variables as the grader.** Four common misjudgements make a perfectly good image look unusable:
 
 | Cause of misjudgement | Consequence |
 | --- | --- |
 | `BASH_ENV` omitted during acceptance testing | The conda environment is not activated and `python -m pytest` reports "No module named pytest" |
+| Treating "correct `BASH_ENV`" as "this repository must provide pytest" | Healthy images such as Django and SymPy, which use repository-native harnesses, are still misclassified |
 | Go installed in `/usr/local/go/bin`, not on the default PATH | A perfectly good Go repository image is judged to have "no test executor" |
 | Java projects ship `./gradlew` instead of a global mvn/gradle | A perfectly good image is misjudged |
 
-The script above reads the same configuration as `grade.py`, so the first misjudgement cannot happen. That is the reason not to let an acceptance script assemble its own environment variables.
+The script above reads the same configuration as `grade.py`, so it does not omit a configured `BASH_ENV`; however, it still verifies only the pytest path and cannot replace repository-level test-command routing. Environment activation and grading routing must be checked separately.
 
 ## Production recommendations
 

--- a/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
+++ b/docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md
@@ -59,11 +59,11 @@ flowchart TB
 
 | 组成 | 内容 | 来源 |
 | --- | --- | --- |
-| 环境 | 镜像 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510`，仓库已停在缺陷提交上、依赖已装好 | 现成评测镜像 |
-| 任务 | 问题描述 `problem_statement` | 上游数据集 |
+| 环境 | 镜像 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/sweb.eval.x86_64:envd_v_0_0_41_getmoto_s_moto-7365-latest_202607231510`，仓库与依赖已装好 | 现成评测镜像 |
+| 任务 | 问题描述 `problem_statement`、缺陷基线 `base_commit` | 上游数据集 |
 | 判定 | `FAIL_TO_PASS`（修好后应通过）、`PASS_TO_PASS`（不能回归）、`test_patch` | 上游数据集 |
 
-镜像只是环境，题目与判定在元数据里。只有镜像没有元数据，题跑不了。
+镜像只是环境，题目、正确基线与判定都在元数据里。只有镜像没有元数据，题跑不了；镜像里的 `HEAD` 也必须与 `base_commit` 一致，不能仅凭镜像不可变就假定基线正确。
 
 ## 装依赖与配置凭据
 
@@ -199,7 +199,7 @@ print(json.dumps({"exit_status": result.get("exit_status"), "patch_bytes": len(p
 
 判定口径与 SWE-bench 官方一致：`FAIL_TO_PASS` 全部通过，且 `PASS_TO_PASS` 没有回归。
 
-判分要在全新沙箱里做，不能复用 Agent 的工作沙箱。Agent 跑完后那个沙箱已经不是原始现场：可能装过额外的包（测试可能因此意外通过）、改过测试文件或 `conftest.py`、留下临时文件。云沙箱的镜像是不可变的，所以只要用同一镜像新建一个沙箱，仓库就自动回到原始状态，不需要清理 Agent 的痕迹。模板已缓存，第二个沙箱起来只要几秒。
+判分要在全新沙箱里做，不能复用 Agent 的工作沙箱。Agent 跑完后那个沙箱已经不是原始现场：可能装过额外的包（测试可能因此意外通过）、改过测试文件或 `conftest.py`、留下临时文件。用同一不可变镜像新建沙箱可以清掉这些痕迹，但**不保证镜像里的 `HEAD` 就是该题的 `base_commit`**；判分前仍要按元数据显式复位并核对。模板已缓存，第二个沙箱起来只要几秒。
 
 ```python
 # grade.py
@@ -252,14 +252,21 @@ f2p, p2p = as_list(inst["FAIL_TO_PASS"]), as_list(inst["PASS_TO_PASS"])
 
 env = get_environment(dict(cfg["environment"], timeout=1800))
 try:
-    # 1) 打被判定的补丁；打不上也是一种结果
+    # 1) 不信任镜像当前 HEAD；按题目元数据复位到唯一正确的缺陷基线
+    base_commit = inst.get("base_commit") or ""
+    assert base_commit, "元数据缺少 base_commit"
+    out = env.execute({"command": f"git reset --hard {shlex.quote(base_commit)} && git clean -fd"},
+                      timeout=300)
+    assert out["returncode"] == 0, f"无法复位到 base_commit: {out['output'][-200:]}"
+
+    # 2) 打被判定的补丁；打不上也是一种结果
     env.sandbox.files.write("/tmp/model.patch", patch)
     out = env.execute({"command": "git apply -v /tmp/model.patch"}, timeout=300)
     if out["returncode"] != 0:
         out = env.execute({"command": "patch -p1 -i /tmp/model.patch"}, timeout=300)
         assert out["returncode"] == 0, f"补丁打不上: {out['output'][-200:]}"
 
-    # 2) 先把测试文件恢复到基线，再打 test_patch —— 测试内容不可被 Agent 篡改
+    # 3) 先把测试文件恢复到基线，再打 test_patch —— 测试内容不可被 Agent 篡改
     tf = patched_files(inst["test_patch"])
     if tf:
         env.execute({"command": f"git checkout -- {' '.join(map(shlex.quote, tf))} || true"})
@@ -267,7 +274,7 @@ try:
     out = env.execute({"command": "git apply -v /tmp/test.patch"}, timeout=300)
     assert out["returncode"] == 0, f"test_patch 打不上: {out['output'][-200:]}"
 
-    # 3) 跑整个测试文件，再从 -rA 报告里按名字匹配。
+    # 4) 跑整个测试文件，再从 -rA 报告里按名字匹配。
     # 不要把用例名当命令行参数传给 pytest：参数化用例名里可能有空格和括号，会 not found。
     # 也不要对报告做 tail 截断：大仓库有几千行，截断会漏判已通过的用例。
     files = sorted(set(tf) | files_of(f2p + p2p))
@@ -327,6 +334,7 @@ finally:
 ```json
 [{"instance_id": "getmoto__moto-7365",
   "problem_statement": "DynamoDB's `update_item` performs floating-point arithmetic …",
+  "base_commit": "7f6c9cb1…",
   "FAIL_TO_PASS": ["tests/test_dynamodb/test_dynamodb_update_expressions.py::test_update_item_add_float"],
   "PASS_TO_PASS": ["tests/test_dynamodb/test_dynamodb_update_expressions.py::test_update_different_map_elements_in_single_request"],
   "test_patch": "diff --git a/tests/... （上游数据集原文）",
@@ -431,26 +439,28 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 | 判定依据被 `tail -N` 截断 | 大仓库测试报告数千行，通过的用例被漏判，分数偏低 | 先过滤出判定行，再单独取统计尾部 |
 | 参数化用例名含空格或换行 | pytest 报告在第一个空白处截断用例名，精确匹配全部落空 | 按截断后的前缀匹配，并按数量满足判定 |
 | 用例名当命令行参数传给 pytest | 名字含空格括号，报 not found，最终 no tests ran | 跑整个测试文件，再从报告按名字匹配 |
+| 镜像 `HEAD` 与元数据 `base_commit` 不同 | 补丁可能打在错误代码现场上，测试结果与题目无关 | 判分前执行 `git reset --hard <base_commit>` 与 `git clean -fd`，复位失败则停止判分 |
+| 正确激活环境后仍没有 pytest | 把仓库原生测试入口误判成坏镜像；Django、SymPy 的代表镜像即属此类 | 读取题库或仓库给出的真实测试命令，不要把所有 Python 仓库都写死为 pytest |
 | 判分命令超时、输出为空被当成「测试未通过」 | 大测试集在高并发下超时，实例被记为 0 通过；串行重跑则全过 | 输出为空或退出码异常时标记为**判分未完成**，不计入分母，降并发重跑 |
 
-最后一类最容易漏。它把基础设施故障读成模型能力差，而且测试用例越多的大仓库越容易触发，结果是分数被整体压低，却看不出任何报错。
+最后三类尤其容易漏：基线或执行器不对时，测试结果根本不属于目标题目；超时则会把基础设施故障读成模型能力差。三者都不能记作普通的 0 分。
 
 ## 上海地域现成的评测镜像
 
-华东1（上海）地域已预置一批开源评测集的镜像，仓库现场与依赖都已就绪，拿到镜像地址构建模板即可使用，无需自行搬运。镜像前缀统一为 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`。
+华东1（上海）地域已预置 19 个镜像族、共 80,298 张开源评测镜像，仓库现场与依赖都已就绪，拿到镜像地址构建模板即可使用，无需自行搬运。镜像前缀统一为 `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/swebench/`。
 
-镜像只解决「环境」。一道题能进评测要三样都齐：镜像能起、拿得到题目元信息（问题描述与判定用例）、判定方式已实现。按这三样，这批镜像分三类：
+镜像只解决「环境」。一道题能进可信评测要三样都齐：镜像能起、拿得到题目元信息（问题描述、正确基线与判定用例）、判分链路在真实运行环境中通过 gold 自检。按这三样，这批镜像分三类：
 
 | 分类 | 镜像数 | 状态 | 你需要做什么 |
 | --- | --- | --- | --- |
 | 一、判定口径已验证 | **29,112** | 三件套齐全，且用数据集自带的正确补丁自检通过 | 换镜像地址与工作目录即可开跑（Scale-SWE 另需换用例引入方式，见下） |
-| 二、元数据齐备，判定需自行实现 | **27,837** | 能起沙箱、能取到题面、关联关系已核对，但判定方式与本文示例不同 | 按该题库的判定方式实现判分 |
+| 二、元数据齐备，判分链路或运行环境待完善 | **30,431** | 能起沙箱、能取到题面、关联关系已核对，但判分器、仓库测试入口、基线复位或全量 gold 自检尚未完成 | 按该题库的真实运行配方补齐并完成 gold 自检 |
 | 三、仅提供镜像 | **20,755** | 镜像能起，但题目与镜像的对应关系无法建立 | 只能当预置好依赖的仓库环境用；要做判分需自行找元数据 |
-| 合计 | **77,704** | | |
+| 合计 | **80,298** | | |
 
-只想先跑通就取第一类。列出第二类是因为镜像与题面都完备，缺的只是判分实现；列出第三类是为了完整披露，它无法自动判分。
+只想先跑通就取第一类。第二类的镜像与题面已经完备，但还不能直接把结果当作可信分数：有些缺判分实现，有些已有判分器却仍缺仓库原生命令、正确基线或足够的 gold 验证。第三类则无法自动关联题目。
 
-> 元数据数据集托管在 HuggingFace 上，**沙箱内不一定能直接访问**。建议在能出网的环境先把需要的字段（`problem_statement` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch`）导出成本地文件，再随评测任务下发；不要在批量评测过程中现拉，一旦拉取失败会把整批拖住。
+> 元数据数据集托管在 HuggingFace 上，**沙箱内不一定能直接访问**。建议在能出网的环境先把需要的字段（`problem_statement` / `base_commit` / `FAIL_TO_PASS` / `PASS_TO_PASS` / `test_patch` / gold `patch`）导出成本地文件，再随评测任务下发；不要在批量评测过程中现拉，一旦拉取失败会把整批拖住。
 
 ### 一、判定口径已验证：29,112 张
 
@@ -469,15 +479,17 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 仓库多样性差别很大：Scale-SWE 覆盖 1,180 个仓库，SWE-rebench V2 的 python 子集 689 个，而 SWE-Gym 只有 11 个（pandas、moto 等占大头）。做跨仓库泛化的基线要看「仓库数」这一列。只用 SWE-Gym 会有天花板，题目再多也集中在同几个仓库上。
 
-### 二、元数据齐备，判定需自行实现：27,837 张
+### 二、元数据齐备，判分链路或运行环境待完善：30,431 张
 
-下表的镜像能起、题面能取、关联字段也已核对到 100%（`SWE-smith` 为 99.7%），差的只是判定实现 —— 它们的判定方式与本文示例不同。
+下表的镜像能起、题面能取、关联字段也已核对到 100%（`SWE-smith` 为 99.7%），但判分器、仓库测试入口、基线复位或全量 gold 自检至少有一项未完成。
 
 | 题库 | 数量 | 题目类型 | 元数据数据集 | 关联字段 | 判定方式与待补内容 |
 | --- | --- | --- | --- | --- | --- |
+| SWE-bench（官方完整 test 集） | **2,294** | 真实 issue 修复，覆盖 12 个 Python 仓库 | [princeton-nlp/SWE-bench](https://huggingface.co/datasets/princeton-nlp/SWE-bench) 的 `test` split | `instance_id`，2,294 张镜像与 2,294 个官方任务双向零差异 | 现有 `test_patch` + F2P/P2P 判分器可复用，但还不能直接升入第一类：上海 Template Build、Sandbox 启动、`/testbed`、git 与 Python 检查为 12/12；正确激活 `BASH_ENV` 后 pytest 为 10/12；`HEAD == base_commit` 为 9/12；代表实例 gold 为 7/12。Django、SymPy 需仓库原生命令，Requests、Xarray、Pytest 需先复位到官方 `base_commit`；补齐后还要完成全量 gold 自检 |
 | SWE-rebench V2（python 以外的 19 种语言） | **24,836** | 真实 PR 修复，仓库覆盖面最广（整族 3,614 个仓库） | [nebius/SWE-rebench-V2](https://huggingface.co/datasets/nebius/SWE-rebench-V2) | `image_name` 字段即镜像的原始地址 | 同为 `FAIL_TO_PASS` + `PASS_TO_PASS`，但用例名形态随测试框架而变，**必须按语言分流**。数据集的 `install_config.test_cmd` 与 `log_parser` 逐实例给出了运行命令与解析方式 |
 | CyberGym | **1,507** | 漏洞挖掘：在真实 OSS 项目中触发并修复已知漏洞（来自 OSS-Fuzz / ARVO） | [sunblaze-ucb/cybergym](https://huggingface.co/datasets/sunblaze-ucb/cybergym) | `task_id`，去掉镜像 tag 末尾的 `-vul` 后缀即相等 | 不用 `FAIL_TO_PASS`，判定漏洞能否被触发、修复后是否不再触发，需接 fuzz 复现链路 |
 | SWE-bench Pro | **731** | 企业级仓库 issue 修复，上下文更长，含 Go / Node 等多语言 | [ScaleAI/SWE-bench_Pro](https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro)，或 [AweAI-Team/AweAgent-Meta-SWE-Bench-Pro](https://huggingface.co/datasets/AweAI-Team/AweAgent-Meta-SWE-Bench-Pro) | `dockerhub_tag` | 同为 `FAIL_TO_PASS` + `PASS_TO_PASS`，需按 `repo_language` 分流。**优先用 AweAI 那份**：行数相同但额外带 `run_script_sh` / `parser_py`，运行与解析脚本都给了 |
+| SWE-bench Multilingual | **300** | 真实 issue 修复，覆盖 41 个仓库和 C / C++ / Go / Java / JavaScript / TypeScript / PHP / Ruby / Rust 9 种非 Python 语言 | [SWE-bench/SWE-bench_Multilingual](https://huggingface.co/datasets/SWE-bench/SWE-bench_Multilingual) | `instance_id`，300 张镜像与 300 个官方任务双向零差异 | 同为 `FAIL_TO_PASS` + `PASS_TO_PASS`，工作目录为 `/testbed`，但不能复用 pytest 判分器。需逐实例执行官方 `eval.sh`，再按 `task.yaml` 的 `log_parser` / `eval_type` 解析真实测试日志；不能只看脚本退出码。Rust gold 已通过，Go 受依赖源网络限制，部分 Maven 任务依赖已下架的 SNAPSHOT，完成全量 gold 自检前保持第二类 |
 | SWE-smith | **363 张环境镜像**（对应上游 **79,418 道题**） | 合成缺陷修复，一个镜像承载同一仓库的多道题 | [SWE-bench/SWE-smith-py](https://huggingface.co/datasets/SWE-bench/SWE-smith-py) 等 7 个语言子集（py / java / js / ts / rs / cpp / php）。上游另有 go 子集，**无对应镜像** | `image_name` | 判定依据同 SWE-bench，但**选题机制要自己接**：在镜像内 `/testbed` 执行 `git checkout <instance_id>` 切到对应缺陷状态 |
 | SEC-bench | **300** | 安全漏洞复现与修复（CVE） | [SEC-bench/SEC-bench](https://huggingface.co/datasets/SEC-bench/SEC-bench) | `instance_id` | 不用 `FAIL_TO_PASS`，看 sanitizer 报告与退出码。数据集自带 `work_dir` / `build_sh` / `secb_sh`，运行与判定脚本都给了 |
 | Terminal-Bench 2.x | **89** | 终端任务（非代码修复）：给一段指令在 shell 中完成，无 git 仓库、不产补丁 | [harborframework/terminal-bench-2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2.0) | 任务目录名即镜像 tag | 跑任务自带的 `tests/test.sh`，**判分不用自己写**；但 Agent 循环要换 —— 它不产出补丁 |
@@ -485,7 +497,11 @@ Agent 阶段只产出 `preds.json`，判分阶段读它，每条另起全新沙�
 
 SWE-smith 的「镜像数」和「题量」不是一回事。363 张是环境镜像，一个仓库一张，背后挂着上游 79,418 道题，靠切分支选题。接好选题机制后，它是这批资产里题量最大的来源。
 
+官方完整 SWE-bench 虽然全是 Python，也不能把「Python」等同于「pytest」。12 个仓库各抽一张后，镜像构建与启动均通过，但只有 10 个仓库在正确激活环境后提供 pytest；Django 和 SymPy 要走仓库原生 harness。另外三张镜像的 `HEAD` 与官方 `base_commit` 不同，因此现有通用 pytest 判分器只能完成 7/12 的代表 gold 自检，不能据此宣称全族可直接评测。
+
 多语言题库要按语言分流判定。以 SWE-rebench V2 为例，用例名的形态随测试框架而变：python 是 pytest 的 node id（`tests/test_x.py::TestA::test_b`），TS / JS 是 jest、mocha 的用例描述，Java 是测试类名。用一套 pytest 的解析逻辑套所有语言，非 python 的实例会**全部判为失败**。清单里的 `swerebenchv2-languages.tsv`（id → 语言）可用于筛选。测试命令的形态比语言集中：Go 全是 `go test`、Rust 全是 `cargo test`、Java 是 Maven 与 Gradle 两种、JS / TS 是 npm 系的 jest / mocha / vitest 等 —— 按四到五组实现解析器即可覆盖大部分。SWE-bench Pro 同理，按 `repo_language` 分流。
+
+SWE-bench Multilingual 则直接以逐实例 `eval.sh` 和 `task.yaml` 的 `log_parser` / `eval_type` 为准。运行时应合并镜像 PID 1 的 `PATH`，以找到 Cargo 等预装工具链；不要无条件设置 Python 镜像常用的 `BASH_ENV=/root/.bashrc`。解析真实测试日志而不是脚本退出码，才能避免把失败测试误报为通过。
 
 ### 三、仅提供镜像：元数据需自行匹配，20,755 张
 
@@ -504,49 +520,41 @@ SWE-smith 的「镜像数」和「题量」不是一回事。363 张是环境镜
 
 ### 镜像清单获取
 
-无论哪一类，都需要一份 `instance_id`（或镜像 tag）到镜像地址的映射表：**镜像 tag 带构建批次信息，无法由 `instance_id` 推导**。清单是制表符分隔的文本文件，每行 `instance_id<TAB>镜像地址`，可直接 `grep` 或 `cut -f2` 喂给脚本。
+无论哪一类，都需要 `instance_id`（或镜像 tag）到镜像地址的映射：**镜像 tag 带构建批次信息，无法由 `instance_id` 推导**。
 
-**按上面三类取用**（这三个文件与前文的三个小节一一对应）：
+为避免每次新增镜像都维护大量下载链接，每个批次只对外发布一个完整包
+`swe-images-<发布日期>.tar.gz`。按档位、题库和语言拆分的文件仍保留在包内，供脚本按需选择，但不再作为独立下载项写入最佳实践。
 
-| 分类 | 清单文件 | 行数 | 下载地址 |
-| --- | --- | --- | --- |
-| 一、判定口径已验证 | `tier-A-images.tsv` | 29,112 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-A-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-A-images.tsv.gz)） |
-| 二、元数据齐备，判定需自行实现 | `tier-B-images.tsv` | 27,837 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-B-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-B-images.tsv.gz)） |
-| 三、仅提供镜像 | `tier-C-images.tsv` | 20,755 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tier-C-images.tsv.gz)） |
+| 当前批次 | 镜像数 | 完整包 | 状态 |
+| --- | ---: | --- | --- |
+| 20260903 | 80,298 | [`swe-images-20260903.tar.gz`](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260903.tar.gz) | 已发布 |
 
-这三个文件都是三列：`instance_id` / 镜像地址 / 题库名，用第三列即可切到单个题库。
+压缩包内容保持稳定：
 
-**按题库单独取用**：
+| 包内文件 | 内容 |
+| --- | --- |
+| `all-images.tsv` | 全量四列清单：`instance_id` / 镜像地址 / 题库 / 分类 |
+| `tier-{A,B,C}-images.tsv` | 与前文三类一一对应；第三列可继续切到单个题库 |
+| `<family>-images.tsv` | 各题库的 `instance_id<TAB>镜像地址`，包括 `swebench-images.tsv` 与 `swebmultilingual-images.tsv` |
+| `swerebenchv2-languages.tsv` | SWE-rebench V2 的语言分流表 |
+| `image-registry.json` | 工作目录、运行用户、判定方式和元数据来源，供 runner 读取 |
+| `MANIFEST.tsv` | 所有包内文件的行数、字节数和 SHA-256 |
+| `README.md` | 当前批次统计、题库关联方式和已知边界 |
 
-| 题库 | 清单文件 | 行数 | 下载地址 |
-| --- | --- | --- | --- |
-| SWE-rebench V2（整族） | `swerebenchv2-images.tsv` | 32,074 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-images.tsv.gz)） |
-| SWE-rebench V2（python 子集） | `swerebenchv2-python-images.tsv` | 7,238 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-python-images.tsv.gz)） |
-| SWE-rebench V2（id → 语言对照） | `swerebenchv2-languages.tsv` | 32,074 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swerebenchv2-languages.tsv.gz)） |
-| Scale-SWE | `scaleswe-images.tsv` | 19,473 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/scaleswe-images.tsv.gz)） |
-| SWE-Gym | `swegym-images.tsv` | 2,401 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swegym-images.tsv.gz)） |
-| CyberGym | `cybergym-images.tsv` | 1,507 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/cybergym-images.tsv) |
-| SWE-bench Pro | `swebpro-images.tsv` | 731 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swebpro-images.tsv.gz)） |
-| SWE-smith | `swesmith-images.tsv` | 363 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/swesmith-images.tsv) |
-| SEC-bench | `secbench-images.tsv` | 300 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/secbench-images.tsv) |
-| Terminal-Bench 2.x | `tb21-images.tsv` | 89 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/tb21-images.tsv) |
-| SWE-Atlas QnA | `sweatlas-images.tsv` | 11 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/sweatlas-images.tsv) |
+```bash
+tar -xzf swe-images-20260903.tar.gz
+cd swe-images-20260903
+```
 
-配套文件：
-
-| 文件 | 内容 | 下载地址 |
-| --- | --- | --- |
-| `all-images.tsv` | 全部 77,704 张，四列：`instance_id` / 镜像地址 / 题库 / 所属分类 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv)（[gz](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/all-images.tsv.gz)） |
-| `image-registry.json` | 每个题库的工作目录、运行用户、判定方式、元数据来源，供 runner 读取 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/image-registry.json) |
-| `MANIFEST.tsv` | 各文件的行数、字节数与 **sha256**，下载后建议校验完整性 | [下载](https://images.devsapp.cn/e2b/swe-bench/swe-images-20260821/MANIFEST.tsv) |
-
-超过 200 KB 的清单另有 `.gz` 版本，内容一致。清单不做原地更新：新一批镜像会发布到新的目录，已发布文件的内容保持不变。
+新批次始终使用新的日期文件名，不覆盖已发布压缩包。以后发布只需上传一个完整包，并更新上表的一行。
 
 **`instance_id` 的形态各题库不同**，写筛选脚本前先看一眼实际内容，不要跨题库套用同一个正则：
 
 | 题库 | `instance_id` 形态 | 示例 |
 | --- | --- | --- |
+| SWE-bench（官方 test 集） | `owner__repo-编号` | `django__django-11099` |
 | SWE-Gym | `owner__repo-编号` | `getmoto__moto-7365` |
+| SWE-bench Multilingual | `owner__repo-编号` | `apache__druid-13704` |
 | Scale-SWE | `user_repo_pr编号` | `geopandas_geopandas_pr2027` |
 | SWE-rebench V2 | `owner-repo:PR-提交前缀` | `keras-team-keras:19955-ca9519b` |
 
@@ -571,7 +579,8 @@ awk -F'\t' 'NR>1{print $4"  "$1}' MANIFEST.tsv > sums && sha256sum -c sums
 
 | 镜像来源形态 | 工作目录 | 怎么拿到 |
 | --- | --- | --- |
-| SWE-bench 标准形态 | `/testbed` | 固定值；python 环境常在 conda 的 `testbed` 里，需 `BASH_ENV` 激活 |
+| SWE-bench / SWE-Gym 等 Python 标准形态 | `/testbed` | 固定值；先用 `BASH_ENV=/root/.bashrc` 激活 conda `testbed`，再按仓库选择真实测试命令。正确激活后 Django、SymPy 仍不提供 pytest，不应误判成坏镜像 |
+| SWE-bench Multilingual | `/testbed` | 固定值；使用非 Python 工具链，应合并 PID 1 的 `PATH`，不能假定存在 `/root/.bashrc`，也不能套用 pytest |
 | 按仓库名分目录 | `/workspace/<repo>` | 取数据集的 `workdir` 字段，每实例不同 |
 | 单一应用目录 | `/app` | 固定值 |
 | 根目录下以仓库原名命名 | 如 `/OpenTripPlanner`、`/ApplicationInsights-node.js` | **无法从镜像 tag 推导**（tag 是小写、目录保留原始大小写），需运行时探测 |
@@ -620,16 +629,17 @@ For a repository-based task this means it is misconfigured: …
 | 构建失败时 SDK 可能长时间不返回 | 失败后客户端会持续轮询构建状态，日志量大时可能拖很久才抛 `ReadTimeout` | 必须在 `Template.build` 外层加超时，不要依赖它自己返回。内置 `e2b` 环境类已经这么做（`build_timeout`，默认 30 分钟）|
 | 大镜像创建沙箱会超时 | 高并发下报 `TimeoutException` | 并发压到 6 左右，失败先串行重试一次 |
 
-镜像接入后，验收不要停在「沙箱起来了」。抽样跑完以下四步，任何一步不过都不算可用：
+镜像接入后，验收不要停在「沙箱起来了」。抽样跑完以下五步，任何一步不过都不能算作可直接评测：
 
 1. 构建模板、创建沙箱成功。
 2. 仓库目录存在、是 git 仓库、`HEAD` 能解析。
-3. 该语言的测试执行器可用。
-4. 能真正收集到用例（如 `pytest --collect-only -q`）。
+3. `HEAD` 与实例元数据的 `base_commit` 一致；不一致时判分器必须能显式复位。
+4. 该仓库的真实测试执行器可用，而不是只按语言猜一个执行器。
+5. 能真正收集或执行判定用例（pytest 题库可用 `pytest --collect-only -q`）。
 
-下面这份脚本是这四步的实现：一个沙箱跑完，不花模型 token。抽样几十上百张镜像时它比 `grade.py --gold` 便宜一个数量级 —— 后者要打补丁、跑完整测试文件。`cwd` 写 `auto` 时它会在沙箱内探测仓库目录（见「换题库要改什么」）。
+下面这份脚本实现其中的 pytest 路径：一个沙箱跑完，不花模型 token。抽样几十上百张镜像时它比 `grade.py --gold` 便宜一个数量级 —— 后者要打补丁、跑完整测试文件。`cwd` 写 `auto` 时它会在沙箱内探测仓库目录（见「换题库要改什么」）。
 
-它只适用于 Python 题库：测试执行器写死 `python -m pytest`、用例名按 pytest node id 解析。换 Go / Java / JS 题库要同时改这两处，判分器同理（见前文「多语言题库要按语言分流判定」）。
+它是 **pytest 判分器的预检脚本**，不是所有 Python 题库的通用验收器：测试执行器写死 `python -m pytest`、用例名按 pytest node id 解析。官方 SWE-bench 的 12 个仓库各抽一张时，这条路径只有 7/12 同时满足 pytest、正确 `base_commit` 和代表 gold；Django、SymPy 要改用仓库原生 harness，Requests、Xarray、Pytest 要先复位基线。换 Go / Java / JS 题库也要同时改执行与解析。**不要用它验收 SWE-bench Multilingual**；该题库必须走逐实例 `eval.sh` 与对应的 `log_parser` / `eval_type`。
 
 ```python
 # preflight.py
@@ -746,15 +756,16 @@ sys.exit(0 if report["ok"] else 1)
   与「工作目录配错」同类，只是方向相反。Scale-SWE 的 `pre_commands` 已在复位时剥掉 refs 与 reflog；
   其他题库要么自己在 `env_startup_command` 里剥，要么至少知道分数含这个成分。
 
-**验收必须在与判分器完全相同的环境变量下进行。** 三类常见误判会让正常镜像被判为不可用：
+**验收必须在与判分器完全相同的环境变量下进行。** 四类常见误判会让正常镜像被判为不可用：
 
 | 误判原因 | 后果 |
 | --- | --- |
 | 验收时漏掉 `BASH_ENV` | conda 环境未激活，`python -m pytest` 报 No module named pytest |
+| 把「正确设置了 `BASH_ENV`」等同于「仓库必须提供 pytest」 | Django、SymPy 这类使用仓库原生 harness 的正常镜像仍被误判 |
 | Go 装在 `/usr/local/go/bin`，不在默认 PATH | 正常的 Go 仓库镜像被判「没有测试执行器」 |
 | Java 项目不装全局 mvn/gradle，而是带 `./gradlew` | 正常镜像被误判 |
 
-上面的脚本与 `grade.py` 读同一份配置，所以第一类误判不会发生。这就是不要让验收脚本自己拼环境变量的原因。
+上面的脚本与 `grade.py` 读同一份配置，所以不会漏掉配置中的 `BASH_ENV`；但它仍只验证 pytest 路径，不能替代按仓库读取真实测试命令。这就是环境激活与判分路由必须分开核验的原因。
 
 ## 上线建议
 


### PR DESCRIPTION
## 修改内容

- 更新上海地域 SWE 评测镜像库存：
  - 总量：80,298
  - Family：19
  - Tier A/B/C：29,112 / 30,431 / 20,755
- 新增官方 SWE-bench 2,294 张镜像及 SWE-bench Multilingual 300 张镜像的 Tier B 说明。
- 补充抽检结果、仓库原生测试入口和多语言判分限制。
- 判分示例增加 `base_commit` 复位，避免镜像 `HEAD` 漂移导致错误判分。
- 将分散清单下载改为单一版本化压缩包：
  `swe-images-20260903.tar.gz`
- 同步更新中英文文档。

## 验证

- 镜像与官方任务 ID 全量对应。
- 归档链接可正常访问。
- 中英文数据及判分口径一致。
- `git diff --check` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 文档范围

本次 PR 更新阿里云函数计算的 SWE Agent 评测文档，覆盖中英文版本：

- `docs/en-US/01.FC Agent Sandbox/05.Best Practices/12.Build a SWE Agent.md`
- `docs/zh-CN/01.云沙箱/05.最佳实践/12.构建 SWE Agent.md`

改动涉及判分流程、SWE 评测镜像清单、镜像验收和测试说明。

## 页面与图片资源

- 未新增或删除页面。
- 未新增、修改或删除图片资源。

## 主要改动

- 判分前增加 `git reset --hard <base_commit>` 和 `git clean -fd`。
- 将镜像清单调整为单一版本化压缩包 `swe-images-20260903.tar.gz`。
- 更新上海地域镜像数量及 Tier B 说明。
- 补充 SWE-bench 官方测试集和 SWE-bench Multilingual 题库说明。
- 扩展镜像验收步骤，并补充 `BASH_ENV`、pytest 等误判说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->