### PR TITLE
docs: clarify denyOut domain support

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/05.Network Access Control.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/06.Network/05.Network Access Control.md
@@ -50,7 +50,7 @@ python demo.py
 | `allowInternetAccess` / `allow_internet_access` | Master egress switch; `false` is equivalent to `denyOut: ["0.0.0.0/0"]` | Yes | Yes (`updateNetwork`) |
 | `network.allowPublicTraffic` | Whether the public URL requires token authentication; defaults to `true` | Yes | No (can only be set at creation) |
 | `network.allowOut` | Egress **allow** list; supports IP / CIDR / domain | Yes | Yes (`updateNetwork`) |
-| `network.denyOut` | Egress **deny** list; supports IP / CIDR only | Yes | Yes (`updateNetwork`) |
+| `network.denyOut` | Egress **deny** list; supports IP / CIDR / domain | Yes | Yes (`updateNetwork`) |
 | `network.egressProxy` | SOCKS5 egress proxy | **Not yet supported** | — |
 | `network.maskRequestHost` | Rewrite the `Host` header of the sandbox's requests | **Not yet supported** | — |
 | `network.rules` | Transform egress requests by domain (e.g. inject HTTP headers) | **Not yet supported** | — |
@@ -245,7 +245,7 @@ finally:
 
 ### Allow List allowOut and Deny List denyOut
 
-Each entry in `allowOut` can be a **CIDR / bare IP / domain** (`"example.com"`, `"*.example.com"`); `denyOut` **supports only IP and CIDR, not domains**.
+Each entry in `allowOut` can be a **CIDR / bare IP / domain** (`"example.com"`, `"*.example.com"`); `denyOut` also supports **IP / CIDR / domain** entries.
 
 **Node.js**
 
@@ -377,7 +377,7 @@ finally:
 
 When filtering by domain, there are several behaviors you must keep in mind:
 
-- **You must explicitly deny the rest of the traffic**: because `denyOut` does not support domains, a domain allowlist must be combined with `denyOut: ["0.0.0.0/0"]` (or `allowInternetAccess: false`), otherwise it has no effect.
+- **A domain allowlist must explicitly deny the rest of the traffic**: a domain allowlist must be combined with `denyOut: ["0.0.0.0/0"]` (or `allowInternetAccess: false`), otherwise it has no effect.
 - **Only covers HTTP:80 and TLS:443**: domain matching relies on the `Host` header on port 80 and the TLS SNI on port 443. **Other ports can only be filtered by IP / CIDR**; UDP protocols such as QUIC / HTTP3 do not support domain filtering.
 - **DNS is automatically allowed**: as long as domains are used, the system automatically allows the default DNS server `8.8.8.8` to keep domain resolution working.
 - Wildcards `*.example.com` are supported to match all subdomains.
@@ -388,7 +388,7 @@ When multiple parameters are present at the same time, whether a given egress re
 
 1. **Allow takes priority over deny**: `allowOut` always takes priority over `denyOut`. If a target matches both the allow and deny lists, it is **allowed**.
 2. **`allowInternetAccess: false` merely appends `["0.0.0.0/0"]` to `denyOut`**: it establishes a "deny all by default" baseline, but is **not a hard kill switch**. Because allow beats deny, targets matched by `allowOut` still punch through this baseline and are allowed—so `allowInternetAccess: false` + `allowOut` means "deny all + allowlist", and it truly forbids all egress only when no `allowOut` is set.
-3. **Domain filtering requires an explicit `denyOut` all**: see the previous section.
+3. **A domain allowlist requires an explicit `denyOut` all**: see the previous section.
 
 Effects of common combinations:
 
@@ -490,7 +490,7 @@ Points to note:
 - `egressProxy`, `maskRequestHost`, and `network.rules` are **not yet supported** and have no effect when passed.
 - `trafficAccessToken` is returned on create / connect / resume; it is not returned on `getInfo` / `list`. Persist it for simpler reuse.
 - `allowPublicTraffic` **can only be set at creation** and cannot be modified afterward.
-- `denyOut` **supports only IP / CIDR**, not domains; domains can only go in `allowOut`.
+- `denyOut` supports **IP / CIDR / domain** entries.
 - Domain filtering only covers HTTP:80 and TLS:443; other ports are filtered by IP / CIDR, and UDP (QUIC/HTTP3) does not support domain filtering.
 - Denied connections may appear as "connected successfully" inside the sandbox; rely on the application-layer response.
 - Egress control (`allowOut` / `denyOut`) and public inbound authentication (`allowPublicTraffic`) are independent of each other.

--- a/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/05.网络访问控制.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/06.网络/05.网络访问控制.md
@@ -50,7 +50,7 @@ python demo.py
 | `allowInternetAccess` / `allow_internet_access` | 出网总开关，`false` 等价于 `denyOut: ["0.0.0.0/0"]` | 支持 | 可（`updateNetwork`） |
 | `network.allowPublicTraffic` | 公网 URL 是否需要令牌鉴权，默认 `true` | 支持 | 否（仅创建时可设） |
 | `network.allowOut` | 出网**允许**清单，支持 IP / CIDR / 域名 | 支持 | 可（`updateNetwork`） |
-| `network.denyOut` | 出网**拒绝**清单，仅支持 IP / CIDR | 支持 | 可（`updateNetwork`） |
+| `network.denyOut` | 出网**拒绝**清单，支持 IP / CIDR / 域名 | 支持 | 可（`updateNetwork`） |
 | `network.egressProxy` | 出网 SOCKS5 代理 | **暂不支持** | — |
 | `network.maskRequestHost` | 改写沙箱请求的 `Host` 头 | 支持 | 否（仅创建时可设） |
 | `network.rules` | 按域名对出网请求做转换（如注入 HTTP 头） | 支持 | 可（`updateNetwork`） |
@@ -245,7 +245,7 @@ finally:
 
 ### 允许清单 allowOut 与拒绝清单 denyOut
 
-`allowOut` 每个条目可以是 **CIDR / 裸 IP / 域名**（`"example.com"`、`"*.example.com"`）；`denyOut` **只支持 IP 和 CIDR，不支持域名**。
+`allowOut` 每个条目可以是 **CIDR / 裸 IP / 域名**（`"example.com"`、`"*.example.com"`）；`denyOut` 同样支持 **IP / CIDR / 域名**。
 
 **Node.js**
 
@@ -377,7 +377,7 @@ finally:
 
 使用域名做过滤时，有几个必须注意的行为：
 
-- **必须显式拒绝其余流量**：由于 `denyOut` 不支持域名，域名白名单必须配合 `denyOut: ["0.0.0.0/0"]`（或 `allowInternetAccess: false`），否则不生效。
+- **域名白名单必须显式拒绝其余流量**：域名白名单必须配合 `denyOut: ["0.0.0.0/0"]`（或 `allowInternetAccess: false`），否则不生效。
 - **仅覆盖 HTTP:80 与 TLS:443**：域名匹配依赖 80 端口的 `Host` 头和 443 端口的 TLS SNI。**其他端口只能按 IP / CIDR 过滤**；QUIC / HTTP3 等 UDP 协议不支持域名过滤。
 - **DNS 自动放行**：只要用到域名，系统会自动放行默认 DNS 服务器 `8.8.8.8`，以保证域名解析可用。
 - 支持通配符 `*.example.com` 匹配所有子域名。
@@ -388,7 +388,7 @@ finally:
 
 1. **允许优先于拒绝**：`allowOut` 始终优先于 `denyOut`。若同一目标同时命中允许和拒绝清单，则**放行**。
 2. **`allowInternetAccess: false` 只是等价于 `denyOut += ["0.0.0.0/0"]`**：它建立「默认拒绝全部」的基线，但**不是硬关闭**。因为 allow 优先于 deny，`allowOut` 命中的目标仍会穿透该基线被放行——因此 `allowInternetAccess: false` + `allowOut` 就是「默认拒绝 + 白名单」，只有在不配 `allowOut` 时才真正禁止一切出网。
-3. **域名过滤必须显式 `denyOut` 全部**：见上一节。
+3. **域名白名单必须显式 `denyOut` 全部**：见上一节。
 
 常见组合的效果：
 
@@ -490,7 +490,7 @@ finally:
 - `egressProxy` **暂不支持**，传入不会生效。
 - `trafficAccessToken` 在 create / connect / resume 时均返回；`getInfo` / `list` 不返回。建议持久化保存以简化使用。
 - `allowPublicTraffic` **仅创建时可设**，创建后不可修改。
-- `denyOut` **仅支持 IP / CIDR**，不支持域名；域名只能写在 `allowOut`。
+- `denyOut` 支持 **IP / CIDR / 域名**。
 - 域名过滤仅覆盖 HTTP:80 与 TLS:443，其余端口按 IP / CIDR 过滤，UDP（QUIC/HTTP3）不支持域名过滤。
 - 被拒绝的连接可能在沙箱内表现为"连接成功"，应以应用层响应为准。
 - 出网控制（`allowOut`/`denyOut`）与公网入站鉴权（`allowPublicTraffic`）相互独立。


### PR DESCRIPTION
## 变更说明

修正云沙箱网络访问控制的中英文文档，明确 `denyOut` 支持 IP、CIDR 和域名，并将“需显式拒绝全部流量”的说明限定为域名白名单。示例代码保持不变。

## 变更类型

- [x] 修正文档内容
- [ ] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [x] 已运行 `make check`（脚本测试、文档结构及引用检查、严格构建通过）
- [x] 已检查新增或修改的链接和图片
- [x] 未提交真实凭证或敏感信息


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 文档范围

- 更新阿里云函数计算云沙箱的网络访问控制文档。
- 涉及中文和英文文档的“网络访问控制”章节。
- 明确 `denyOut` 支持 IP 地址、CIDR 网段和域名。
- 同步修正域名白名单、优先级规则和限制说明。
- 未新增或删除页面。
- 未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->