### PR TITLE
docs(sandbox): 补齐挂载路径限制与符号链接使用说明

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/04.Dynamic OSS Mounts.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/04.Dynamic OSS Mounts.md
@@ -49,6 +49,14 @@ Field descriptions:
 | `endpoint` | Yes | OSS Endpoint. Must match the Bucket's region. |
 | `readOnly` | No | Whether the mount is read-only. Set to `true` for read-only access to the mount directory. |
 
+## Local mount directory
+
+`mountDir` specifies a local filesystem mount point inside the Sandbox runtime, not a remote storage directory.
+
+- We recommend a subdirectory of `/home`, `/mnt`, `/tmp`, or `/data`, such as `/mnt/oss` or `/data/files`, to avoid covering existing directories in the template.
+- Common Linux and Unix system directories and their subdirectories cannot be used as mount points. Examples include `/bin`, `/opt`, `/var`, `/dev`, and subdirectories such as `/opt/data` and `/var/data`. Using these paths can cause the mount to fail.
+- **Mount paths do not support hidden files or directories (names beginning with `.`), such as `/root/.cache` and `/home/user/.cache`.** Even under a recommended directory such as `/home`, the path cannot contain a hidden directory such as `.cache`. To access mounted content through a hidden directory, first mount the storage at a supported path, then use `ln -s` to create a symbolic link pointing to that mount directory.
+
 ## Create a Sandbox with OSS mounts
 
 The following example creates a Sandbox with dynamic OSS mounts and lists the files under the mount directory.
@@ -241,5 +249,5 @@ print(result.stdout.strip())
 - OSS mounts require `fc.sandbox.auth.role` to be configured as well; otherwise the Sandbox cannot obtain permissions to access OSS.
 - The `endpoint` must match the Bucket's region; cross-region access may cause higher latency or access failures.
 - `bucketPath` should use absolute paths, for example `/e2b-test`. Use `/` for the root directory.
-- `mountDir` should avoid conflicts with existing system directories in the template. Recommended paths: `/mnt/oss` or `/home/user/oss`.
+- `mountDir` must follow the requirements in [Local mount directory](#local-mount-directory).
 - Configure OSS lifecycle cleanup rules for temporary artifacts when appropriate.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/09.Append Sandbox Storage Mounts.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/09.Append Sandbox Storage Mounts.md
@@ -67,6 +67,14 @@ The following table describes the inline configuration fields. Field names are c
 | `agenticFS` | `mountPoints[].serverAddr` | Yes | AgenticFS Access Point address, up to 128 characters. |
 | `agenticFS` | `mountPoints[].mountDir` | Yes | Normalized absolute path inside the Sandbox, up to 128 characters. It cannot be `/`. |
 
+## Local mount directory
+
+`mountDir` in `inlineVolumeMounts` and `namedVolumeMounts[].path` specify a local filesystem mount point inside the Sandbox runtime, not a remote storage directory.
+
+- We recommend a subdirectory of `/home`, `/mnt`, `/tmp`, or `/data`, such as `/mnt/oss`, `/mnt/agenticfs`, or `/data/files`, to avoid covering existing directories in the template.
+- Common Linux and Unix system directories and their subdirectories cannot be used as mount points. Examples include `/bin`, `/opt`, `/var`, `/dev`, and subdirectories such as `/opt/data` and `/var/data`. Using these paths can cause the mount to fail.
+- **Mount paths do not support hidden files or directories (names beginning with `.`), such as `/root/.cache` and `/home/user/.cache`.** Even under a recommended directory such as `/home`, the path cannot contain a hidden directory such as `.cache`. To access mounted content through a hidden directory, first mount the storage at a supported path, then use `ln -s` to create a symbolic link pointing to that mount directory.
+
 ## Append an Existing Volume
 
 The following example appends an existing Volume to a running Sandbox:

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/01.Mount an OSS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/01.Mount an OSS Volume.md
@@ -129,7 +129,11 @@ python 01_mount_oss_volume.py
 
 - A single sandbox can mount at most five OSS Volumes.
 - The mount directory must be a normalized absolute Unix path. It cannot be `/`, and it cannot contain leading or trailing whitespace or `..`.
-- Mount directories in the same sandbox cannot be duplicated. We recommend `/mnt/oss` or a subdirectory to avoid overriding directories from the template.
+- The local mount directory is a filesystem mount point inside the sandbox runtime. It is the key in `volume_mounts`, not the remote directory in OSS.
+- We recommend a subdirectory of `/home`, `/mnt`, `/tmp`, or `/data`, such as `/mnt/oss` or `/data/files`, to avoid covering existing directories in the template.
+- Common Linux and Unix system directories and their subdirectories cannot be used as mount points. Examples include `/bin`, `/opt`, `/var`, `/dev`, and subdirectories such as `/opt/data` and `/var/data`. Using these paths can cause the mount to fail.
+- **Mount paths do not support hidden files or directories (names beginning with `.`), such as `/root/.cache` and `/home/user/.cache`.** Even under a recommended directory such as `/home`, the path cannot contain a hidden directory such as `.cache`. To access mounted content through a hidden directory, first mount the storage at a supported path, then use `ln -s` to create a symbolic link pointing to that mount directory.
+- Mount directories in the same sandbox cannot be duplicated.
 
 ## FAQ
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/02.Mount an AgenticFS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/12.Volumes/02.Mount an AgenticFS Volume.md
@@ -141,7 +141,11 @@ python 02_mount_agenticfs_volume.py
 - A single sandbox can mount at most five AgenticFS Volumes.
 - When multiple AgenticFS Volumes are mounted into one sandbox, all Volumes must use identical `user_id` and `group_id` settings.
 - The mount directory has a maximum length of 128 characters and must be a normalized absolute Unix path. It cannot be `/`, and it cannot contain leading or trailing whitespace or `..`.
-- Mount directories in the same sandbox cannot be duplicated. We recommend `/mnt/agenticfs` or a subdirectory to avoid overriding directories from the template.
+- The local mount directory is a filesystem mount point inside the sandbox runtime. It is the key in `volume_mounts`, not the remote directory in AgenticFS.
+- We recommend a subdirectory of `/home`, `/mnt`, `/tmp`, or `/data`, such as `/mnt/agenticfs` or `/data/files`, to avoid covering existing directories in the template.
+- Common Linux and Unix system directories and their subdirectories cannot be used as mount points. Examples include `/bin`, `/opt`, `/var`, `/dev`, and subdirectories such as `/opt/data` and `/var/data`. Using these paths can cause the mount to fail.
+- **Mount paths do not support hidden files or directories (names beginning with `.`), such as `/root/.cache` and `/home/user/.cache`.** Even under a recommended directory such as `/home`, the path cannot contain a hidden directory such as `.cache`. To access mounted content through a hidden directory, first mount the storage at a supported path, then use `ln -s` to create a symbolic link pointing to that mount directory.
+- Mount directories in the same sandbox cannot be duplicated.
 
 ## FAQ
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/04.动态挂载 OSS.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/04.动态挂载 OSS.md
@@ -49,6 +49,14 @@ OSS 动态挂载通过 Sandbox metadata 配置，不需要把挂载配置固化�
 | `endpoint` | 是 | OSS Endpoint，应与 Bucket 所在地域匹配。 |
 | `readOnly` | 否 | 是否只读挂载。设置为 `true` 时 Sandbox 只能读取挂载目录。 |
 
+## 本地挂载目录 {#local-mount-directory}
+
+`mountDir` 表示 Sandbox 运行环境中的本地文件系统挂载点，不是远端存储目录。
+
+- 建议使用 `/home`、`/mnt`、`/tmp` 或 `/data` 的子目录，例如 `/mnt/oss` 或 `/data/files`，避免覆盖模板内已有目录。
+- 不能使用通用的 Linux 和 Unix 系统目录及其子目录作为挂载点，例如 `/bin`、`/opt`、`/var`、`/dev`，以及 `/opt/data`、`/var/data` 等子目录，以免挂载失败。
+- **挂载路径不支持隐藏文件或隐藏目录（名称以 `.` 开头），例如 `/root/.cache`、`/home/user/.cache`。** 即使路径位于推荐的 `/home` 子目录下，也不能包含 `.cache` 这类隐藏目录；如需通过隐藏目录访问挂载内容，可先挂载到符合要求的目录，再自行使用 `ln -s` 创建指向该挂载目录的符号链接。
+
 ## 创建带 OSS 挂载的 Sandbox
 
 以下示例在创建 Sandbox 时动态挂载 OSS，并列出挂载目录下的文件。
@@ -242,5 +250,5 @@ print(result.stdout.strip())
 - OSS 挂载需要同时配置 `fc.sandbox.auth.role`，否则 Sandbox 无法获得访问 OSS 的权限。
 - `endpoint` 应与 Bucket 地域匹配；跨地域访问可能导致延迟升高或访问失败。
 - `bucketPath` 建议使用绝对路径，例如 `/e2b-test`。挂载根目录时使用 `/`。
-- `mountDir` 应避免与模板内已有系统目录冲突，推荐使用 `/mnt/oss` 或 `/home/user/oss`。
+- `mountDir` 必须符合[本地挂载目录](#local-mount-directory)中的目录要求。
 - 临时产物建议配置 OSS 生命周期清理规则。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/09.追加挂载沙箱存储.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/09.追加挂载沙箱存储.md
@@ -69,6 +69,14 @@ POST /sandboxes/{sandboxID}/fc-volume-mounts
 | `agenticFS` | `mountPoints[].serverAddr` | 是    | AgenticFS Access Point 地址，最长 128 个字符。           |
 | `agenticFS` | `mountPoints[].mountDir`   | 是    | Sandbox 内的规范化绝对路径，最长 128 个字符，不能为 `/`。           |
 
+## 本地挂载目录
+
+`inlineVolumeMounts` 中的 `mountDir` 和 `namedVolumeMounts[].path` 表示 Sandbox 运行环境中的本地文件系统挂载点，不是远端存储目录。
+
+- 建议使用 `/home`、`/mnt`、`/tmp` 或 `/data` 的子目录，例如 `/mnt/oss`、`/mnt/agenticfs` 或 `/data/files`，避免覆盖模板内已有目录。
+- 不能使用通用的 Linux 和 Unix 系统目录及其子目录作为挂载点，例如 `/bin`、`/opt`、`/var`、`/dev`，以及 `/opt/data`、`/var/data` 等子目录，以免挂载失败。
+- **挂载路径不支持隐藏文件或隐藏目录（名称以 `.` 开头），例如 `/root/.cache`、`/home/user/.cache`。** 即使路径位于推荐的 `/home` 子目录下，也不能包含 `.cache` 这类隐藏目录；如需通过隐藏目录访问挂载内容，可先挂载到符合要求的目录，再自行使用 `ln -s` 创建指向该挂载目录的符号链接。
+
 ## 追加已创建的 Volume
 
 以下示例向运行中的 Sandbox 追加一个已创建的 Volume：

--- a/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/01.挂载 OSS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/01.挂载 OSS Volume.md
@@ -129,7 +129,11 @@ python 01_mount_oss_volume.py
 
 - 同一个 Sandbox 最多挂载 5 个 OSS Volume。
 - 挂载目录必须是规范化的绝对 Unix 路径，不能为 `/`，不能包含前后空格或 `..`。
-- 同一个 Sandbox 中的挂载目录不能重复。建议使用 `/mnt/oss` 或其子目录，避免覆盖模板内已有目录。
+- 本地挂载目录是 Sandbox 运行环境中的文件系统挂载点，对应 `volume_mounts` 的键，不是 OSS 的远端目录。
+- 建议使用 `/home`、`/mnt`、`/tmp` 或 `/data` 的子目录，例如 `/mnt/oss` 或 `/data/files`，避免覆盖模板内已有目录。
+- 不能使用通用的 Linux 和 Unix 系统目录及其子目录作为挂载点，例如 `/bin`、`/opt`、`/var`、`/dev`，以及 `/opt/data`、`/var/data` 等子目录，以免挂载失败。
+- **挂载路径不支持隐藏文件或隐藏目录（名称以 `.` 开头），例如 `/root/.cache`、`/home/user/.cache`。** 即使路径位于推荐的 `/home` 子目录下，也不能包含 `.cache` 这类隐藏目录；如需通过隐藏目录访问挂载内容，可先挂载到符合要求的目录，再自行使用 `ln -s` 创建指向该挂载目录的符号链接。
+- 同一个 Sandbox 中的挂载目录不能重复。
 
 ## 常见问题
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/02.挂载 AgenticFS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/12.卷/02.挂载 AgenticFS Volume.md
@@ -141,7 +141,11 @@ python 02_mount_agenticfs_volume.py
 - 同一个 Sandbox 最多挂载 5 个 AgenticFS Volume。
 - 同一个 Sandbox 挂载多个 AgenticFS Volume 时，各 Volume 的 `user_id` 和 `group_id` 必须完全一致。
 - 挂载目录最大长度为 128 个字符，必须是规范化的绝对 Unix 路径，不能为 `/`，不能包含前后空格或 `..`。
-- 同一个 Sandbox 中的挂载目录不能重复。建议使用 `/mnt/agenticfs` 或其子目录，避免覆盖模板内已有目录。
+- 本地挂载目录是 Sandbox 运行环境中的文件系统挂载点，对应 `volume_mounts` 的键，不是 AgenticFS 的远端目录。
+- 建议使用 `/home`、`/mnt`、`/tmp` 或 `/data` 的子目录，例如 `/mnt/agenticfs` 或 `/data/files`，避免覆盖模板内已有目录。
+- 不能使用通用的 Linux 和 Unix 系统目录及其子目录作为挂载点，例如 `/bin`、`/opt`、`/var`、`/dev`，以及 `/opt/data`、`/var/data` 等子目录，以免挂载失败。
+- **挂载路径不支持隐藏文件或隐藏目录（名称以 `.` 开头），例如 `/root/.cache`、`/home/user/.cache`。** 即使路径位于推荐的 `/home` 子目录下，也不能包含 `.cache` 这类隐藏目录；如需通过隐藏目录访问挂载内容，可先挂载到符合要求的目录，再自行使用 `ln -s` 创建指向该挂载目录的符号链接。
+- 同一个 Sandbox 中的挂载目录不能重复。
 
 ## 常见问题
 


### PR DESCRIPTION
## 变更说明

云沙箱挂载文档原先只说明绝对路径和目录冲突，未明确系统目录、隐藏文件及隐藏目录的限制。例如，`/home/user/.cache` 虽位于推荐的 `/home` 下，也不能直接作为挂载点。

同步更新动态挂载 OSS、OSS Volume、AgenticFS Volume 和追加挂载接口的中英文文档，共 8 篇：

- 明确本地挂载点与远端存储目录的区别，以及推荐目录范围。
- 补充系统目录及其子目录、隐藏文件和隐藏目录的挂载限制。
- 说明可使用 `ln -s` 创建指向合法挂载目录的符号链接，以便通过隐藏目录访问挂载内容。

## 变更类型

- [x] 修正文档内容
- [ ] 新增或删除页面
- [ ] 更新图片或媒体资源
- [ ] 修改构建脚本或 CI

## 验证

- [x] 已运行 `make check`：13 项脚本测试、文档结构及本地引用检查、MkDocs 严格构建通过
- [x] 已检查新增或修改的链接和图片
- [x] 未提交真实凭证或敏感信息

## 相关 Issue

[E2B 挂载文档更新](https://project.aone.alibaba-inc.com/v2/project/2168440/req/86513560)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 更新阿里云云沙箱（FC Agent Sandbox）挂载路径相关文档，覆盖中英文版本共 8 篇：

- FC 扩展：动态挂载 OSS、追加挂载沙箱存储。
- Volume：挂载 OSS Volume、挂载 AgenticFS Volume。

文档补充本地挂载点定义、推荐目录、系统目录限制、隐藏路径限制及符号链接用法，并同步中英文内容。

本 PR 未新增或删除页面，未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->