### PR TITLE
补充 OSS 与 AgenticFS Volume 的挂载权限提醒

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/04.Dynamic OSS Mounts.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/04.Dynamic OSS Mounts.md
@@ -236,11 +236,64 @@ result = sandbox.commands.run(
 print(result.stdout.strip())
 ```
 
-## Permission recommendations
+## Mount permissions
 
+When mounting, FC Agent Sandbox assumes the RAM Role specified by `fc.sandbox.auth.role` and obtains temporary OSS credentials through STS. The system narrows the resources and actions in the STS credentials based on the `bucketName`, `bucketPath`, and `readOnly` configuration for the mount. The effective permissions never exceed the permissions granted to the RAM Role or the scope required by the mount.
+
+For example, when `/users/abc` in `oss-bucket1` is mounted to `/mnt/oss`:
+
+- The temporary STS credentials are restricted to the `users/abc` prefix in `oss-bucket1`. The credentials cannot be used to access `users/def` or other paths in the same Bucket.
+- `oss:ListObjects` is a Bucket-level operation. The policy uses the Bucket resource and `oss:Prefix` to restrict listing to `users/abc` and `users/abc/*`.
+
+The following is an example of the STS Policy structure generated for a read-write mount of `oss-bucket1/users/abc`. You do not need to configure this policy directly for the RAM Role. The actual STS Policy is adjusted based on the mount mode and required operations.
+
+```json
+{
+  "Version": "1",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "acs:oss:*:*:oss-bucket1"
+      ],
+      "Action": [
+        "oss:ListObjects"
+      ],
+      "Condition": {
+        "StringLike": {
+          "oss:Prefix": [
+            "users/abc",
+            "users/abc/*"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "acs:oss:*:*:oss-bucket1/users/abc/*"
+      ],
+      "Action": [
+        "oss:AbortMultipartUpload",
+        "oss:CompleteMultipartUpload",
+        "oss:DeleteObject",
+        "oss:GetObject",
+        "oss:InitiateMultipartUpload",
+        "oss:ListParts",
+        "oss:PutObject",
+        "oss:UploadPart"
+      ],
+      "Condition": {}
+    }
+  ]
+}
+```
+
+Permission guidance:
+
+- Grant the execution Role only the basic OSS operations required by the mount. You do not need to manually write fine-grained `Resource` or `Condition` entries based on `bucketPath`; the system automatically narrows the STS credentials to the mount scope.
 - Use `readOnly: true` to mount input data directories to prevent tasks from accidentally modifying or deleting source data.
 - Use a separate prefix for write results, for example `tenants/<tenant-id>/tasks/<task-id>/outputs/`.
-- Scope the RAM Policy to only the object prefixes required by the task. Grant `oss:ListObjects` and `oss:GetObject` for read-only tasks; add `oss:PutObject`, `oss:DeleteObject`, `oss:AbortMultipartUpload`, and `oss:ListParts` as needed for read-write tasks.
 - Do not write long-term AK/SK into code, templates, or metadata. Access OSS through the RAM Role specified by `fc.sandbox.auth.role`.
 
 ## Notes

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/07.Create an OSS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/07.Create an OSS Volume.md
@@ -20,7 +20,7 @@ For how to create a Team and obtain the Team ID, see [Create a Team](../../01.Ge
 
 ## Permission Configuration
 
-The RAM identity that calls the Volume API needs the following permissions. Replace the placeholders:
+The RAM identity that calls the Volume API needs the following permissions. These permissions authorize Volume API operations and are separate from the OSS data access permissions used when the Volume is mounted. Replace the placeholders:
 
 ```json
 {
@@ -87,6 +87,14 @@ Request parameters, response parameters, and error codes follow the OpenAPI port
 | `bucket_path` | Yes | Mount path inside the bucket. To mount the bucket root, set it to `/`. |
 | `endpoint` | Yes | OSS Endpoint. Must match the bucket's region. |
 | `read_only` | Yes | Whether the mount is read-only. `true` means read-only; `false` means read-write. |
+
+## Permission reminder
+
+When you create an OSS Volume, `bucket_path` and `read_only` determine the Volume's data access scope and read/write capability:
+
+- If you do not need to access the entire Bucket, do not set `bucket_path` to `/`. For example, if you set it to `/users/abc`, the Volume's access scope is the `users/abc` prefix.
+- When the Volume is mounted, FC Agent Sandbox uses the execution Role to obtain temporary STS credentials and automatically narrows the permissions based on the Volume configuration. You do not need to manually write fine-grained `Resource` or `Condition` entries for each Bucket subdirectory.
+- Grant the execution Role only the basic OSS operations required by the mount. The system determines the actual scope of the STS credentials from the Volume configuration used at creation time.
 
 The following example creates an OSS Volume and prints the result. Save the code as `07_create_oss_volume.py`:
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/08.Create an AgenticFS Volume.md
@@ -26,7 +26,7 @@ For how to create a Team and obtain the Team ID, see [Create a Team](../../01.Ge
 
 ## Permission Configuration
 
-The RAM identity that calls the Volume API needs the following permissions. Replace the placeholders:
+The RAM identity that calls the Volume API needs the following permissions. These permissions authorize Volume API operations and are separate from the AgenticFS data access permissions used when the Volume is mounted. Replace the placeholders:
 
 ```json
 {
@@ -160,6 +160,15 @@ ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/projec
 ```
 
 `CreateVolume` only creates Volume metadata. If the remote subdirectory does not exist, it is automatically created when the Volume is first mounted to a sandbox. The subdirectory path cannot contain whitespace, control characters, repeated separators, `.` or `..`, and cannot end with `/`.
+
+## Permission reminder
+
+When you create an AgenticFS Volume, the directory bound to the Access Point determines the permission boundary. The subdirectory after the Access Point in `server_addr` only determines the actual mount path and cannot further narrow the permissions:
+
+- For example, if Access Point `ap1` is bound to `/abc` and `server_addr` specifies `/def`, the actual mount is AgenticFS `/abc/def`, but the temporary STS credentials still cover `/abc`, which is the permission scope of `ap1`.
+- Do not bind an Access Point to `/users` and then have different Sandboxes use `/user1` and `/user2`, expecting `/users/user1` and `/users/user2` to isolate credentials. If credentials are leaked, `user1` may be able to access or modify `user2`'s data.
+- To isolate users or tenants, use OSS subdirectories, or create a separate Access Point for each isolation unit and bind them directly to `/user1`, `/user2`, and so on.
+- Grant the execution Role only the basic permissions required to mount AgenticFS. You do not need to manually configure fine-grained policies for a specific FileSystem or Access Point; the system generates the corresponding restriction through STS when the Volume is mounted.
 
 Next, see [Mount an AgenticFS Volume](../12.Volumes/02.Mount%20an%20AgenticFS%20Volume.md) to create a sandbox and mount the Volume. Then, read and write files in the mount directory to verify that the specified Access Point subdirectory is accessible.
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/09.Append Sandbox Storage Mounts.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/07.FC Extensions/09.Append Sandbox Storage Mounts.md
@@ -40,6 +40,17 @@ The following table lists the configurations required by each storage type when 
 - If you plan to append an OSS mount, configure the execution Role through `fc.sandbox.auth.role` when calling `createSandbox`.
 - If you plan to append an AgenticFS mount, in addition to the execution Role, configure a complete VPC through `fc.sandbox.network.vpc`. The configuration must include `vpcId`, `securityGroupId`, and `vSwitchIds` with at least one element. For details, see [VPC Network Configuration](./02.VPC%20Network%20Configuration.md).
 
+## Storage access permissions
+
+An appended mount uses the execution Role configured when the Sandbox was created through `fc.sandbox.auth.role`. The request does not add to or expand the permissions of the execution Role. FC Agent Sandbox uses the Role to obtain temporary STS credentials and narrows the permissions based on the actual mount configuration:
+
+- The OSS permission boundary is determined by the Bucket and `bucketPath`. For example, after mounting `/users/abc` from `oss-bucket1`, the credentials can access only that prefix; `oss:ListObjects` is restricted through `oss:Prefix`.
+- The AgenticFS permission boundary is determined by the Access Point. The `serverAddr` subdirectory under the Access Point only determines the actual remote path and cannot replace Access Point-level isolation.
+
+You only need to grant the execution Role the basic storage operations required by the mount. You do not need to manually configure fine-grained resource scopes for a Bucket, FileSystem, or Access Point. The system automatically generates the corresponding restrictions in the STS permissions based on the Volume configuration used at creation time or the inline mount configuration in this request.
+
+For permission reminders when creating Volumes, see [Create an OSS Volume](./07.Create%20an%20OSS%20Volume.md) and [Create an AgenticFS Volume](./08.Create%20an%20AgenticFS%20Volume.md).
+
 ## Request Parameters
 
 The request body supports inline mounts, existing Volumes, or both:

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/04.动态挂载 OSS.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/04.动态挂载 OSS.md
@@ -237,11 +237,64 @@ result = sandbox.commands.run(
 print(result.stdout.strip())
 ```
 
-## 权限建议
+## 挂载权限说明
 
+挂载时，云沙箱使用 `fc.sandbox.auth.role` 指定的 RAM Role 扮演角色，通过 STS 获取访问 OSS 的临时凭证。系统会根据本次挂载的 `bucketName`、`bucketPath` 和 `readOnly` 配置，对 STS 临时凭证的资源和操作权限进行收缩。最终有效权限不会超过 RAM Role 原有权限，也不会超出本次挂载所需的范围。
+
+例如，将 `oss-bucket1` 的 `/users/abc` 挂载到 `/mnt/oss`：
+
+- STS 临时凭证的访问范围会收缩到 `oss-bucket1` 的 `users/abc` 前缀，不能通过该凭证访问同一 Bucket 下的 `users/def` 或其他路径。
+- `oss:ListObjects` 是 Bucket 级操作，策略需要使用 Bucket 资源，并通过 `oss:Prefix` 限制到 `users/abc` 和 `users/abc/*`。
+
+以下为系统生成的 `oss-bucket1/users/abc` 读写挂载 STS Policy 结构示例，不是用户需要直接配置到 RAM Role 的策略。实际 STS Policy 会根据挂载模式和所需操作进行调整。
+
+```json
+{
+  "Version": "1",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "acs:oss:*:*:oss-bucket1"
+      ],
+      "Action": [
+        "oss:ListObjects"
+      ],
+      "Condition": {
+        "StringLike": {
+          "oss:Prefix": [
+            "users/abc",
+            "users/abc/*"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "acs:oss:*:*:oss-bucket1/users/abc/*"
+      ],
+      "Action": [
+        "oss:AbortMultipartUpload",
+        "oss:CompleteMultipartUpload",
+        "oss:DeleteObject",
+        "oss:GetObject",
+        "oss:InitiateMultipartUpload",
+        "oss:ListParts",
+        "oss:PutObject",
+        "oss:UploadPart"
+      ],
+      "Condition": {}
+    }
+  ]
+}
+```
+
+权限配置建议：
+
+- 执行 Role 只需授予挂载所需的基础 OSS 操作权限。用户无需根据 `bucketPath` 手工编写精细的 `Resource` 或 `Condition`，系统会在 STS 临时凭证中自动收缩到挂载范围。
 - 使用 `readOnly: true` 挂载输入数据目录，避免任务误写或删除源数据。
 - 写入结果时使用独立前缀，例如 `tenants/<tenant-id>/tasks/<task-id>/outputs/`。
-- RAM Policy 只授权任务需要的对象前缀。只读任务授予 `oss:ListObjects` 和 `oss:GetObject`；读写任务再按需增加 `oss:PutObject`、`oss:DeleteObject`、`oss:AbortMultipartUpload`、`oss:ListParts`。
 - 不要在代码、模板或 metadata 中写入长期 AK/SK。访问 OSS 应通过 `fc.sandbox.auth.role` 指定的 RAM Role 完成。
 
 ## 注意事项

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/07.创建 OSS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/07.创建 OSS Volume.md
@@ -88,6 +88,14 @@ export OSS_ENDPOINT="https://oss-cn-hangzhou.aliyuncs.com"
 | `endpoint` | 是 | OSS Endpoint，应与 Bucket 所在地域匹配。 |
 | `read_only` | 是 | 是否只读挂载；`true` 表示只读，`false` 表示可读写。 |
 
+## 权限提醒
+
+创建 OSS Volume 时，`bucket_path` 和 `read_only` 会确定该 Volume 的访问范围和读写能力：
+
+- 不需要访问整个 Bucket 时，不要将 `bucket_path` 设置为 `/`。例如设置为 `/users/abc`，该 Volume 的访问范围就是 `users/abc` 前缀。
+- 挂载时，云沙箱使用执行 Role 获取 STS 临时凭证，并根据 Volume 配置自动收缩权限。用户无需手工为每个 Bucket 子目录编写精细的 `Resource` 或 `Condition`。
+- 执行 Role 只需具备 OSS 挂载所需的基础操作权限；STS 临时凭证的实际访问范围由系统根据创建时的 Volume 配置控制。
+
 以下示例创建 OSS Volume 并输出创建结果。将代码保存为 `07_create_oss_volume.py`：
 
 ```python

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/08.创建 AgenticFS Volume.md
@@ -161,6 +161,15 @@ ap-<access-point-id>.<file-system-id>-<suffix>.<region>.nas.aliyuncs.com:/projec
 
 `CreateVolume` 仅创建 Volume 元数据。若远端子目录不存在，系统会在首次挂载 Sandbox 时自动创建。子目录路径不能包含空白字符、控制字符、重复分隔符、`.` 或 `..`，也不能以 `/` 结尾。
 
+## 权限提醒
+
+创建 AgenticFS Volume 时，Access Point 绑定的目录会确定权限边界。`server_addr` 中 Access Point 后的子目录只决定实际挂载路径，不能进一步收缩权限：
+
+- 例如，Access Point `ap1` 绑定 `/abc`，`server_addr` 指定 `/def` 时，实际挂载的是 AgenticFS 的 `/abc/def`，但 STS 临时凭证的权限范围仍然是 `/abc`，即 `ap1` 的权限范围。
+- 不要将 Access Point 绑定到 `/users`，再让不同 Sandbox 分别使用 `/user1`、`/user2`，并期望通过 `/users/user1` 和 `/users/user2` 实现凭证隔离。凭证泄露后，`user1` 可能访问或修改 `user2` 的数据。
+- 需要按用户或租户隔离时，建议使用 OSS 子目录，或为每个隔离单元创建独立的 Access Point，并分别将 Access Point 绑定到 `/user1`、`/user2`。
+- 执行 Role 只需具备 AgenticFS 挂载所需的基础权限，用户无需手工配置具体文件系统或 Access Point 的精细策略；系统会在挂载时通过 STS 自动生成对应限制。
+
 下一步，参见 [挂载 AgenticFS Volume](../12.卷/02.挂载%20AgenticFS%20Volume.md) 创建 Sandbox 并挂载该 Volume，然后在挂载目录中读写文件，以确认指定的 Access Point 子目录可用。
 
 ## 管理 Volume

--- a/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/09.追加挂载沙箱存储.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/07.FC 扩展/09.追加挂载沙箱存储.md
@@ -42,6 +42,17 @@ POST /sandboxes/{sandboxID}/fc-volume-mounts
 - 如果计划追加 AgenticFS，除执行 Role 外，还需要通过 `fc.sandbox.network.vpc` 配置完整 VPC，包括 `vpcId`、`securityGroupId` 和至少包含一个元素的 `vSwitchIds`。VPC 配置方式参见
 [VPC 网络配置](./02.VPC%20网络配置.md)。
 
+## 存储访问权限
+
+追加挂载使用创建 Sandbox 时配置的 `fc.sandbox.auth.role`，不会为本次请求补充或扩大执行 Role 的权限。云沙箱通过该 Role 获取 STS 临时凭证，并根据实际挂载配置收缩权限：
+
+- OSS 的权限边界由 Bucket 和 `bucketPath` 决定。例如挂载 `oss-bucket1` 的 `/users/abc` 后，凭证只能访问该前缀；`oss:ListObjects` 通过 `oss:Prefix` 限制列举范围。
+- AgenticFS 的权限边界由 Access Point 决定。Access Point 下的 `serverAddr` 子目录只决定实际挂载的远端路径，不能替代 Access Point 级别的隔离。
+
+用户只需为执行 Role 授予挂载所需的基础存储操作权限，无需手工配置 Bucket、文件系统或 Access Point 的精细资源范围。系统会在 STS 权限中根据创建时的 Volume 配置或本次内联挂载配置自动生成对应限制。
+
+创建 OSS Volume 和 AgenticFS Volume 时的权限提醒，请分别参见[创建 OSS Volume](./07.创建%20OSS%20Volume.md)和[创建 AgenticFS Volume](./08.创建%20AgenticFS%20Volume.md)。
+
 ## 请求参数
 
 请求体支持内联挂载、已创建的 Volume，或者同时使用两种方式：


### PR DESCRIPTION
## 变更说明

- 在创建 OSS Volume 文档中说明 `bucket_path`、`read_only` 确定权限边界，挂载时系统通过 STS 自动收缩权限。
- 在创建 AgenticFS Volume 文档中说明 Access Point 是权限边界，Access Point 下的子目录不能替代隔离。
- 补充 Access Point 绑定父目录导致不同 Sandbox 之间无法隔离的常见误用及建议。
- 在动态挂载和追加挂载文档中补充 Role、STS 及基础权限要求说明。

用户无需手工配置精细的 `Resource` 或 `Condition`，实际权限在 Volume 创建配置和挂载时由系统控制。

## 验证

- `make check-docs`
- `python3 -m unittest discover -s tests -v`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

本 PR 涉及阿里云函数计算云沙箱文档，覆盖 OSS Volume、AgenticFS Volume、动态挂载和追加挂载章节，补充挂载权限、STS、Role 及权限边界说明。

未新增或删除文档页面，未改动图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->