### PR TITLE
docs: add DeepSeek template page for FC Agent Sandbox

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/02.Built-in Templates.md
@@ -13,7 +13,7 @@ Use a built-in template first when you need general capabilities such as Python,
 
 > **Note**
 >
-> `base` and `code-interpreter-v1` are automatically ready after FC Agent Sandbox is activated. You can create a sandbox directly by template name. Browser, All-In-One, Desktop, Claude Code, OpenClaw, and other templates must be built from their official images. See [Other Templates](07.Other%20Templates.md).
+> `base` and `code-interpreter-v1` are automatically ready after FC Agent Sandbox is activated. You can create a sandbox directly by template name. Browser, All-In-One, Desktop, Claude Code, OpenClaw, DeepSeek, and other templates must be built from their official images. See [Other Templates](07.Other%20Templates.md).
 
 ## View templates
 
@@ -50,5 +50,5 @@ const sandbox = await Sandbox.create("code-interpreter-v1");
 ## Further reading
 
 - If you need to preinstall dependencies or toolchains, see [Build Custom Image Templates](03.Build%20Custom%20Image%20Templates.md).
-- For browser automation, desktop, or agent templates such as Claude Code and OpenClaw, see [Other Templates](07.Other%20Templates.md).
+- For browser automation, desktop, or agent templates such as Claude Code, OpenClaw, and DeepSeek, see [Other Templates](07.Other%20Templates.md).
 - If you need to view template tags, aliases, or build status, see [Template Names and Versioning](06.Template%20Names%20and%20Versioning.md).

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates.md
@@ -11,6 +11,7 @@ FC Agent Sandbox provides official images for these templates, but it does not c
 | [Desktop template](07.Other%20Templates/03.Desktop%20Template.md) | Computer use, desktop automation, and GUI testing | Linux desktop, mouse and keyboard control, screenshots, and live streaming |
 | [Claude Code template](07.Other%20Templates/04.Claude%20Code%20Template.md) | Run Claude Code in an isolated environment | Claude Code CLI, MCP, and Skills |
 | [OpenClaw template](07.Other%20Templates/05.OpenClaw%20Template.md) | Run OpenClaw Agents and Gateway | Agent CLI, Gateway, and Skills |
+| [DeepSeek template](07.Other%20Templates/06.DeepSeek%20Template.md) | Run DeepSeek Harness Agents and Web UI | dsh CLI, Web UI, and Profiles |
 
 Each template page documents the image address, capabilities, default configuration, build procedure, minimal verification, and limitations. See the corresponding best practice for complete workflows, framework integration, and production security guidance.
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/06.DeepSeek Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/06.DeepSeek Template.md
@@ -22,14 +22,14 @@ Select `FROM_IMAGE` by region:
 
 | Region | Image |
 |--------|------|
-| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| us-east-1 | `fc-e2b-registry.us-east-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| us-west-1 | `fc-e2b-registry.us-west-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| us-east-1 | `fc-e2b-registry.us-east-1.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| us-west-1 | `fc-e2b-registry.us-west-1.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
 
 Recommended build specifications: `cpu_count=2`, `memory_mb=4096`.
 
@@ -48,8 +48,8 @@ import time
 
 from e2b import Template, default_build_logger
 
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek:v0.0.50"
-TEMPLATE_NAME = f"deepseek-{int(time.time())}"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52"
+TEMPLATE_NAME = f"deepseek-harness-{int(time.time())}"
 
 OPTS = {
     "api_key": "<your E2B API Key>",
@@ -201,7 +201,7 @@ sandbox.kill()
 | Item | Specification |
 |------|------|
 | Operating System | Debian 13 |
-| dsh Path | `/home/user/.dsh/bin/dsh` (0.1.2-rc.1, an rc release; behavior may change upstream) |
+| dsh Path | `/home/user/.dsh/bin/dsh` (0.1.5-rc.1, an rc release; behavior may change upstream) |
 | Bundled Node | v22.22.3 (`/home/user/.dsh/tools/node/bin/node`; dsh does not depend on the system Node) |
 | System Node | v20.x |
 | Default User / Working Directory | `user` / `/home/user` |

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/06.DeepSeek Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/06.DeepSeek Template.md
@@ -31,7 +31,7 @@ Select `FROM_IMAGE` by region:
 
 Recommended build specifications: `cpu_count=2`, `memory_mb=4096`.
 
-The image ships with a one-command Web UI startup script at `/opt/deepseek-harness/start.sh`; see [Running DeepSeek Harness](#web-ui).
+The image ships with a one-command Web UI startup script at `/opt/deepseek-harness/start.sh`; see [Web UI](#web-ui).
 
 ---
 
@@ -86,15 +86,9 @@ sandbox = Sandbox.create(
 )
 ```
 
-Release resources when you are done (this also stops the `dsh web` process inside the sandbox):
-
-```python
-sandbox.kill()
-```
-
 ---
 
-## Running DeepSeek Harness
+## Run DeepSeek Harness
 
 ### Headless Single Task
 
@@ -113,7 +107,7 @@ If the model API Key is missing or invalid, `dsh` exits with a non-zero code and
 | Scenario | Output |
 |----------|--------|
 | Key missing | `dsh: MISSING_CREDENTIAL: llm-deepseek: no API key for provider route "deepseek-official"; store DEEPSEEK_API_KEY through the credentials service (the web Models page writes it), or export DEEPSEEK_API_KEY in the launching environment` |
-| Key invalid | `dsh: AUTH: Authentication Fails, Your api key: ****-000 is invalid` (`000` is the tail of the invalid key and varies) |
+| Key invalid | `dsh: AUTH: Authentication Fails, Your api key: ****3000 is invalid` (`3000` is the last four characters of the invalid key and varies) |
 
 ### Web UI
 
@@ -124,6 +118,7 @@ import re
 
 r = sandbox.commands.run("/opt/deepseek-harness/start.sh", timeout=180)
 print(r.stdout)
+# Expected output:
 # DSH_WEB_TOKEN=<token>
 # DSH_WEB_LAUNCH_URL=http://127.0.0.1:8080/?token=<token>
 
@@ -139,43 +134,43 @@ print(f"https://{host}/?token={token}")
 
 If `DEEPSEEK_API_KEY` is not injected, `start.sh` exits with a non-zero code and prompts you to inject it via `envs`.
 
-#### Browser Access (Custom Domain + `--trusted-host`)
+### Browser Access (Custom Domain + `--trusted-host`)
 
 **The Web UI cannot be used in a browser under the default platform domain (`*.e2b.fc.aliyuncs.com`)**, for two reasons:
 
 1. The platform forces `Content-Disposition: attachment` on HTTP responses served from the default domain, so browsers download an HTML file instead of rendering the page.
 2. dsh applies a browser trust fence to `/api` requests and trusts only loopback hostnames by default. When accessed through the platform-domain proxy, the Host header is not trusted, every `/api` call returns 403, and the page is an empty shell.
 
-The default domain is only suitable for curl/SDK-level verification: `/api/health` returns 401 without a token (dsh's native response) and 200 with one.
+The default domain is only suitable for curl/SDK-level verification: the root path returns 401 without a token (dsh's native auth challenge), 303 with a token (which issues a session cookie), and 200 when revisited with that cookie.
 
 To use the Web UI in a browser, first bind a custom domain and pass the public hostname via `--trusted-host` at startup:
 
 1. **Bind a custom domain**: For the complete console, DNS, and certificate steps, see [Custom Domains for FC Agent Sandbox](../../07.FC%20Extensions/03.Custom%20Domains.md). Key points: configure the control-plane domain `api.<your-domain>` and the data-plane wildcard `*.<your-domain>`; the certificate must cover the wildcard; the domain must be ICP-filed where applicable.
 2. **Switch the SDK to the custom domain**: Replace `OPTS` to match the console configuration (`api_key` must belong to the same account that bound the domain), and use these `OPTS` consistently for `Template.build(...)`, `Sandbox.create(...)`, and every other call:
 
-```python
-OPTS = {
-    "api_key": "<your E2B API Key>",
-    "api_url": "https://api.<your-domain>",
-    "domain": "<your-domain>",
-}
-```
+    ```python
+    OPTS = {
+        "api_key": "<your E2B API Key>",
+        "api_url": "https://api.<your-domain>",
+        "domain": "<your-domain>",
+    }
+    ```
 
 3. **Start with `--trusted-host` and open the URL**: extra arguments to `start.sh` are passed through to `dsh web` verbatim. Pass the public hostname returned by `sandbox.get_host(8080)`:
 
-```python
-host = sandbox.get_host(8080)   # 8080-<sandbox_id>.<your-domain>
+    ```python
+    host = sandbox.get_host(8080)   # 8080-<sandbox_id>.<your-domain>
 
-r = sandbox.commands.run(
-    f"/opt/deepseek-harness/start.sh --trusted-host {host}",
-    timeout=180,
-)
-token = re.search(r"DSH_WEB_TOKEN=(\S+)", r.stdout).group(1)
+    r = sandbox.commands.run(
+        f"/opt/deepseek-harness/start.sh --trusted-host {host}",
+        timeout=180,
+    )
+    token = re.search(r"DSH_WEB_TOKEN=(\S+)", r.stdout).group(1)
 
-print(f"https://{host}/?token={token}")
-```
+    print(f"https://{host}/?token={token}")
+    ```
 
-Open the printed URL in a browser to use the Web UI. On first entry, an Internal Testing Notice appears (a notice about the DeepSeek Harness 0.1 internal testing phase) — click Continue to dismiss it. **You must choose a workspace before chatting** (click Choose workspace and pick a directory); afterwards the model streams replies, with a collapsible thought process and per-turn token usage stats.
+Open the printed URL in a browser to use the Web UI. On first entry, an **Internal Testing Notice** appears (a notice about the DeepSeek Harness 0.1 internal testing phase) — click **Continue** to dismiss it. **You must choose a workspace before chatting** (click **Choose workspace** and pick a directory); afterwards the model streams replies, with a collapsible thought process and per-turn token usage stats.
 
 Notes on `--trusted-host` and authentication:
 
@@ -183,26 +178,36 @@ Notes on `--trusted-host` and authentication:
 - You can pass `--trusted-host` multiple times; an entry with a port matches that port exactly, an entry without a port matches any port.
 - The token changes when dsh restarts, but already-issued browser session cookies remain valid.
 
-> Troubleshooting: if access returns a proxy-level 403 (JSON error body), retry with the `X-Access-Token: <sandbox._envd_access_token>` request header (the Sandbox Access Token returned by `Sandbox.create`, which becomes invalid when the sandbox is destroyed).
+> **Troubleshooting**: if access returns a proxy-level 403 (JSON error body), retry with the `X-Access-Token: <sandbox._envd_access_token>` request header (the Sandbox Access Token returned by `Sandbox.create`, which becomes invalid when the sandbox is destroyed).
+
+---
+
+## Destroy Sandbox
+
+Release resources when you are done (this also stops the `dsh web` process inside the sandbox):
+
+```python
+sandbox.kill()
+```
 
 ---
 
 ## Environment Overview
 
 | Item | Specification |
-|------|---------------|
-| Operating system | Debian 13 |
-| dsh path | `/home/user/.dsh/bin/dsh` (v0.1.2-rc.1, an rc release; behavior may change upstream) |
+|------|------|
+| Operating System | Debian 13 |
+| dsh Path | `/home/user/.dsh/bin/dsh` (0.1.2-rc.1, an rc release; behavior may change upstream) |
 | Bundled Node | v22.22.3 (`/home/user/.dsh/tools/node/bin/node`; dsh does not depend on the system Node) |
 | System Node | v20.x |
-| Default user / working directory | `user` / `/home/user` |
+| Default User / Working Directory | `user` / `/home/user` |
 
 ---
 
-## Profiles and Plugins
+## Profile Capability Notes
 
 | Profile | Usage | Description |
-|---------|-------|-------------|
+|--------|------|-------------|
 | `headless` | `dsh --profile headless "<task>"` | Run a single task, print the final answer, and exit |
 | `web` | `/opt/deepseek-harness/start.sh` (or bare `dsh web --no-open`) | Web UI with token authentication; the script listens on `127.0.0.1:8080`, bare dsh web defaults to `127.0.0.1:3080` |
 | `sdk` | `dsh --profile sdk` | JSON-RPC over stdio, for SDK clients |
@@ -211,7 +216,7 @@ Notes on `--trusted-host` and authentication:
 
 `headless` and `web` are the profiles used on this page; `sdk` / `sdk-minimal` / `acp` are documented in the dsh README bundled in the image (`/home/user/.dsh/lib/node_modules/@deepseek-ai/dsh/README.zh.md`). Built-in profiles initialize automatically on first use. Manage other profiles with `dsh plugin --profile <name> <pnpm args>`; the working directory of the launching command is the default workspace root.
 
-## Related Documentation
+## Related Documents
 
 - [Built-in Templates](../02.Built-in%20Templates.md)
 - [Template Names and Versioning](../06.Template%20Names%20and%20Versioning.md)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/06.DeepSeek Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/06.DeepSeek Template.md
@@ -1,0 +1,218 @@
+# DeepSeek Template
+
+[DeepSeek Harness](https://www.npmjs.com/package/@deepseek-ai/dsh) is an open-source agent harness from DeepSeek AI (npm package `@deepseek-ai/dsh`, CLI name `dsh`) that supports headless single tasks, a Web UI, and SDK/ACP programmatic access. We have pre-built DeepSeek Harness images in ACR across all regions, so you don't need to push images or configure ACR EE yourself. Simply select an image address below and build a template using `from_image` + `Template.build` to get started. This page covers image specifications and full usage: prerequisites, image addresses, building a Template, creating a sandbox, running DeepSeek Harness, custom-domain browser access, and environment/Profile capability notes.
+
+If this is your first time, complete the prerequisites, API key creation, and SDK setup in [Use FC Agent Sandbox with the SDK](../../../01.Getting%20Started/03.Quickstarts/01.Use%20FC%20Agent%20Sandbox%20with%20the%20SDK.md).
+
+---
+
+## Prerequisites
+
+- Completed [SDK integration](../../../01.Getting%20Started/03.Quickstarts/01.Use%20FC%20Agent%20Sandbox%20with%20the%20SDK.md) (E2B API Key, `api_url`, `domain`)
+- Installed dependencies: `pip install e2b==2.31.0` (this template does not use Code Interpreter, so `e2b-code-interpreter` is not required)
+- Prepared a model API Key to inject via `envs` when creating the sandbox — images do not include pre-configured keys
+  - Obtain `DEEPSEEK_API_KEY` from the [DeepSeek Platform](https://platform.deepseek.com/)
+  - Optional `DEEPSEEK_BASE_URL`: a relay endpoint (read natively by dsh); if unset, dsh connects to DeepSeek directly
+
+---
+
+## Image Addresses
+
+Select `FROM_IMAGE` by region:
+
+| Region | Image |
+|--------|------|
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+
+Recommended build specifications: `cpu_count=2`, `memory_mb=4096`.
+
+The image ships with a one-command Web UI startup script at `/opt/deepseek-harness/start.sh`; see [Running DeepSeek Harness](#web-ui).
+
+---
+
+## Build Template
+
+A custom template requires building the image into a Template first — **this only needs to be done once**. Save the template name for reuse when creating sandboxes later.
+
+The following example uses the Beijing region:
+
+```python
+import time
+
+from e2b import Template, default_build_logger
+
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek:v0.0.50"
+TEMPLATE_NAME = f"deepseek-{int(time.time())}"
+
+OPTS = {
+    "api_key": "<your E2B API Key>",
+    "api_url": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
+    "domain": "cn-beijing.e2b.fc.aliyuncs.com",
+}
+
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name=TEMPLATE_NAME,
+    cpu_count=2,
+    memory_mb=4096,
+    on_build_logs=default_build_logger(),
+    **OPTS,
+)
+
+print(f"template: {build.name}")   # Save for later reuse
+```
+
+After the build completes, the template status in the console should be `ready`. The same template name can create multiple sandboxes without rebuilding.
+
+---
+
+## Create Sandbox
+
+Inject the DeepSeek API Key via `envs` when creating the sandbox:
+
+```python
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template=TEMPLATE_NAME,
+    envs={"DEEPSEEK_API_KEY": "<your-deepseek-api-key>"},
+    timeout=600,
+    **OPTS,
+)
+```
+
+Release resources when you are done (this also stops the `dsh web` process inside the sandbox):
+
+```python
+sandbox.kill()
+```
+
+---
+
+## Running DeepSeek Harness
+
+### Headless Single Task
+
+`--profile headless` runs a single task, prints the final answer, and exits:
+
+```python
+result = sandbox.commands.run(
+    'dsh --profile headless "Introduce DeepSeek Harness in one sentence"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+If the model API Key is missing or invalid, `dsh` exits with a non-zero code and a clear error (errors go to stderr; the table below shows the merged `2>&1` output):
+
+| Scenario | Output |
+|----------|--------|
+| Key missing | `dsh: MISSING_CREDENTIAL: llm-deepseek: no API key for provider route "deepseek-official"; store DEEPSEEK_API_KEY through the credentials service (the web Models page writes it), or export DEEPSEEK_API_KEY in the launching environment` |
+| Key invalid | `dsh: AUTH: Authentication Fails, Your api key: ****-000 is invalid` (`000` is the tail of the invalid key and varies) |
+
+### Web UI
+
+The image ships with a one-command startup script: run a single command inside the sandbox to start the Web UI. The script launches dsh web in the background (listening on `127.0.0.1:8080` only, with token authentication) and prints `DSH_WEB_TOKEN` and `DSH_WEB_LAUNCH_URL` to stdout once ready. The script is idempotent: if the Web UI is already running, it prints the existing token without starting another instance:
+
+```python
+import re
+
+r = sandbox.commands.run("/opt/deepseek-harness/start.sh", timeout=180)
+print(r.stdout)
+# DSH_WEB_TOKEN=<token>
+# DSH_WEB_LAUNCH_URL=http://127.0.0.1:8080/?token=<token>
+
+token = re.search(r"DSH_WEB_TOKEN=(\S+)", r.stdout).group(1)
+```
+
+Map port `8080` inside the sandbox to a publicly accessible address with the SDK port proxy:
+
+```python
+host = sandbox.get_host(8080)
+print(f"https://{host}/?token={token}")
+```
+
+If `DEEPSEEK_API_KEY` is not injected, `start.sh` exits with a non-zero code and prompts you to inject it via `envs`.
+
+#### Browser Access (Custom Domain + `--trusted-host`)
+
+**The Web UI cannot be used in a browser under the default platform domain (`*.e2b.fc.aliyuncs.com`)**, for two reasons:
+
+1. The platform forces `Content-Disposition: attachment` on HTTP responses served from the default domain, so browsers download an HTML file instead of rendering the page.
+2. dsh applies a browser trust fence to `/api` requests and trusts only loopback hostnames by default. When accessed through the platform-domain proxy, the Host header is not trusted, every `/api` call returns 403, and the page is an empty shell.
+
+The default domain is only suitable for curl/SDK-level verification: `/api/health` returns 401 without a token (dsh's native response) and 200 with one.
+
+To use the Web UI in a browser, first bind a custom domain and pass the public hostname via `--trusted-host` at startup:
+
+1. **Bind a custom domain**: For the complete console, DNS, and certificate steps, see [Custom Domains for FC Agent Sandbox](../../07.FC%20Extensions/03.Custom%20Domains.md). Key points: configure the control-plane domain `api.<your-domain>` and the data-plane wildcard `*.<your-domain>`; the certificate must cover the wildcard; the domain must be ICP-filed where applicable.
+2. **Switch the SDK to the custom domain**: Replace `OPTS` to match the console configuration (`api_key` must belong to the same account that bound the domain), and use these `OPTS` consistently for `Template.build(...)`, `Sandbox.create(...)`, and every other call:
+
+```python
+OPTS = {
+    "api_key": "<your E2B API Key>",
+    "api_url": "https://api.<your-domain>",
+    "domain": "<your-domain>",
+}
+```
+
+3. **Start with `--trusted-host` and open the URL**: extra arguments to `start.sh` are passed through to `dsh web` verbatim. Pass the public hostname returned by `sandbox.get_host(8080)`:
+
+```python
+host = sandbox.get_host(8080)   # 8080-<sandbox_id>.<your-domain>
+
+r = sandbox.commands.run(
+    f"/opt/deepseek-harness/start.sh --trusted-host {host}",
+    timeout=180,
+)
+token = re.search(r"DSH_WEB_TOKEN=(\S+)", r.stdout).group(1)
+
+print(f"https://{host}/?token={token}")
+```
+
+Open the printed URL in a browser to use the Web UI. On first entry, an Internal Testing Notice appears (a notice about the DeepSeek Harness 0.1 internal testing phase) — click Continue to dismiss it. **You must choose a workspace before chatting** (click Choose workspace and pick a directory); afterwards the model streams replies, with a collapsible thought process and per-turn token usage stats.
+
+Notes on `--trusted-host` and authentication:
+
+- Adding a host to the trust list only affects the trust fence; authentication is unchanged: requests without a token still return 401, and after the first visit the session cookie takes over (valid for 30 days).
+- You can pass `--trusted-host` multiple times; an entry with a port matches that port exactly, an entry without a port matches any port.
+- The token changes when dsh restarts, but already-issued browser session cookies remain valid.
+
+> Troubleshooting: if access returns a proxy-level 403 (JSON error body), retry with the `X-Access-Token: <sandbox._envd_access_token>` request header (the Sandbox Access Token returned by `Sandbox.create`, which becomes invalid when the sandbox is destroyed).
+
+---
+
+## Environment Overview
+
+| Item | Specification |
+|------|---------------|
+| Operating system | Debian 13 |
+| dsh path | `/home/user/.dsh/bin/dsh` (v0.1.2-rc.1, an rc release; behavior may change upstream) |
+| Bundled Node | v22.22.3 (`/home/user/.dsh/tools/node/bin/node`; dsh does not depend on the system Node) |
+| System Node | v20.x |
+| Default user / working directory | `user` / `/home/user` |
+
+---
+
+## Profiles and Plugins
+
+| Profile | Usage | Description |
+|---------|-------|-------------|
+| `headless` | `dsh --profile headless "<task>"` | Run a single task, print the final answer, and exit |
+| `web` | `/opt/deepseek-harness/start.sh` (or bare `dsh web --no-open`) | Web UI with token authentication; the script listens on `127.0.0.1:8080`, bare dsh web defaults to `127.0.0.1:3080` |
+| `sdk` | `dsh --profile sdk` | JSON-RPC over stdio, for SDK clients |
+| `sdk-minimal` | `dsh --profile sdk-minimal` | Standalone minimal agent configuration tree |
+| `acp` | `dsh --profile acp` | ACP over stdio, for automation clients |
+
+`headless` and `web` are the profiles used on this page; `sdk` / `sdk-minimal` / `acp` are documented in the dsh README bundled in the image (`/home/user/.dsh/lib/node_modules/@deepseek-ai/dsh/README.zh.md`). Built-in profiles initialize automatically on first use. Manage other profiles with `dsh plugin --profile <name> <pnpm args>`; the working directory of the launching command is the default workspace root.
+
+## Related Documentation
+
+- [Built-in Templates](../02.Built-in%20Templates.md)
+- [Template Names and Versioning](../06.Template%20Names%20and%20Versioning.md)
+- [Custom Domains for FC Agent Sandbox](../../07.FC%20Extensions/03.Custom%20Domains.md)

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/06.DeepSeek Template.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/07.Other Templates/06.DeepSeek Template.md
@@ -28,6 +28,8 @@ Select `FROM_IMAGE` by region:
 | cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
 | cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
 | cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| us-east-1 | `fc-e2b-registry.us-east-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| us-west-1 | `fc-e2b-registry.us-west-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
 
 Recommended build specifications: `cpu_count=2`, `memory_mb=4096`.
 
@@ -132,6 +134,8 @@ host = sandbox.get_host(8080)
 print(f"https://{host}/?token={token}")
 ```
 
+> **Security note**: The printed URL contains `?token=` and is effectively a credential — do not share or log token-bearing URLs (browser history, terminal output, and proxy logs may retain them). After the first visit establishes a session, use the URL without `?token=` instead.
+
 If `DEEPSEEK_API_KEY` is not injected, `start.sh` exits with a non-zero code and prompts you to inject it via `envs`.
 
 ### Browser Access (Custom Domain + `--trusted-host`)
@@ -170,7 +174,7 @@ To use the Web UI in a browser, first bind a custom domain and pass the public h
     print(f"https://{host}/?token={token}")
     ```
 
-Open the printed URL in a browser to use the Web UI. On first entry, an **Internal Testing Notice** appears (a notice about the DeepSeek Harness 0.1 internal testing phase) — click **Continue** to dismiss it. **You must choose a workspace before chatting** (click **Choose workspace** and pick a directory); afterwards the model streams replies, with a collapsible thought process and per-turn token usage stats.
+Open the printed URL in a browser to use the Web UI. On first entry, an **Internal Testing Notice** appears (a notice about the DeepSeek Harness 0.1 internal testing phase) — click **Continue** to dismiss it. **You must choose a workspace before chatting** (click **Choose workspace** and pick a directory); afterwards the model streams replies, with a collapsible thought process and per-turn token usage stats. The printed URL also contains the token, so treat it as a credential; after the first visit establishes a session, use the URL without `?token=` instead.
 
 Notes on `--trusted-host` and authentication:
 
@@ -178,7 +182,7 @@ Notes on `--trusted-host` and authentication:
 - You can pass `--trusted-host` multiple times; an entry with a port matches that port exactly, an entry without a port matches any port.
 - The token changes when dsh restarts, but already-issued browser session cookies remain valid.
 
-> **Troubleshooting**: if access returns a proxy-level 403 (JSON error body), retry with the `X-Access-Token: <sandbox._envd_access_token>` request header (the Sandbox Access Token returned by `Sandbox.create`, which becomes invalid when the sandbox is destroyed).
+> **Troubleshooting**: if access returns a proxy-level 403 (JSON error body), retry with the `X-Access-Token: <sandbox._envd_access_token>` request header. `_envd_access_token` is an internal property of the Python SDK (verified on `e2b==2.31.0`; it may be renamed or removed in later versions); it holds the Sandbox Access Token, which becomes invalid when the sandbox is destroyed.
 
 ---
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/02.内置模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/02.内置模板.md
@@ -13,7 +13,7 @@
 
 > **说明**
 >
-> `base` 与 `code-interpreter-v1` 在账号开通云沙箱后会自动就绪，可直接用模板名创建沙箱。browser、All-In-One、Desktop、Claude Code、OpenClaw 等模板需从对应官方镜像自行构建，参见[其他模板](07.其他模板.md)。
+> `base` 与 `code-interpreter-v1` 在账号开通云沙箱后会自动就绪，可直接用模板名创建沙箱。browser、All-In-One、Desktop、Claude Code、OpenClaw、DeepSeek 等模板需从对应官方镜像自行构建，参见[其他模板](07.其他模板.md)。
 
 ## 查看模板
 
@@ -50,5 +50,5 @@ const sandbox = await Sandbox.create("code-interpreter-v1");
 ## 后续阅读
 
 - 需要预装依赖或工具链时，参见[通过 OpenAPI 构建和管理模板](03.通过%20OpenAPI%20构建和管理模板.md)。
-- 需要浏览器自动化、桌面环境或 Claude Code、OpenClaw 等 Agent 模板时，参见[其他模板](07.其他模板.md)。
+- 需要浏览器自动化、桌面环境或 Claude Code、OpenClaw、DeepSeek 等 Agent 模板时，参见[其他模板](07.其他模板.md)。
 - 需要查看模板标签、别名和构建状态时，参见[模板名称与版本](06.模板名称与版本.md)。

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板.md
@@ -11,6 +11,7 @@
 | [Desktop 模板](07.其他模板/03.desktop-模板.md) | Computer Use、桌面软件自动化、GUI 测试 | Linux 桌面、鼠标键盘、截图、实时流 |
 | [Claude Code 模板](07.其他模板/04.Claude%20Code%20模板.md) | 在隔离环境中运行 Claude Code | Claude Code CLI、MCP、Skill |
 | [OpenClaw 模板](07.其他模板/05.OpenClaw%20模板.md) | 运行 OpenClaw Agent 和 Gateway | Agent CLI、Gateway、Skill |
+| [DeepSeek 模板](07.其他模板/06.DeepSeek%20模板.md) | 运行 DeepSeek Harness Agent 和 Web UI | dsh CLI、Web UI、Profile |
 
 每篇模板文档提供镜像地址、功能、默认配置、构建方法、最小验证和使用限制。完整业务流程、框架接入与生产安全建议见对应的最佳实践。
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/06.DeepSeek 模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/06.DeepSeek 模板.md
@@ -31,7 +31,7 @@
 
 推荐构建规格：`cpu_count=2`，`memory_mb=4096`。
 
-镜像内置 Web UI 一键启动脚本 `/opt/deepseek-harness/start.sh`，用法见[运行 DeepSeek Harness](#web-ui)。
+镜像内置 Web UI 一键启动脚本 `/opt/deepseek-harness/start.sh`，用法见[Web UI](#web-ui)。
 
 ---
 
@@ -86,12 +86,6 @@ sandbox = Sandbox.create(
 )
 ```
 
-任务完成后释放资源（会一并结束沙箱内的 `dsh web` 进程）：
-
-```python
-sandbox.kill()
-```
-
 ---
 
 ## 运行 DeepSeek Harness
@@ -113,7 +107,7 @@ print(result.stdout)
 | 场景 | 输出 |
 |------|------|
 | 未提供 Key | `dsh: MISSING_CREDENTIAL: llm-deepseek: no API key for provider route "deepseek-official"; store DEEPSEEK_API_KEY through the credentials service (the web Models page writes it), or export DEEPSEEK_API_KEY in the launching environment` |
-| Key 无效 | `dsh: AUTH: Authentication Fails, Your api key: ****-000 is invalid`（`000` 为无效 key 的尾段，随实际 key 变化） |
+| Key 无效 | `dsh: AUTH: Authentication Fails, Your api key: ****3000 is invalid`（`3000` 为无效 key 的末 4 位，随实际 key 变化） |
 
 ### Web UI
 
@@ -124,6 +118,7 @@ import re
 
 r = sandbox.commands.run("/opt/deepseek-harness/start.sh", timeout=180)
 print(r.stdout)
+# 输出形如：
 # DSH_WEB_TOKEN=<token>
 # DSH_WEB_LAUNCH_URL=http://127.0.0.1:8080/?token=<token>
 
@@ -139,51 +134,61 @@ print(f"https://{host}/?token={token}")
 
 `DEEPSEEK_API_KEY` 未注入时，`start.sh` 非零退出并提示通过 `envs` 注入。
 
-#### 浏览器访问（自定义域名 + `--trusted-host`）
+### 浏览器访问（自定义域名 + `--trusted-host`）
 
 **默认平台域名（`*.e2b.fc.aliyuncs.com`）下 Web UI 无法在浏览器中使用**，原因有二：
 
 1. 平台对默认域名的 HTTP 响应强制添加 `Content-Disposition: attachment`，浏览器打开会下载 HTML 文件而非渲染页面。
 2. dsh 对 `/api` 请求设有浏览器信任栅栏，默认只信任 loopback 主机名；经平台域名代理访问时 Host 不被信任，`/api` 全部返回 403，页面为空壳。
 
-默认域名仅适合 curl / SDK 层验证：不带 token 访问 `/api/health` 返回 401（dsh 原生提示），带 token 返回 200。
+默认域名仅适合 curl / SDK 层验证：不带 token 访问返回 401（dsh 原生鉴权提示），带 token 访问返回 303 并签发会话 cookie，携带 cookie 再访返回 200。
 
 要在浏览器中使用 Web UI，须先绑定自定义域名，并在启动时通过 `--trusted-host` 把公网主机名加入信任列表：
 
 1. **绑定自定义域名**：控制台添加域名、DNS 解析与 HTTPS 证书的完整步骤见[云沙箱自定义域名](../../07.FC%20扩展/03.自定义域名.md)。要点：配置控制链路域名 `api.<你的自定义域名>` 与数据链路泛域名 `*.<你的自定义域名>`，证书须覆盖泛域名，域名需完成备案。
 2. **SDK 换用自定义域名**：将 `OPTS` 替换为与控制台一致（`api_key` 须为绑定该域名同一账号下的 Key），后续 `Template.build(...)`、`Sandbox.create(...)` 等所有调用一致：
 
-```python
-OPTS = {
-    "api_key": "<你的 E2B API Key>",
-    "api_url": "https://api.<你的自定义域名>",
-    "domain": "<你的自定义域名>",
-}
-```
+    ```python
+    OPTS = {
+        "api_key": "<你的 E2B API Key>",
+        "api_url": "https://api.<你的自定义域名>",
+        "domain": "<你的自定义域名>",
+    }
+    ```
 
 3. **带 `--trusted-host` 启动并访问**：`start.sh` 额外参数原样透传给 `dsh web`，将 `sandbox.get_host(8080)` 返回的公网主机名传入：
 
-```python
-host = sandbox.get_host(8080)   # 8080-<sandbox_id>.<你的自定义域名>
+    ```python
+    host = sandbox.get_host(8080)   # 8080-<sandbox_id>.<你的自定义域名>
 
-r = sandbox.commands.run(
-    f"/opt/deepseek-harness/start.sh --trusted-host {host}",
-    timeout=180,
-)
-token = re.search(r"DSH_WEB_TOKEN=(\S+)", r.stdout).group(1)
+    r = sandbox.commands.run(
+        f"/opt/deepseek-harness/start.sh --trusted-host {host}",
+        timeout=180,
+    )
+    token = re.search(r"DSH_WEB_TOKEN=(\S+)", r.stdout).group(1)
 
-print(f"https://{host}/?token={token}")
-```
+    print(f"https://{host}/?token={token}")
+    ```
 
-浏览器打开输出的 URL 即可使用 Web UI。首次进入会弹出 Internal Testing Notice（DeepSeek Harness 0.1 内测期提示），点 Continue 关闭；**必须先选 workspace 才能对话**（点击 Choose workspace 选择一个目录），之后模型流式回复，界面含思考过程折叠与每轮 Token 用量统计。
+浏览器打开输出的 URL 即可使用 Web UI。首次进入会弹出 **Internal Testing Notice**（DeepSeek Harness 0.1 内测期提示），单击 **Continue** 关闭；**必须先选 workspace 才能对话**（单击 **Choose workspace** 选择一个目录），之后模型流式回复，界面含思考过程折叠与每轮 Token 用量统计。
 
 关于 `--trusted-host` 与鉴权：
 
-- 加白只影响信任栅栏，鉴权不变：不带 token 访问仍返回 401，首次访问后由会话 cookie 承接（30 天有效）。
+- 加入信任列表只影响信任栅栏，鉴权不变：不带 token 访问仍返回 401，首次访问后由会话 cookie 承接（30 天有效）。
 - 可重复传入多个主机名；条目带端口号时精确匹配，不带端口号时匹配任意端口。
 - dsh 重启后 token 会变化，已签发的浏览器会话 cookie 仍有效。
 
-> 排障：若访问返回代理层 403（JSON 错误体），带 `X-Access-Token: <sandbox._envd_access_token>` 请求头重试（`Sandbox.create` 返回的 Sandbox Access Token，随沙箱销毁失效）。
+> **排障**：若访问返回代理层 403（JSON 错误体），带 `X-Access-Token: <sandbox._envd_access_token>` 请求头重试（`Sandbox.create` 返回的 Sandbox Access Token，随沙箱销毁失效）。
+
+---
+
+## 销毁沙箱
+
+任务完成后释放资源（会一并结束沙箱内的 `dsh web` 进程）：
+
+```python
+sandbox.kill()
+```
 
 ---
 
@@ -192,16 +197,16 @@ print(f"https://{host}/?token={token}")
 | 项目 | 规格 |
 |------|------|
 | 操作系统 | Debian 13 |
-| dsh 路径 | `/home/user/.dsh/bin/dsh`（v0.1.2-rc.1，rc 版本，行为可能随上游变动） |
-| dsh 自带 Node | v22.22.3（`/home/user/.dsh/tools/node/bin/node`，dsh 不依赖系统 Node） |
+| dsh 路径 | `/home/user/.dsh/bin/dsh`（0.1.2-rc.1，rc 版本，行为可能随上游变动） |
+| 自带 Node | v22.22.3（`/home/user/.dsh/tools/node/bin/node`，dsh 不依赖系统 Node） |
 | 系统 Node | v20.x |
 | 默认用户 / 工作目录 | `user` / `/home/user` |
 
 ---
 
-## Profile 与插件
+## Profile 能力约定
 
-| profile | 用法 | 说明 |
+| Profile | 用法 | 说明 |
 |---------|------|------|
 | `headless` | `dsh --profile headless "<任务>"` | 执行单任务，打印最终答案后退出 |
 | `web` | `/opt/deepseek-harness/start.sh`（或裸 `dsh web --no-open`） | Web UI，Token 鉴权；脚本固定监听 `127.0.0.1:8080`，裸 dsh web 默认 `127.0.0.1:3080` |

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/06.DeepSeek 模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/06.DeepSeek 模板.md
@@ -28,6 +28,8 @@
 | cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
 | cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
 | cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| us-east-1 | `fc-e2b-registry.us-east-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| us-west-1 | `fc-e2b-registry.us-west-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
 
 推荐构建规格：`cpu_count=2`，`memory_mb=4096`。
 
@@ -132,6 +134,8 @@ host = sandbox.get_host(8080)
 print(f"https://{host}/?token={token}")
 ```
 
+> **安全提示**：输出的 URL 含 `?token=`，等同于访问凭据，不要分享或记录带 token 的 URL（浏览器历史、终端输出、代理日志都可能留存）。首次访问建立会话后，改用不带 `?token=` 的 URL 继续访问。
+
 `DEEPSEEK_API_KEY` 未注入时，`start.sh` 非零退出并提示通过 `envs` 注入。
 
 ### 浏览器访问（自定义域名 + `--trusted-host`）
@@ -145,7 +149,7 @@ print(f"https://{host}/?token={token}")
 
 要在浏览器中使用 Web UI，须先绑定自定义域名，并在启动时通过 `--trusted-host` 把公网主机名加入信任列表：
 
-1. **绑定自定义域名**：控制台添加域名、DNS 解析与 HTTPS 证书的完整步骤见[云沙箱自定义域名](../../07.FC%20扩展/03.自定义域名.md)。要点：配置控制链路域名 `api.<你的自定义域名>` 与数据链路泛域名 `*.<你的自定义域名>`，证书须覆盖泛域名，域名需完成备案。
+1. **绑定自定义域名**：控制台添加域名、DNS 解析与 HTTPS 证书的完整步骤见[云沙箱自定义域名](../../07.FC%20扩展/03.自定义域名.md)。要点：配置控制链路域名 `api.<你的自定义域名>` 与数据链路泛域名 `*.<你的自定义域名>`，证书须覆盖泛域名，域名需按所在地域要求完成备案。
 2. **SDK 换用自定义域名**：将 `OPTS` 替换为与控制台一致（`api_key` 须为绑定该域名同一账号下的 Key），后续 `Template.build(...)`、`Sandbox.create(...)` 等所有调用一致：
 
     ```python
@@ -170,7 +174,7 @@ print(f"https://{host}/?token={token}")
     print(f"https://{host}/?token={token}")
     ```
 
-浏览器打开输出的 URL 即可使用 Web UI。首次进入会弹出 **Internal Testing Notice**（DeepSeek Harness 0.1 内测期提示），单击 **Continue** 关闭；**必须先选 workspace 才能对话**（单击 **Choose workspace** 选择一个目录），之后模型流式回复，界面含思考过程折叠与每轮 Token 用量统计。
+浏览器打开输出的 URL 即可使用 Web UI。首次进入会弹出 **Internal Testing Notice**（DeepSeek Harness 0.1 内测期提示），单击 **Continue** 关闭；**必须先选 workspace 才能对话**（单击 **Choose workspace** 选择一个目录），之后模型流式回复，界面含思考过程折叠与每轮 Token 用量统计。输出的 URL 同样含 token，按凭据处理；首次访问建立会话后，改用不带 `?token=` 的 URL 即可。
 
 关于 `--trusted-host` 与鉴权：
 
@@ -178,7 +182,7 @@ print(f"https://{host}/?token={token}")
 - 可重复传入多个主机名；条目带端口号时精确匹配，不带端口号时匹配任意端口。
 - dsh 重启后 token 会变化，已签发的浏览器会话 cookie 仍有效。
 
-> **排障**：若访问返回代理层 403（JSON 错误体），带 `X-Access-Token: <sandbox._envd_access_token>` 请求头重试（`Sandbox.create` 返回的 Sandbox Access Token，随沙箱销毁失效）。
+> **排障**：若访问返回代理层 403（JSON 错误体），带 `X-Access-Token: <sandbox._envd_access_token>` 请求头重试。`_envd_access_token` 是 Python SDK 的内部属性（`e2b==2.31.0` 实测可用，后续版本可能重命名或移除），对应 Sandbox Access Token，随沙箱销毁失效。
 
 ---
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/06.DeepSeek 模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/06.DeepSeek 模板.md
@@ -22,14 +22,14 @@
 
 | Region | 镜像 |
 |--------|------|
-| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| us-east-1 | `fc-e2b-registry.us-east-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
-| us-west-1 | `fc-e2b-registry.us-west-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| us-east-1 | `fc-e2b-registry.us-east-1.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
+| us-west-1 | `fc-e2b-registry.us-west-1.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52` |
 
 推荐构建规格：`cpu_count=2`，`memory_mb=4096`。
 
@@ -48,8 +48,8 @@ import time
 
 from e2b import Template, default_build_logger
 
-FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek:v0.0.50"
-TEMPLATE_NAME = f"deepseek-{int(time.time())}"
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek-harness:v0.0.52"
+TEMPLATE_NAME = f"deepseek-harness-{int(time.time())}"
 
 OPTS = {
     "api_key": "<你的 E2B API Key>",
@@ -201,7 +201,7 @@ sandbox.kill()
 | 项目 | 规格 |
 |------|------|
 | 操作系统 | Debian 13 |
-| dsh 路径 | `/home/user/.dsh/bin/dsh`（0.1.2-rc.1，rc 版本，行为可能随上游变动） |
+| dsh 路径 | `/home/user/.dsh/bin/dsh`（0.1.5-rc.1，rc 版本，行为可能随上游变动） |
 | 自带 Node | v22.22.3（`/home/user/.dsh/tools/node/bin/node`，dsh 不依赖系统 Node） |
 | 系统 Node | v20.x |
 | 默认用户 / 工作目录 | `user` / `/home/user` |

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/06.DeepSeek 模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/07.其他模板/06.DeepSeek 模板.md
@@ -1,0 +1,218 @@
+# DeepSeek 模板
+
+[DeepSeek Harness](https://www.npmjs.com/package/@deepseek-ai/dsh) 是 DeepSeek AI 开源的 Agent harness（npm 包 `@deepseek-ai/dsh`，CLI 名 `dsh`），支持 headless 单任务、Web UI 与 SDK/ACP 程序化接入。我们已在各地域 ACR 预置 DeepSeek Harness 镜像，您无需自行推送镜像或配置 ACR EE，选取下方镜像地址，通过 `from_image` + `Template.build` 构建模板后即可使用。本页说明镜像规格与完整用法：前置条件、镜像地址、构建 Template、创建 Sandbox、运行 DeepSeek Harness、自定义域名浏览器访问、环境与 Profile 能力约定。
+
+首次使用请先完成[通过 SDK 使用云沙箱](../../../01.开始使用/03.快速入门/01.通过%20SDK%20使用云沙箱.md)中的前置准备、API Key 创建和 SDK 配置。
+
+---
+
+## 前置条件
+
+- 已完成 [SDK 接入](../../../01.开始使用/03.快速入门/01.通过%20SDK%20使用云沙箱.md)（E2B API Key、`api_url`、`domain`）
+- 已安装依赖：`pip install e2b==2.31.0`（本模板不使用 Code Interpreter，无需安装 `e2b-code-interpreter`）
+- 已准备模型 API Key，创建沙箱时通过 `envs` 注入 — 镜像内不预置
+  - [DeepSeek 开放平台](https://platform.deepseek.com/) 获取 `DEEPSEEK_API_KEY`
+  - 可选 `DEEPSEEK_BASE_URL`：指定中转端点（dsh 原生读取），不设置则直连 DeepSeek 官方
+
+---
+
+## 镜像地址
+
+按地域选取 `FROM_IMAGE`：
+
+| Region | 镜像 |
+|--------|------|
+| cn-beijing | `fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-shenzhen | `fc-e2b-registry.cn-shenzhen.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| ap-southeast-1 | `fc-e2b-registry.ap-southeast-1.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-hongkong | `fc-e2b-registry.cn-hongkong.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-shanghai | `fc-e2b-registry.cn-shanghai.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+| cn-hangzhou | `fc-e2b-registry.cn-hangzhou.cr.aliyuncs.com/runtime/deepseek:v0.0.50` |
+
+推荐构建规格：`cpu_count=2`，`memory_mb=4096`。
+
+镜像内置 Web UI 一键启动脚本 `/opt/deepseek-harness/start.sh`，用法见[运行 DeepSeek Harness](#web-ui)。
+
+---
+
+## 构建 Template
+
+自定义模板需先将镜像构建为 Template，**只需执行一次**。完成后保存模板名称，后续创建 Sandbox 时直接复用。
+
+以下以北京地域为例：
+
+```python
+import time
+
+from e2b import Template, default_build_logger
+
+FROM_IMAGE = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/deepseek:v0.0.50"
+TEMPLATE_NAME = f"deepseek-{int(time.time())}"
+
+OPTS = {
+    "api_key": "<你的 E2B API Key>",
+    "api_url": "https://api.cn-beijing.e2b.fc.aliyuncs.com",
+    "domain": "cn-beijing.e2b.fc.aliyuncs.com",
+}
+
+build = Template.build(
+    Template().from_image(FROM_IMAGE),
+    name=TEMPLATE_NAME,
+    cpu_count=2,
+    memory_mb=4096,
+    on_build_logs=default_build_logger(),
+    **OPTS,
+)
+
+print(f"template: {build.name}")   # 保存，后续可复用
+```
+
+构建完成后控制台模板状态应为 `ready`。同一模板名称可多次创建 Sandbox，无需每次重新构建。
+
+---
+
+## 创建 Sandbox
+
+创建沙箱时通过 `envs` 注入 DeepSeek API Key：
+
+```python
+from e2b import Sandbox
+
+sandbox = Sandbox.create(
+    template=TEMPLATE_NAME,
+    envs={"DEEPSEEK_API_KEY": "<your-deepseek-api-key>"},
+    timeout=600,
+    **OPTS,
+)
+```
+
+任务完成后释放资源（会一并结束沙箱内的 `dsh web` 进程）：
+
+```python
+sandbox.kill()
+```
+
+---
+
+## 运行 DeepSeek Harness
+
+### headless 单任务
+
+`--profile headless` 执行一个任务，打印最终答案后退出：
+
+```python
+result = sandbox.commands.run(
+    'dsh --profile headless "用一句话介绍 DeepSeek Harness"',
+    timeout=0,
+)
+print(result.stdout)
+```
+
+模型 API Key 未注入或无效时，`dsh` 以非零码退出并给出明确错误（错误输出在 stderr，下表为经 `2>&1` 合并后的错误原文）：
+
+| 场景 | 输出 |
+|------|------|
+| 未提供 Key | `dsh: MISSING_CREDENTIAL: llm-deepseek: no API key for provider route "deepseek-official"; store DEEPSEEK_API_KEY through the credentials service (the web Models page writes it), or export DEEPSEEK_API_KEY in the launching environment` |
+| Key 无效 | `dsh: AUTH: Authentication Fails, Your api key: ****-000 is invalid`（`000` 为无效 key 的尾段，随实际 key 变化） |
+
+### Web UI
+
+镜像内置一键启动脚本，沙箱内执行一条命令即可启动 Web UI。脚本后台启动 dsh web（仅监听 `127.0.0.1:8080`，Token 鉴权），就绪后在 stdout 输出 `DSH_WEB_TOKEN` 与 `DSH_WEB_LAUNCH_URL`；脚本幂等，Web UI 已在运行时直接回显现有 token，不重复启动：
+
+```python
+import re
+
+r = sandbox.commands.run("/opt/deepseek-harness/start.sh", timeout=180)
+print(r.stdout)
+# DSH_WEB_TOKEN=<token>
+# DSH_WEB_LAUNCH_URL=http://127.0.0.1:8080/?token=<token>
+
+token = re.search(r"DSH_WEB_TOKEN=(\S+)", r.stdout).group(1)
+```
+
+用 SDK 端口代理把沙箱内 `8080` 端口映射为公网可访问地址：
+
+```python
+host = sandbox.get_host(8080)
+print(f"https://{host}/?token={token}")
+```
+
+`DEEPSEEK_API_KEY` 未注入时，`start.sh` 非零退出并提示通过 `envs` 注入。
+
+#### 浏览器访问（自定义域名 + `--trusted-host`）
+
+**默认平台域名（`*.e2b.fc.aliyuncs.com`）下 Web UI 无法在浏览器中使用**，原因有二：
+
+1. 平台对默认域名的 HTTP 响应强制添加 `Content-Disposition: attachment`，浏览器打开会下载 HTML 文件而非渲染页面。
+2. dsh 对 `/api` 请求设有浏览器信任栅栏，默认只信任 loopback 主机名；经平台域名代理访问时 Host 不被信任，`/api` 全部返回 403，页面为空壳。
+
+默认域名仅适合 curl / SDK 层验证：不带 token 访问 `/api/health` 返回 401（dsh 原生提示），带 token 返回 200。
+
+要在浏览器中使用 Web UI，须先绑定自定义域名，并在启动时通过 `--trusted-host` 把公网主机名加入信任列表：
+
+1. **绑定自定义域名**：控制台添加域名、DNS 解析与 HTTPS 证书的完整步骤见[云沙箱自定义域名](../../07.FC%20扩展/03.自定义域名.md)。要点：配置控制链路域名 `api.<你的自定义域名>` 与数据链路泛域名 `*.<你的自定义域名>`，证书须覆盖泛域名，域名需完成备案。
+2. **SDK 换用自定义域名**：将 `OPTS` 替换为与控制台一致（`api_key` 须为绑定该域名同一账号下的 Key），后续 `Template.build(...)`、`Sandbox.create(...)` 等所有调用一致：
+
+```python
+OPTS = {
+    "api_key": "<你的 E2B API Key>",
+    "api_url": "https://api.<你的自定义域名>",
+    "domain": "<你的自定义域名>",
+}
+```
+
+3. **带 `--trusted-host` 启动并访问**：`start.sh` 额外参数原样透传给 `dsh web`，将 `sandbox.get_host(8080)` 返回的公网主机名传入：
+
+```python
+host = sandbox.get_host(8080)   # 8080-<sandbox_id>.<你的自定义域名>
+
+r = sandbox.commands.run(
+    f"/opt/deepseek-harness/start.sh --trusted-host {host}",
+    timeout=180,
+)
+token = re.search(r"DSH_WEB_TOKEN=(\S+)", r.stdout).group(1)
+
+print(f"https://{host}/?token={token}")
+```
+
+浏览器打开输出的 URL 即可使用 Web UI。首次进入会弹出 Internal Testing Notice（DeepSeek Harness 0.1 内测期提示），点 Continue 关闭；**必须先选 workspace 才能对话**（点击 Choose workspace 选择一个目录），之后模型流式回复，界面含思考过程折叠与每轮 Token 用量统计。
+
+关于 `--trusted-host` 与鉴权：
+
+- 加白只影响信任栅栏，鉴权不变：不带 token 访问仍返回 401，首次访问后由会话 cookie 承接（30 天有效）。
+- 可重复传入多个主机名；条目带端口号时精确匹配，不带端口号时匹配任意端口。
+- dsh 重启后 token 会变化，已签发的浏览器会话 cookie 仍有效。
+
+> 排障：若访问返回代理层 403（JSON 错误体），带 `X-Access-Token: <sandbox._envd_access_token>` 请求头重试（`Sandbox.create` 返回的 Sandbox Access Token，随沙箱销毁失效）。
+
+---
+
+## 环境概览
+
+| 项目 | 规格 |
+|------|------|
+| 操作系统 | Debian 13 |
+| dsh 路径 | `/home/user/.dsh/bin/dsh`（v0.1.2-rc.1，rc 版本，行为可能随上游变动） |
+| dsh 自带 Node | v22.22.3（`/home/user/.dsh/tools/node/bin/node`，dsh 不依赖系统 Node） |
+| 系统 Node | v20.x |
+| 默认用户 / 工作目录 | `user` / `/home/user` |
+
+---
+
+## Profile 与插件
+
+| profile | 用法 | 说明 |
+|---------|------|------|
+| `headless` | `dsh --profile headless "<任务>"` | 执行单任务，打印最终答案后退出 |
+| `web` | `/opt/deepseek-harness/start.sh`（或裸 `dsh web --no-open`） | Web UI，Token 鉴权；脚本固定监听 `127.0.0.1:8080`，裸 dsh web 默认 `127.0.0.1:3080` |
+| `sdk` | `dsh --profile sdk` | JSON-RPC stdio，供 SDK client 接入 |
+| `sdk-minimal` | `dsh --profile sdk-minimal` | 独立极简 agent 配置树 |
+| `acp` | `dsh --profile acp` | ACP stdio，供自动化 client 接入 |
+
+`headless` 与 `web` 为本页流程所用 profile；`sdk` / `sdk-minimal` / `acp` 说明来自镜像内 dsh README（`/home/user/.dsh/lib/node_modules/@deepseek-ai/dsh/README.zh.md`），内置 profile 在首次使用时自动初始化。其他 profile 通过 `dsh plugin --profile <name> <pnpm args>` 管理；运行命令所在目录即默认 workspace 根目录。
+
+## 相关文档
+
+- [内置模板](../02.内置模板.md)
+- [模板名称与版本](../06.模板名称与版本.md)
+- [云沙箱自定义域名](../../07.FC%20扩展/03.自定义域名.md)


### PR DESCRIPTION
## Summary

- Add zh-CN and en-US DeepSeek template pages under Other Templates, covering the `runtime/deepseek:v0.0.50` official image across 6 regions, template build, headless dsh single task, Web UI startup via `/opt/deepseek-harness/start.sh`, and custom-domain browser access with `--trusted-host`.
- Update the Other Templates and Built-in Templates index pages in both languages to include DeepSeek.

## Validation

- `make check` passes: 13 unit tests, check-docs (715 Markdown files, all local references), and `mkdocs build --strict`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
本 PR 更新函数计算（FC）云沙箱（FC Agent Sandbox）文档，涉及中英文“模板”章节。

- 新增中文和英文 DeepSeek 模板页面。
- 更新“内置模板”和“其他模板”页面，加入 DeepSeek 模板链接及能力说明。
- DeepSeek 模板页面涵盖镜像、Template 构建、Sandbox 创建、`dsh` 无头任务、Web UI、自定义域名访问、Sandbox 清理和 Profile。
- 未删除页面。
- 未改动图片资源。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->