### PR TITLE
docs(sandbox): OpenAPI 模板文档新增「使用第二代运行时」章节

### DIFF
--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
@@ -1,26 +1,24 @@
-# 构建和管理模板
+# Build and Manage Templates via OpenAPI
 
-## 正文
+FC Agent Sandbox templates can be created, queried, and deleted through Alibaba Cloud OpenAPI. `CreateTemplate` completes template creation and the first build in one call. The build runs asynchronously; poll `GetTemplate` for the build status. Once the template is ready, you can use it to create sandboxes. For more information, see [Quickstart](01.Quickstart.md).
 
-云沙箱模板支持通过阿里云 OpenAPI 创建、查询和删除。`CreateTemplate` 一次完成模板创建和首次构建，构建异步执行，轮询 `GetTemplate` 获取构建状态；模板就绪后即可用于创建沙箱，参见[快速开始](01.快速开始.md)。
+There are two ways to build a custom image template. Both share the same image and network requirements: build via OpenAPI by calling `CreateTemplate` so the server runs the build, which suits automation scripts, infrastructure as code (IaC), and platform integration; or build locally with the E2B SDK by running `Template.build` on your machine, which suits first-time verification and individual development.
 
-构建自定义镜像模板有两条路径，镜像要求和网络要求相同：通过 OpenAPI 构建，调用 `CreateTemplate` 由服务端完成构建，适合自动化脚本、基础设施即代码（IaC）和平台化集成场景；通过 E2B SDK 本地构建，在本地运行 `Template.build` 提交构建，适合首次验证和个人开发。
+## Prerequisites
 
-### 前提条件
+Before you start:
 
-使用前需要准备：
+- Function Compute and FC Agent Sandbox are activated.
+- A team is created in the FC Agent Sandbox console and you have the team ID.
+- An Alibaba Cloud account or RAM user is prepared, and the caller identity is granted template API permissions. See "Configure permissions" below.
+- Confirm the region where the template resides. For example, the Beijing region is `cn-beijing`. For all regions, see [Supported Regions](../../09.Support/02.Supported%20Regions.md).
+- When building locally with the E2B SDK, obtain the connection parameters `E2B_API_KEY`, `E2B_API_URL`, and `E2B_DOMAIN`. The SDK reads these three environment variables automatically. For details, see [E2B SDK Connection Parameters](../../07.Developer%20Reference/02.E2B%20SDK%20Connection%20Parameters.md).
 
-- 已开通函数计算和云沙箱。
-- 已在云沙箱控制台创建 Team，并获取 Team ID。
-- 准备阿里云账号或 RAM 用户，并为调用身份配置模板 API 权限，参见下文权限配置。
-- 确认模板所在地域，例如北京地域为 `cn-beijing`，全部地域参见[支持地域](../../09.服务支持/02.支持地域.md)。
-- 使用 E2B SDK 本地构建时，获取连接参数 `E2B_API_KEY`、`E2B_API_URL` 和 `E2B_DOMAIN`，SDK 会自动读取这三个环境变量。参数详情见 [E2B SDK 接入参数说明](../../07.开发参考/02.E2B%20SDK%20接入参数说明.md)。
+For more information about how to create a team and obtain the team ID, see [Create a Team](../../01.Getting%20Started/02.Create%20a%20Team.md).
 
-Team 的创建和 Team ID 获取方式参见[创建 Team](../../01.开始使用/02.创建%20Team.md)。
+## Configure permissions
 
-### 权限配置
-
-调用模板 API 的 RAM 身份需要以下权限：
+The RAM identity that calls the template APIs requires the following permissions:
 
 ```json
 {
@@ -40,17 +38,17 @@ Team 的创建和 Team ID 获取方式参见[创建 Team](../../01.开始使用/
 }
 ```
 
-支持按 Team 精确授权 Template 资源：
+Template resources can be authorized per team:
 
 ```text
 acs:fcsandbox:<region>:<account-id>:teams/<team-id>/templates/*
 ```
 
-权限策略的配置方法参见[配置 RAM 用户权限](../../01.开始使用/05.配置%20RAM%20用户权限.md)。E2B SDK 本地构建通过 API Key 鉴权，不涉及 RAM 权限配置。
+For how to configure a permission policy, see [Configure RAM User Permissions](../../01.Getting%20Started/05.Configure%20RAM%20User%20Permissions.md). Local builds with the E2B SDK authenticate with an API key and do not involve RAM permission configuration.
 
-### 安装 SDK
+## Install the SDK
 
-云沙箱 OpenAPI 当前支持 Python、TypeScript、Go 和 Java SDK。支持范围、安装方式和版本以[阿里云 SDK & API 说明](https://help.aliyun.com/zh/functioncompute/alibaba-cloud-sdk-api-description)为准：
+The FC Agent Sandbox OpenAPI currently supports Python, TypeScript, Go, and Java SDKs. For the scope of support, installation, and versioning, see [Alibaba Cloud SDK & API description](https://www.alibabacloud.com/help/en/functioncompute/alibaba-cloud-sdk-api-description):
 
 === "Python"
 
@@ -75,7 +73,7 @@ acs:fcsandbox:<region>:<account-id>:teams/<team-id>/templates/*
 
 === "Java"
 
-    Maven 依赖（版本以 SDK 说明页面为准），在工程 `pom.xml` 中添加：
+    Maven dependency (see the SDK description page for the version). Add the following to your project's `pom.xml`:
 
     ```xml
     <dependency>
@@ -85,7 +83,7 @@ acs:fcsandbox:<region>:<account-id>:teams/<team-id>/templates/*
     </dependency>
     ```
 
-    新建工程时可使用以下最小 `pom.xml`：
+    For a new project, you can use the following minimal `pom.xml`:
 
     ```xml
     <?xml version="1.0" encoding="UTF-8"?>
@@ -111,14 +109,14 @@ acs:fcsandbox:<region>:<account-id>:teams/<team-id>/templates/*
     </project>
     ```
 
-    示例代码保存为工程下的 `src/main/java/CreateTemplateDemo.java`。
+    Save the sample code as `src/main/java/CreateTemplateDemo.java` in the project.
 
-运行示例前设置以下环境变量：
+Set the following environment variables before running the examples:
 
 ```bash
 export ALIBABA_CLOUD_ACCESS_KEY_ID="<your-access-key-id>"
 export ALIBABA_CLOUD_ACCESS_KEY_SECRET="<your-access-key-secret>"
-# 使用 STS 临时凭证时还需要设置：
+# When using STS temporary credentials, also set:
 # export ALIBABA_CLOUD_SECURITY_TOKEN="<your-security-token>"
 
 export FCSANDBOX_REGION_ID="cn-beijing"
@@ -126,20 +124,20 @@ export FCSANDBOX_ENDPOINT="fcsandbox.cn-beijing.aliyuncs.com"
 export FCSANDBOX_TEAM_ID="<team-id>"
 ```
 
-`FCSANDBOX_ENDPOINT` 不包含 `https://`。如果 SDK 已内置目标地域的 Endpoint，可以不设置该变量，由 SDK 根据 `FCSANDBOX_REGION_ID` 解析。
+`FCSANDBOX_ENDPOINT` does not include `https://`. If the SDK already has a built-in endpoint for the target region, you can leave this variable unset and let the SDK resolve the endpoint from `FCSANDBOX_REGION_ID`.
 
-### 创建模板并构建
+## Create a template and build
 
-请求参数、返回参数和错误码以 OpenAPI 门户的 [CreateTemplate - 创建模板](https://api.aliyun.com/api/FCSandbox/2026-05-09/CreateTemplate) 为准。
+For request parameters, response parameters, and error codes, see [CreateTemplate - Create a template](https://api.aliyun.com/api/FCSandbox/2026-05-09/CreateTemplate) in the OpenAPI portal.
 
-请求体 `CreateTemplateInput` 包含 `name`、`team_id`、`runtime_config`、`build_config` 四个字段，模板创建后立即开始首次构建：
+The request body `CreateTemplateInput` contains four fields: `name`, `team_id`, `runtime_config`, and `build_config`. The first build starts immediately after the template is created:
 
-- `runtime_config`：最终模板的运行规格。`cpu`（核数）、`memory_size`（MB）、`disk_size`（MB）按需填写，缺省时使用默认规格；`sandbox_config.image` 为必填的构建源镜像。
-- `build_config`：构建方式。整段缺省时按源镜像自动推导——云沙箱官方镜像直接使用，不再构建；其他镜像自动执行 copy（处理并推送目标镜像）和 envdInject（注入沙箱运行依赖）。
+- `runtime_config`: the runtime specifications of the final template. Specify `cpu` (cores), `memory_size` (MB), and `disk_size` (MB) as needed; default specifications apply when they are omitted. `sandbox_config.image` is the required source image for the build.
+- `build_config`: the build mode. When the whole section is omitted, the mode is derived from the source image: official FC Agent Sandbox images are used directly without a build; other images automatically go through copy (process and push the target image) and envdInject (inject sandbox runtime dependencies).
 
-镜像要求与各镜像源的约束、传参见下文「镜像要求」「镜像源」。
+For image requirements and the constraints and parameters of each image source, see "Image requirements" and "Image sources" below.
 
-以下示例以北京地域为例，使用云沙箱官方镜像（无需自备 ACR EE 实例）创建模板，轮询构建状态至就绪后删除模板：
+The following examples use the Beijing region and an official FC Agent Sandbox image (no ACR EE instance needed) to create a template, poll the build status until it is ready, and then delete the template:
 
 === "Python"
 
@@ -155,7 +153,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
     def require_env(name: str) -> str:
         value = os.environ.get(name, "").strip()
         if not value:
-            raise RuntimeError(f"缺少环境变量: {name}")
+            raise RuntimeError(f"missing environment variable: {name}")
         return value
 
 
@@ -172,7 +170,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
     team_id = require_env("FCSANDBOX_TEAM_ID")
     from_image = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"
 
-    # 1. 创建模板并提交首次构建，返回 templateID。
+    # 1. Create the template and submit the first build. The templateID is returned.
     response = pop_client.create_template(
         models.CreateTemplateRequest(
             body=models.CreateTemplateInput(
@@ -187,7 +185,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
     template_id = response.body.template_id
     print(f"created templateID: {template_id}, request_id: {response.body.request_id}")
 
-    # 2. 轮询 GetTemplate 直到终态。
+    # 2. Poll GetTemplate until a terminal state.
     deadline = time.time() + 900
     while True:
         got = pop_client.get_template(template_id, models.GetTemplateRequest(team_id=team_id))
@@ -196,12 +194,12 @@ export FCSANDBOX_TEAM_ID="<team-id>"
         if state in ("ready", "error"):
             break
         if time.time() > deadline:
-            raise SystemExit("构建超时")
+            raise SystemExit("build timed out")
         time.sleep(5)
     if state == "error":
-        raise SystemExit(f"构建失败: {got.body.status.reason.message}")
+        raise SystemExit(f"build failed: {got.body.status.reason.message}")
 
-    # 3. 模板就绪后即可用于创建沙箱；不再使用时删除模板清理资源。
+    # 3. The ready template can be used to create sandboxes. Delete it when it is no longer needed.
     pop_client.delete_template(template_id, models.DeleteTemplateRequest(team_id=team_id))
     print(f"deleted templateID: {template_id}")
     ```
@@ -216,7 +214,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
     function requireEnv(name: string): string {
       const value = (process.env[name] ?? '').trim();
       if (!value) {
-        throw new Error(`缺少环境变量: ${name}`);
+        throw new Error(`missing environment variable: ${name}`);
       }
       return value;
     }
@@ -234,7 +232,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
       const teamID = requireEnv('FCSANDBOX_TEAM_ID');
       const fromImage = 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49';
 
-      // 1. 创建模板并提交首次构建，返回 templateID。
+      // 1. Create the template and submit the first build. The templateID is returned.
       const created = await popClient.createTemplate(new $FCSandbox20260509.CreateTemplateRequest({
         body: new $FCSandbox20260509.CreateTemplateInput({
           name: `pop-demo-${Math.floor(Date.now() / 1000)}`,
@@ -247,7 +245,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
       const templateID = created.body.templateID;
       console.log(`created templateID: ${templateID}, request_id: ${created.body.requestId}`);
 
-      // 2. 轮询 GetTemplate 直到终态。
+      // 2. Poll GetTemplate until a terminal state.
       const deadline = Date.now() + 900_000;
       let state = '';
       let reasonMessage = '';
@@ -261,15 +259,15 @@ export FCSANDBOX_TEAM_ID="<team-id>"
           break;
         }
         if (Date.now() > deadline) {
-          throw new Error('构建超时');
+          throw new Error('build timed out');
         }
         await new Promise(resolve => setTimeout(resolve, 5000));
       }
       if (state === 'error') {
-        throw new Error(`构建失败: ${reasonMessage}`);
+        throw new Error(`build failed: ${reasonMessage}`);
       }
 
-      // 3. 模板就绪后即可用于创建沙箱；不再使用时删除模板清理资源。
+      // 3. The ready template can be used to create sandboxes. Delete it when it is no longer needed.
       await popClient.deleteTemplate(templateID,
         new $FCSandbox20260509.DeleteTemplateRequest({ teamID }));
       console.log(`deleted templateID: ${templateID}`);
@@ -294,11 +292,11 @@ export FCSANDBOX_TEAM_ID="<team-id>"
         "github.com/alibabacloud-go/tea/tea"
     )
 
-    // requireEnv 读取必填环境变量，缺失时直接 panic。
+    // requireEnv reads a required environment variable and panics if it is missing.
     func requireEnv(name string) string {
         value := strings.TrimSpace(os.Getenv(name))
         if value == "" {
-            panic(fmt.Sprintf("缺少环境变量: %s", name))
+            panic(fmt.Sprintf("missing environment variable: %s", name))
         }
         return value
     }
@@ -323,7 +321,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
         teamID := requireEnv("FCSANDBOX_TEAM_ID")
         fromImage := "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"
 
-        // 1. 创建模板并提交首次构建，返回 templateID。
+        // 1. Create the template and submit the first build. The templateID is returned.
         created, err := popClient.CreateTemplate(&fcsandbox20260509.CreateTemplateRequest{
             Body: &fcsandbox20260509.CreateTemplateInput{
                 Name:   tea.String(fmt.Sprintf("pop-demo-%d", time.Now().Unix())),
@@ -342,7 +340,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
         fmt.Printf("created templateID: %s, request_id: %s\n",
             templateID, tea.StringValue(created.Body.RequestId))
 
-        // 2. 轮询 GetTemplate 直到终态。
+        // 2. Poll GetTemplate until a terminal state.
         deadline := time.Now().Add(900 * time.Second)
         state := ""
         reasonMessage := ""
@@ -362,15 +360,15 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                 break
             }
             if time.Now().After(deadline) {
-                panic("构建超时")
+                panic("build timed out")
             }
             time.Sleep(5 * time.Second)
         }
         if state == "error" {
-            panic(fmt.Sprintf("构建失败: %s", reasonMessage))
+            panic(fmt.Sprintf("build failed: %s", reasonMessage))
         }
 
-        // 3. 模板就绪后即可用于创建沙箱；不再使用时删除模板清理资源。
+        // 3. The ready template can be used to create sandboxes. Delete it when it is no longer needed.
         if _, err := popClient.DeleteTemplate(tea.String(templateID), &fcsandbox20260509.DeleteTemplateRequest{
             TeamID: tea.String(teamID),
         }); err != nil {
@@ -409,7 +407,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
         private static String requireEnv(String name) {
             String value = System.getenv(name);
             if (value == null || value.isBlank()) {
-                throw new RuntimeException("缺少环境变量: " + name);
+                throw new RuntimeException("missing environment variable: " + name);
             }
             return value.trim();
         }
@@ -432,7 +430,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
             String teamID = requireEnv("FCSANDBOX_TEAM_ID");
             String fromImage = "fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49";
 
-            // 1. 创建模板并提交首次构建，返回 templateID。
+            // 1. Create the template and submit the first build. The templateID is returned.
             CreateTemplateInput body = new CreateTemplateInput()
                     .setName("pop-demo-" + System.currentTimeMillis() / 1000)
                     .setTeamID(teamID)
@@ -444,7 +442,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                     .getBody().getTemplateID();
             System.out.printf("created templateID: %s%n", templateID);
 
-            // 2. 轮询 GetTemplate 直到终态。
+            // 2. Poll GetTemplate until a terminal state.
             long deadline = System.currentTimeMillis() + 900_000;
             String state = "";
             GetTemplateResponse got = null;
@@ -457,16 +455,16 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                     break;
                 }
                 if (System.currentTimeMillis() > deadline) {
-                    throw new RuntimeException("构建超时");
+                    throw new RuntimeException("build timed out");
                 }
                 Thread.sleep(5000);
             }
             if ("error".equals(state)) {
-                throw new RuntimeException("构建失败: "
+                throw new RuntimeException("build failed: "
                         + got.getBody().getStatus().getReason().getMessage());
             }
 
-            // 3. 模板就绪后即可用于创建沙箱；不再使用时删除模板清理资源。
+            // 3. The ready template can be used to create sandboxes. Delete it when it is no longer needed.
             popClient.deleteTemplate(templateID,
                     new DeleteTemplateRequest().setTeamID(teamID));
             System.out.printf("deleted templateID: %s%n", templateID);
@@ -474,7 +472,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
     }
     ```
 
-运行示例：
+Run the examples:
 
 === "Python"
 
@@ -501,31 +499,31 @@ export FCSANDBOX_TEAM_ID="<team-id>"
     mvn compile exec:java -Dexec.mainClass="CreateTemplateDemo"
     ```
 
-构建为异步执行，轮询耗时取决于镜像大小，通常在数十秒到数分钟之间。
+The build runs asynchronously. Polling takes tens of seconds to several minutes depending on the image size.
 
-### 使用第二代运行时
+## Use the second-generation runtime
 
-云沙箱运行时分为两代。第一代为默认；第二代基于轻量虚拟机（MicroVM）隔离，提供快照等第一代不具备的能力（快照仅第二代运行时可用，参见[快照](../01.沙箱/12.快照.md)）。
+FC Agent Sandbox runtimes come in two generations. The first generation is the default. The second generation is isolated by lightweight virtual machines (MicroVMs) and provides capabilities unavailable in the first generation, such as snapshots (snapshots are available only on the second-generation runtime; see [Snapshots](../01.Sandbox/12.Snapshots.md)).
 
-第二代运行时当前仅对已开通白名单的账号和地域可用，未开通时模板构建会以 `MicroSandbox runtime is not enabled for this account` 失败。如需使用，请联系技术支持开通。
+The second-generation runtime is currently available only to whitelisted accounts and regions. Without access, the template build fails with `MicroSandbox runtime is not enabled for this account`. To use it, contact technical support to request access.
 
-在 `runtime_config.sandbox_config` 中传 `generation` 选择代际：缺省或显式 `1` 为第一代，传 `2` 为第二代，其他取值返回 `400 InvalidParameter`（`runtimeConfig.sandboxConfig.generation must be 1 or 2`）。`GetTemplate`、`ListTemplates` 回显模板的 `generation`。
+Pass `generation` in `runtime_config.sandbox_config` to select the generation: omitted or explicit `1` selects the first generation, and `2` selects the second generation. Any other value returns `400 InvalidParameter` (`runtimeConfig.sandboxConfig.generation must be 1 or 2`). `GetTemplate` and `ListTemplates` echo the template's `generation`.
 
-第二代与第一代的差异：
+Differences between the two generations:
 
-| 维度 | 第一代 | 第二代 |
+| Dimension | First generation | Second generation |
 | --- | --- | --- |
-| `os_type` | 不支持，提供即 `400 InvalidParameter` | 可选，指定沙箱操作系统类型，缺省为 Linux |
-| `build_config` | 按源镜像自动推导构建方式 | 整体忽略，沙箱运行依赖由平台注入，不涉及 copy 与 envdInject |
-| `registry_config`（`auth_config`、`cert_config`、`network_config`） | 支持 | 不支持，`cert_config`、`network_config` 提供即 `400 InvalidParameter` |
-| `vpc_config` | 仅作为沙箱运行网络 | 同时作为镜像拉取网络与沙箱运行网络，拉取 `-vpc` 内网镜像时必填 |
-| 缺省规格 | 2 vCPU / 2 GiB 内存 / 10 GiB 磁盘 | 8 vCPU / 8 GiB 内存 / 60 GiB 磁盘 |
-| 镜像发行版 | 推荐 Ubuntu 20.04、Debian 12 及以上，不强制 | 仅支持 Ubuntu/Debian 系，且需保留 `systemd`、`openssh-server`、`sudo`、`chrony`、`fuse3`、`iptables` 等系统组件（或保证 `apt-get` 可用）；Alpine、BusyBox 等精简 rootfs 不可用 |
-| `/workspace` 工作目录 | 构建时由平台注入 | 不注入，需要时请在镜像中自带 |
+| `os_type` | Not supported; providing it returns `400 InvalidParameter` | Optional; specifies the sandbox operating system type; defaults to Linux |
+| `build_config` | Build mode is auto-derived from the source image | Ignored as a whole; sandbox runtime dependencies are injected by the platform without copy or envdInject |
+| `registry_config` (`auth_config`, `cert_config`, `network_config`) | Supported | Not supported; providing `cert_config` or `network_config` returns `400 InvalidParameter` |
+| `vpc_config` | Serves only as the sandbox runtime network | Serves as both the image pull network and the sandbox runtime network; required when pulling `-vpc` internal images |
+| Default specifications | 2 vCPU / 2 GiB memory / 10 GiB disk | 8 vCPU / 8 GiB memory / 60 GiB disk |
+| Image distribution | Ubuntu 20.04, Debian 12 or later recommended but not enforced | Ubuntu/Debian-based images only, with system components such as `systemd`, `openssh-server`, `sudo`, `chrony`, `fuse3`, and `iptables` preserved (or `apt-get` guaranteed to work); minimal rootfs images such as Alpine and BusyBox are not supported |
+| `/workspace` working directory | Injected by the platform during the build | Not injected; bake it into the image if needed |
 
-第二代使用 ACR EE 镜像时，`image` 填实例的 `-vpc` 内网域名地址，并必须在 `runtime_config.vpc_config` 中传入 VPC 三件套（`vpc_id`、`v_switch_ids`、`security_group_id`）：第二代不经过构建器，平台直接以该 VPC 配置创建沙箱函数并经由您的 VPC 拉取镜像，`vpc_config` 同时是模板运行期沙箱所在的 VPC。镜像拉取使用同账号 ACR EE 实例的托管授权，无需配置仓库凭证；ACR EE 实例的前置准备（同账号同地域、绑定专有网络）与第一代相同，参见下文「镜像源 → ACR 企业版（ACR EE）」。第二代暂不支持 `registry_config`（`auth_config`、`cert_config`、`network_config` 均不可用），需要显式仓库凭证或自签证书的场景请使用第一代。
+When using an ACR EE image with the second generation, set `image` to the instance's `-vpc` internal endpoint address and pass the VPC trio (`vpc_id`, `v_switch_ids`, `security_group_id`) in `runtime_config.vpc_config`: the second generation has no builder stage, so the platform creates the sandbox function directly with this VPC configuration and pulls the image through your VPC; `vpc_config` is also the VPC where sandboxes created from this template run. Image pulls use the managed authorization of the ACR EE instance under the same account, so no registry credentials are required. The ACR EE prerequisites (same account and region, with a VPC attached) are the same as for the first generation; see "Image sources → ACR Enterprise Edition (ACR EE)" below. The second generation does not support `registry_config` (`auth_config`, `cert_config`, and `network_config` are all unavailable). Use the first generation when explicit registry credentials or self-signed certificates are required.
 
-传参示例（以 ACR EE `-vpc` 内网镜像创建第二代模板为例，轮询与删除步骤与上文相同）：
+Parameter examples (create a second-generation template from an ACR EE `-vpc` internal image; the polling and deletion steps are the same as above):
 
 === "Python"
 
@@ -536,7 +534,8 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                 name=f"pop-demo-gen2-{int(time.time())}",
                 team_id=team_id,
                 runtime_config=models.CreateTemplateRuntimeConfig(
-                    # 第二代拉取 -vpc 内网镜像必须配置 VPC 三件套，该 VPC 同时是沙箱运行网络。
+                    # For the second generation, pulling a -vpc internal image requires the
+                    # VPC trio; this VPC is also the sandbox runtime network.
                     vpc_config=models.CreateTemplateVPCConfig(
                         vpc_id="vpc-xxxxxx",
                         v_switch_ids=["vsw-xxxxxx"],
@@ -544,7 +543,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                     ),
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1",
-                        # 使用第二代运行时。
+                        # Use the second-generation runtime.
                         generation=2,
                     ),
                 ),
@@ -561,7 +560,8 @@ export FCSANDBOX_TEAM_ID="<team-id>"
         name: `pop-demo-gen2-${Math.floor(Date.now() / 1000)}`,
         teamID,
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
-          // 第二代拉取 -vpc 内网镜像必须配置 VPC 三件套，该 VPC 同时是沙箱运行网络。
+          // For the second generation, pulling a -vpc internal image requires the
+          // VPC trio; this VPC is also the sandbox runtime network.
           vpcConfig: new $FCSandbox20260509.CreateTemplateVPCConfig({
             vpcId: 'vpc-xxxxxx',
             vSwitchIds: ['vsw-xxxxxx'],
@@ -569,7 +569,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
           }),
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1',
-            // 使用第二代运行时。
+            // Use the second-generation runtime.
             generation: 2,
           }),
         }),
@@ -585,7 +585,8 @@ export FCSANDBOX_TEAM_ID="<team-id>"
             Name:   tea.String(fmt.Sprintf("pop-demo-gen2-%d", time.Now().Unix())),
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
-                // 第二代拉取 -vpc 内网镜像必须配置 VPC 三件套，该 VPC 同时是沙箱运行网络。
+                // For the second generation, pulling a -vpc internal image requires the
+                // VPC trio; this VPC is also the sandbox runtime network.
                 VpcConfig: &fcsandbox20260509.CreateTemplateVPCConfig{
                     VpcId:           tea.String("vpc-xxxxxx"),
                     VSwitchIds:      []*string{tea.String("vsw-xxxxxx")},
@@ -593,7 +594,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                 },
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
                     Image: tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
-                    // 使用第二代运行时。
+                    // Use the second-generation runtime.
                     Generation: tea.Int32(2),
                 },
             },
@@ -611,58 +612,59 @@ export FCSANDBOX_TEAM_ID="<team-id>"
             .setName("pop-demo-gen2-" + System.currentTimeMillis() / 1000)
             .setTeamID(teamID)
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
-                    // 第二代拉取 -vpc 内网镜像必须配置 VPC 三件套，该 VPC 同时是沙箱运行网络。
+                    // For the second generation, pulling a -vpc internal image requires the
+                    // VPC trio; this VPC is also the sandbox runtime network.
                     .setVpcConfig(new CreateTemplateVPCConfig()
                             .setVpcId("vpc-xxxxxx")
                             .setVSwitchIds(java.util.Arrays.asList("vsw-xxxxxx"))
                             .setSecurityGroupId("sg-xxxxxx"))
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")
-                            // 使用第二代运行时。
+                            // Use the second-generation runtime.
                             .setGeneration(2)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
     ```
 
-### 镜像要求
+## Image requirements
 
-推荐基础镜像：Ubuntu 20.04、Debian 12 (bookworm) 及以上（仅作推荐，不强制发行版）。自定义镜像需满足下表要求，按“硬性 / 条件 / 推荐”分级：
+Recommended base images: Ubuntu 20.04, Debian 12 (bookworm) or later (recommended only, not a hard distribution requirement). Custom images must meet the requirements below, grouped by Required / Conditional / Recommended:
 
-| 级别 | 要求 | 不满足时影响 |
+| Level | Requirement | Impact if not met |
 | --- | --- | --- |
-| 硬性 | 架构为 `linux/amd64`；若为多架构镜像，其 manifest 列表必须包含 `linux/amd64` 变体 | 模板构建直接失败 |
-| 硬性 | ACR 镜像不应开启镜像加速选项 | 模板构建直接失败 |
-| 条件 | 镜像内存在固定路径 `/bin/bash`（不仅是 PATH 中可找到 Bash） | `commands.run`、PTY 失败 |
-| 硬性 | `/etc/passwd`、`/etc/group` 为标准文件且可写 | 沙箱无法初始化默认用户，容器启动失败 |
-| 条件 | PATH 中存在 `python3` 或 `python` | Python `run_code` 不可用 |
-| 条件 | PATH 中存在 `node` | JavaScript `run_code` 不可用 |
-| 条件 | 按需提供：`git`、`openssh-client`、CA 证书、编译工具链 | 对应的 Git、SSH、HTTPS、编译安装操作不可用 |
-| 推荐 | 系统 PATH 至少包含 `/usr/local/bin`、`/usr/bin`、`/bin` | 登录 Shell 常用命令可能找不到 |
+| Required | Architecture is `linux/amd64`; for multi-architecture images, the manifest list must include the `linux/amd64` variant | The template build fails immediately |
+| Required | ACR images should not have the image acceleration option enabled | The template build fails immediately |
+| Conditional | The fixed path `/bin/bash` exists in the image (not merely resolvable through PATH) | `commands.run` and PTY fail |
+| Required | `/etc/passwd` and `/etc/group` are standard files and writable | The sandbox cannot initialize the default user and the container fails to start |
+| Conditional | `python3` or `python` exists in PATH | Python `run_code` is unavailable |
+| Conditional | `node` exists in PATH | JavaScript `run_code` is unavailable |
+| Conditional | Provide as needed: `git`, `openssh-client`, CA certificates, build toolchain | The corresponding Git, SSH, HTTPS, and build-from-source operations are unavailable |
+| Recommended | The system PATH includes at least `/usr/local/bin`, `/usr/bin`, and `/bin` | Common commands may not be found in the login shell |
 
-向自己的镜像仓库推送镜像时，不要向同一个 tag 推送内容不同的镜像。每个不同的镜像都必须使用新的唯一 tag，例如使用版本号、日期或提交 ID，并让模板固定引用对应 tag。
+When pushing images to your own registry, do not push different content to the same tag. Every distinct image must use a new unique tag, such as a version number, date, or commit ID, and templates must pin the corresponding tag.
 
-### 镜像源
+## Image sources
 
-构建源镜像分为四类：公共镜像、ACR 企业版、公网 OCI 仓库、VPC 内私有 OCI 仓库。每类的准备、约束与传参写法如下；示例均为完整的创建模板调用，可直接替换快速开始示例中的第 1 步，其余步骤（轮询、删除）保持不变。
+Build source images fall into four categories: public images, ACR Enterprise Edition, public OCI registries, and private OCI registries in a VPC. The preparation, constraints, and parameter passing of each category are described below. Each example is a complete template creation call that can directly replace step 1 of the quickstart example; the other steps (polling and deletion) remain unchanged.
 
-#### 公共镜像
+### Public images
 
-使用云沙箱官方镜像无需准备 ACR EE 实例，无需凭证与网络配置。官方镜像在全部支持地域均有提供，地址格式为 `fc-e2b-registry.<地域>.cr.aliyuncs.com/runtime/<镜像名>:<tag>`，地域清单参见[支持地域](../../09.服务支持/02.支持地域.md)。以北京地域为例：
+Official FC Agent Sandbox images require no ACR EE instance, credentials, or network configuration. Official images are available in all supported regions in the format `fc-e2b-registry.<region>.cr.aliyuncs.com/runtime/<image-name>:<tag>`. For the region list, see [Supported Regions](../../09.Support/02.Supported%20Regions.md). For the Beijing region:
 
 ```bash
 fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/base:v0.0.49
 fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49
 ```
 
-约束：
+Constraints:
 
-- 只能引用已发布的官方 tag，不能向官方仓库推送镜像。
-- `build_config` 缺省时官方镜像直接使用，不再触发构建。
-- 官方镜像已满足上文镜像要求，快速开始即此方式。
-- 镜像地址的地域须与 `FCSANDBOX_REGION_ID` 一致。
+- Only published official tags can be referenced; you cannot push images to the official registry.
+- When `build_config` is omitted, official images are used directly and no build is triggered.
+- Official images already meet the image requirements above. The quickstart uses this approach.
+- The region in the image address must match `FCSANDBOX_REGION_ID`.
 
-传参示例：
+Parameter example:
 
 === "Python"
 
@@ -731,37 +733,37 @@ fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49
             .getBody().getTemplateID();
     ```
 
-#### ACR 企业版（ACR EE）
+### ACR Enterprise Edition (ACR EE)
 
-前置准备：
+Prerequisites:
 
-1. 在与云沙箱相同的阿里云账号和地域下，[创建 ACR EE 实例](https://www.aliyun.com/product/acr)（经济版暂不支持）。
-2. 为 ACR EE 实例添加专有网络，确保云沙箱可以通过 VPC 拉取镜像。
-3. 创建命名空间与镜像仓库并推送镜像，得到支持 VPC 访问的内网镜像地址，例如：
+1. [Create an ACR EE instance](https://www.alibabacloud.com/help/en/acr/getting-started/use-a-container-registry-enterprise-edition-instance-to-push-and-pull-images) under the same Alibaba Cloud account and in the same region as FC Agent Sandbox (Economy Edition is not supported).
+2. Attach a VPC to the ACR EE instance so that FC Agent Sandbox can pull images over the VPC.
+3. Create a namespace and an image repository and push the image to obtain the internal image address accessible over the VPC, for example:
 
 ```text
 test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
 ```
 
-网络约束：
+Network constraints:
 
-- ACR EE 实例已至少绑定一个专有网络 VPC。
-- 该 VPC 下至少有一个 vSwitch 位于函数计算支持的可用区。
-- ACR EE 镜像仓库、VPC、vSwitch 与云沙箱需位于同一地域，例如本文默认使用北京地域。
-- ACR EE 访问控制与 VPC 配置已允许对应网络访问。
-- VPC 网段需使用 RFC 1918 规定的私有地址段，即 `10.0.0.0/8`、`172.16.0.0/12` 或 `192.168.0.0/16`。不支持公网私用，详情请参见[VPC 常见问题](https://help.aliyun.com/zh/vpc/frequently-asked-questions#c814109cb0l1h)。
-- VPC 下需至少配置一个自建的安全组，且该安全组的出方向规则需放行 443/TCP 端口。
+- The ACR EE instance has at least one VPC attached.
+- At least one vSwitch in that VPC is located in an availability zone supported by Function Compute.
+- The ACR EE image repository, VPC, vSwitch, and FC Agent Sandbox must be in the same region. The examples in this topic use the Beijing region by default.
+- ACR EE access control and VPC configurations allow the corresponding network access.
+- The VPC CIDR block uses the private address ranges defined by RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16`. Public IP reuse is not supported. For details, see [VPC FAQ](https://www.alibabacloud.com/help/en/vpc/frequently-asked-questions).
+- At least one self-managed security group is configured in the VPC, and its outbound rules allow port 443/TCP.
 
-函数计算支持的可用区会随地域和产品能力调整，最新列表请参考[配置网络](../../../02.云函数/04.功能说明/048.配置网络.md)。
+The availability zones supported by Function Compute may change by region and product capability. For the latest list, see [Configure network settings](https://www.alibabacloud.com/help/en/functioncompute/fc/user-guide/configure-network-settings).
 
-常见失败：
+Common failures:
 
-- 镜像拉取失败：依次检查镜像地址、地域、命名空间、仓库权限、VPC 绑定和访问控制配置。使用私有 ACR EE 镜像时，网络配置错误比 SDK 参数错误更常见。
-- 拉取网络 vSwitch 可用区不支持：处理方式参见下文常见问题「vSwitch 所在可用区不支持」。
+- Image pull failure: check the image address, region, namespace, repository permissions, VPC attachment, and access control configuration in turn. With private ACR EE images, network misconfiguration is more common than SDK parameter errors.
+- The pull network vSwitch is in an unsupported availability zone: see "The vSwitch is in an unsupported zone" in the FAQ below.
 
-拉取方式：最简单的方式是只传 `image`，平台按镜像地址推导 ACR EE 实例与仓库类型，使用实例临时授权拉取，并从实例绑定的 VPC 推导拉取网络。需要显式指定实例、凭证或拉取网络时，再传 `acr_instance_id`、`registry_config.auth_config` 与 `registry_config.network_config`；实例推导出的 vSwitch 落在不支持的可用区导致拉取失败时，必须用 `network_config` 显式指定 VPC 三件套。
+Pull modes: the simplest way is to pass only `image`. The platform derives the ACR EE instance and repository type from the image address, pulls with the instance's temporary authorization, and derives the pull network from the VPC attached to the instance. Pass `acr_instance_id`, `registry_config.auth_config`, and `registry_config.network_config` when you need to explicitly specify the instance, credentials, or pull network. If the vSwitch derived from the instance falls in an unsupported availability zone and the pull fails, you must explicitly specify the VPC trio with `network_config`.
 
-传参示例一：只传 `image`，实例、凭证与拉取网络全部缺省推导：
+Parameter example 1: pass only `image`; the instance, credentials, and pull network are all derived by default:
 
 === "Python"
 
@@ -830,7 +832,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             .getBody().getTemplateID();
     ```
 
-传参示例二：`acr_instance_id`、`auth_config`、`network_config` 都传，显式指定实例、凭证与拉取网络：
+Parameter example 2: pass `acr_instance_id`, `auth_config`, and `network_config` to explicitly specify the instance, credentials, and pull network:
 
 === "Python"
 
@@ -944,17 +946,17 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             .getBody().getTemplateID();
     ```
 
-#### 公网 OCI 仓库
+### Public OCI registries
 
-公网可达、TLS 证书正常的 OCI 仓库，无需 VPC 与证书配置。其中「公网可达」指函数计算能够从对应地域访问到该仓库，而不只是仓库对公网开放了域名。
+A publicly reachable OCI registry with a valid TLS certificate requires no VPC or certificate configuration. "Publicly reachable" means Function Compute can access the registry from the corresponding region, not merely that the registry exposes a public domain name.
 
-约束：
+Constraints:
 
-- 只需 `auth_config` 凭证两项（用户名/密码），无需 `network_config`；凭证需要对该仓库有拉取权限。
-- `build_config` 缺省时构建产物会推送回同一仓库的新 tag，因此凭证还需要具备推送权限。
-- `network_config`、`cert_config` 按实际网络与证书情况追加。
+- Only the two `auth_config` credential fields (username/password) are required; `network_config` is not needed. The credentials must have pull permission on the repository.
+- When `build_config` is omitted, the build artifact is pushed back to a new tag in the same repository, so the credentials must also have push permission.
+- Append `network_config` and `cert_config` based on the actual network and certificate situation.
 
-传参示例：
+Parameter example:
 
 === "Python"
 
@@ -1045,18 +1047,18 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             .getBody().getTemplateID();
     ```
 
-#### VPC 内私有 OCI 仓库
+### Private OCI registries in a VPC
 
-Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS 上自建的 Harbor。
+A self-managed private registry whose domain name is reachable only within a VPC, such as a Harbor instance on an ECS instance in the VPC.
 
-约束：
+Constraints:
 
-- 仓库必须以 HTTPS 提供服务且监听 443 端口，不支持自定义端口或 HTTP。
-- 必须提供 `registry_config.network_config`（VPC 三件套 `vpc_id`/`v_switch_id`/`security_group_id`，同时提供）。
-- 使用自签证书的私有仓库还必须在 `cert_config` 中声明跳过证书校验（`insecure=True`），否则构建在拉取源镜像阶段以 x509 证书错误失败。
-- 凭证通过 `auth_config` 照常传入。
+- The registry must serve HTTPS on port 443. Custom ports and HTTP are not supported.
+- `registry_config.network_config` is required (the VPC trio `vpc_id`/`v_switch_id`/`security_group_id`, provided together).
+- A private registry with a self-signed certificate must also declare `insecure=True` in `cert_config` to skip certificate verification; otherwise the build fails at the source image pull stage with an x509 certificate error.
+- Pass credentials through `auth_config` as usual.
 
-传参示例：
+Parameter example:
 
 === "Python"
 
@@ -1177,11 +1179,11 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             .getBody().getTemplateID();
     ```
 
-### 运行时网络
+## Runtime network
 
-`vpc_config` 决定模板最终运行时沙箱所在的 VPC（vSwitch 支持多个），与构建阶段拉取源镜像的网络（`registry_config.network_config`）相互独立，按需分别配置。
+`vpc_config` determines the VPC where sandboxes created from the template run (multiple vSwitches are supported). It is independent of the network used to pull the source image during the build (`registry_config.network_config`); configure each as needed.
 
-关闭公网出口（`internet_access=False`）后，沙箱内访问公网会失败：
+After the public egress is disabled (`internet_access=False`), public network access from inside the sandbox fails:
 
 === "Python"
 
@@ -1273,9 +1275,9 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             .getBody().getTemplateID();
     ```
 
-### 日志配置
+## Log configuration
 
-沙箱运行日志可通过 `runtime_config` 中的 `log_config` 投递到您账号下的 SLS，仅开放 `project` 与 `logstore` 两项，需与云沙箱位于同一地域：
+Sandbox runtime logs can be delivered to Simple Log Service (SLS) under your account through `log_config` in `runtime_config`. Only `project` and `logstore` are supported, and they must be in the same region as FC Agent Sandbox:
 
 === "Python"
 
@@ -1359,13 +1361,13 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             .getBody().getTemplateID();
     ```
 
-### 目标镜像与构建复用
+## Target image and build reuse
 
-构建非官方镜像时，平台会临时启动一个函数计算函数，由它拉取源镜像、加入云沙箱运行所需的依赖，并推送为目标镜像；模板最终使用这个目标镜像创建沙箱运行环境。该临时函数创建在您自己的账号下，构建期间会产生少量函数计算费用。
+When building a non-official image, the platform temporarily starts a Function Compute function that pulls the source image, adds the dependencies required by the FC Agent Sandbox runtime, and pushes the result as the target image. The template uses this target image to create sandbox runtime environments. The temporary function is created under your own account and incurs a small amount of Function Compute charges during the build.
 
-目标镜像可以通过 `build_config.copy.image` 显式指定，例如推送到您镜像仓库的新 tag；目标仓库与源镜像相同时无需重复提供目标侧凭证，推送到其他仓库时需要在 `build_config.copy.registry_config` 显式提供目标仓库的凭证与网络配置。多次构建使用完全相同的目标镜像时，复用同一个目标镜像：只有首次构建会推送，后续构建命中复用、不再推送新镜像，构建耗时显著缩短，且目标 tag 的 manifest digest 与首次构建一致。
+The target image can be explicitly specified with `build_config.copy.image`, for example, a new tag in your registry. When the target repository is the same as the source image, you do not need to provide target-side credentials again; when pushing to a different repository, explicitly provide the target repository's credentials and network configuration in `build_config.copy.registry_config`. When multiple builds use the exact same target image, the target image is reused: only the first build pushes, subsequent builds hit the reuse path and do not push a new image, the build time is significantly shortened, and the manifest digest of the target tag is identical to that of the first build.
 
-传参示例（目标与源镜像同仓库；`build_config.copy` 提供时 `enabled` 必填）：
+Parameter example (the target and the source image share the same repository; `enabled` is required when `build_config.copy` is provided):
 
 === "Python"
 
@@ -1478,52 +1480,52 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             .getBody().getTemplateID();
     ```
 
-### 查询构建状态
+## Query the build status
 
-通过 [GetTemplate - 查询模板](https://api.aliyun.com/api/FCSandbox/2026-05-09/GetTemplate) 查询单个模板的配置与构建状态。构建状态通过响应体的 `status.state` 获取，取值：
+Call [GetTemplate - Query a template](https://api.aliyun.com/api/FCSandbox/2026-05-09/GetTemplate) to query the configuration and build status of a single template. The build status is obtained from `status.state` in the response body. Valid values:
 
-| 状态 | 说明 |
+| State | Description |
 | --- | --- |
-| `pending` | 已受理，等待构建 |
-| `building` | 构建进行中 |
-| `ready` | 构建成功，可用于创建沙箱 |
-| `error` | 构建失败，`status.reason.message` 给出具体原因 |
+| `pending` | Accepted and waiting to be built |
+| `building` | Build in progress |
+| `ready` | Build succeeded; the template can be used to create sandboxes |
+| `error` | Build failed; `status.reason.message` provides the specific cause |
 
-进入 `ready` 或 `error` 终态后，响应包含 `status.finished_at`，即构建结束时间。
+After the template enters the `ready` or `error` terminal state, the response includes `status.finished_at`, the time when the build ended.
 
-响应按实际配置回显字段，不使用平台默认值补齐；镜像拉取凭证等敏感字段不会回显。
+The response echoes fields according to the actual configuration and is not padded with platform default values. Sensitive fields such as image pull credentials are not echoed.
 
-### 管理模板
+## Manage templates
 
-通过 [ListTemplates - 查询模板列表](https://api.aliyun.com/api/FCSandbox/2026-05-09/ListTemplates) 分页查询 Team 下的模板列表，按创建时间倒序返回；通过 [DeleteTemplate - 删除模板](https://api.aliyun.com/api/FCSandbox/2026-05-09/DeleteTemplate) 删除不再使用的模板：
+Call [ListTemplates - Query the template list](https://api.aliyun.com/api/FCSandbox/2026-05-09/ListTemplates) to page through the templates of a team in descending order of creation time. Call [DeleteTemplate - Delete a template](https://api.aliyun.com/api/FCSandbox/2026-05-09/DeleteTemplate) to delete templates that are no longer needed:
 
 === "Python"
 
     ```python
-    # 分页查询 Team 下的模板列表。
+    # Page through the templates of the team.
     response = pop_client.list_templates(
         models.ListTemplatesRequest(team_id=team_id)
     )
     for template in response.body.templates:
         print(template.template_id, template.status.state, template.created_time)
-    # 还有下一页时，把 response.body.next_token 传入下一次请求的 next_token 继续查询。
+    # When another page exists, pass response.body.next_token as the next_token of the next request.
 
-    # 删除模板。
+    # Delete the template.
     pop_client.delete_template(template_id, models.DeleteTemplateRequest(team_id=team_id))
     ```
 
 === "TypeScript"
 
     ```typescript
-    // 分页查询 Team 下的模板列表。
+    // Page through the templates of the team.
     const response = await popClient.listTemplates(
       new $FCSandbox20260509.ListTemplatesRequest({ teamID }));
     for (const template of response.body.templates ?? []) {
       console.log(template.templateID, template.status.state, template.createdTime);
     }
-    // 还有下一页时，把 response.body.nextToken 传入下一次请求的 nextToken 继续查询。
+    // When another page exists, pass response.body.nextToken as the nextToken of the next request.
 
-    // 删除模板。
+    // Delete the template.
     await popClient.deleteTemplate(templateID,
       new $FCSandbox20260509.DeleteTemplateRequest({ teamID }));
     ```
@@ -1531,7 +1533,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
 === "Go"
 
     ```go
-    // 分页查询 Team 下的模板列表。
+    // Page through the templates of the team.
     resp, err := popClient.ListTemplates(&fcsandbox20260509.ListTemplatesRequest{
         TeamID: tea.String(teamID),
     })
@@ -1543,9 +1545,9 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             tea.StringValue(template.Status.State),
             tea.StringValue(template.CreatedTime))
     }
-    // 还有下一页时，把 resp.Body.NextToken 传入下一次请求的 NextToken 继续查询。
+    // When another page exists, pass resp.Body.NextToken as the NextToken of the next request.
 
-    // 删除模板。
+    // Delete the template.
     _, err = popClient.DeleteTemplate(tea.String(templateID), &fcsandbox20260509.DeleteTemplateRequest{
         TeamID: tea.String(teamID),
     })
@@ -1557,35 +1559,35 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
 === "Java"
 
     ```java
-    // 分页查询 Team 下的模板列表。
+    // Page through the templates of the team.
     ListTemplatesResponse response = popClient.listTemplates(
             new ListTemplatesRequest().setTeamID(teamID));
     for (PublicTemplate template : response.getBody().getTemplates()) {
         System.out.printf("%s %s %s%n", template.getTemplateID(),
                 template.getStatus().getState(), template.getCreatedTime());
     }
-    // 还有下一页时，把 response.getBody().getNextToken() 传入下一次请求的 nextToken 继续查询。
+    // When another page exists, pass response.getBody().getNextToken() as the nextToken of the next request.
 
-    // 删除模板。
+    // Delete the template.
     popClient.deleteTemplate(templateID,
             new DeleteTemplateRequest().setTeamID(teamID));
     ```
 
-- 模板处于任意状态（含构建中）都可删除，删除会终止进行中的构建。
-- 删除成功后模板名立即释放，可创建同名新模板。
-- 平台内置模板（如 `base`）不允许删除。
-- 刚创建的模板可能延迟数秒才会出现在列表中，属于索引同步的正常现象，`GetTemplate` 不受影响。
+- A template in any state (including building) can be deleted. Deletion terminates the ongoing build.
+- After a successful deletion, the template name is released immediately and can be reused for a new template.
+- Built-in platform templates (such as `base`) cannot be deleted.
+- A newly created template may take a few seconds to appear in the list. This is normal index synchronization and does not affect `GetTemplate`.
 
-### 使用限制
+## Limits
 
-- 所有模板接口都必须传入 Team ID，缺失时返回 `400 InvalidParameter`。
-- 请求体采用严格 JSON 校验：未知字段、重复 key、显式 `null` 都会返回 `400`；请求体上限 1 MiB。
-- 同一 Team 中模板名称不能重复，重复创建返回 `409 TemplateAlreadyExists`。
-- 没有独立的更新接口，更新模板需要先删除旧模板再重新创建。
+- All template APIs require the team ID. If it is missing, `400 InvalidParameter` is returned.
+- The request body is validated with strict JSON: unknown fields, duplicate keys, and explicit `null` all return `400`. The request body is limited to 1 MiB.
+- Template names must be unique within a team. Duplicate creation returns `409 TemplateAlreadyExists`.
+- There is no dedicated update API. To update a template, delete the old template and create a new one.
 
-### 通过 E2B SDK 本地构建
+## Build locally with the E2B SDK
 
-E2B SDK 在本地定义模板并提交构建，适合首次验证和个人开发。安装依赖：
+The E2B SDK defines a template locally and submits the build, which suits first-time verification and individual development. Install the dependencies:
 
 ```bash
 python3 -m venv .venv
@@ -1593,21 +1595,21 @@ source .venv/bin/activate
 pip install e2b==2.32.0 e2b-code-interpreter==2.8.1 python-dotenv
 ```
 
-创建 `.env` 文件：
+Create a `.env` file:
 
 ```bash
-# 使用前请替换为自己的 API Key
+# Replace with your own API key before use
 E2B_API_KEY=e2b_xxx
 FROM_IMAGE="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"
 
-# 北京生产环境地址示例值
+# Sample values for the Beijing production endpoint
 E2B_API_URL=https://api.cn-beijing.e2b.fc.aliyuncs.com
 E2B_DOMAIN=cn-beijing.e2b.fc.aliyuncs.com
 ```
 
-`FROM_IMAGE` 默认为云沙箱官方镜像，无需凭证与网络配置；其他官方镜像地址参见上文「镜像源」。使用需要鉴权或网络配置的私有镜像源时，请改用本文 OpenAPI 方式创建模板，参见上文「镜像源」。
+`FROM_IMAGE` defaults to an official FC Agent Sandbox image and requires no credentials or network configuration. For other official image addresses, see "Image sources" above. When using a private image source that requires authentication or network configuration, create the template with the OpenAPI approach described in this topic instead; see "Image sources" above.
 
-运行脚本，将镜像构建为模板，并创建沙箱验证：
+Run the script to build the image into a template and create a sandbox for verification:
 
 ```python
 #!/usr/bin/env python3
@@ -1625,7 +1627,7 @@ load_dotenv()
 FROM_IMAGE = os.getenv("FROM_IMAGE", "").strip()
 RUN_CODE = "print('hello')"
 
-# SDK 自动读取 E2B_API_KEY / E2B_API_URL / E2B_DOMAIN 环境变量。
+# The SDK reads the E2B_API_KEY / E2B_API_URL / E2B_DOMAIN environment variables automatically.
 build = Template.build(
     Template().from_image(FROM_IMAGE),
     name=f"template-{int(time.time())}",
@@ -1652,18 +1654,18 @@ try:
     print(f"run_code error: {execution.error}")
 
     if execution.error is not None:
-        raise RuntimeError(f"run_code 执行失败: {execution.error}")
+        raise RuntimeError(f"run_code execution failed: {execution.error}")
     if stdout.strip() != "hello":
-        raise RuntimeError(f"run_code stdout 不符合预期: {stdout!r}")
+        raise RuntimeError(f"unexpected run_code stdout: {stdout!r}")
 finally:
     print(f"killing sandbox: {sandbox.sandbox_id}")
     sandbox.kill()
     print("sandbox killed")
 ```
 
-#### 使用 CLI 查看模板并创建沙箱
+### Use the CLI to view templates and create sandboxes
 
-如果已经安装 E2B CLI，可以通过模板列表确认构建状态：
+If the E2B CLI is already installed, you can confirm the build status through the template list:
 
 ```bash
 export E2B_API_KEY=e2b_xxx
@@ -1673,13 +1675,13 @@ export E2B_DOMAIN=cn-beijing.e2b.fc.aliyuncs.com
 e2b template list
 ```
 
-当模板状态为 `ready` 后，可以使用模板名称或 `template_id` 创建沙箱。模板需先创建并构建完成，例如上一步本地构建产出的 `template-{时间戳}`，`my-code-interpreter-v1` 为示例名：
+When the template state is `ready`, you can create a sandbox with the template name or `template_id`. The template must be created and built first, such as the `template-{timestamp}` produced by the local build in the previous step; `my-code-interpreter-v1` is a sample name:
 
 ```bash
 e2b sandbox create my-code-interpreter-v1
 ```
 
-进入沙箱后建议先验证关键依赖：
+After entering the sandbox, verify the key dependencies first:
 
 ```bash
 env | sort | head
@@ -1687,59 +1689,59 @@ python3 --version
 which python3
 ```
 
-#### 模板名称建议
+### Template naming suggestions
 
-建议在模板名称中包含业务名、基础镜像、关键依赖版本或日期，例如 `agent-python313-20260531`。生产环境避免覆盖正在使用的模板，先创建新模板并灰度验证。
+Include the business name, base image, key dependency versions, or date in the template name, for example, `agent-python313-20260531`. In production, avoid overwriting templates that are in use; create a new template and verify it with a canary release first.
 
-E2B SDK 本地构建适合使用官方镜像快速验证。构建拉取网络、运行时 VPC 等配置需要在创建模板时设置，请改用本文 OpenAPI 方式创建模板，使用 `registry_config.network_config`、`vpc_config` 字段，参见上文「镜像源」「运行时网络」。
+Building locally with the E2B SDK is suitable for quick verification with official images. Configurations such as the build pull network and the runtime VPC must be set when creating the template. Use the OpenAPI approach in this topic instead, with the `registry_config.network_config` and `vpc_config` fields; see "Image sources" and "Runtime network" above.
 
-### 常见问题
+## FAQ
 
-排查接口问题时，优先查看 SDK 异常对象中的 `code`、`message` 和 `request_id`；联系技术支持时请提供 `request_id`。
+When troubleshooting API issues, check the `code`, `message`, and `request_id` in the SDK exception object first. Provide the `request_id` when contacting technical support.
 
-#### 返回 `InvalidParameter` 错误码
+### The `InvalidParameter` error code is returned
 
-检查 Team ID 是否缺失，以及请求体是否包含未知字段、重复 key、显式 `null`，或传入了暂不支持的 `start_command`、`ready_command` 字段。
+Check whether the team ID is missing, whether the request body contains unknown fields, duplicate keys, or explicit `null`, or whether the not-yet-supported `start_command` and `ready_command` fields are passed.
 
-#### 返回 `TemplateAlreadyExists` 错误码
+### The `TemplateAlreadyExists` error code is returned
 
-同一 Team 中已存在同名模板。可通过 [ListTemplates](https://api.aliyun.com/api/FCSandbox/2026-05-09/ListTemplates) 查询确认，不再使用后通过 [DeleteTemplate](https://api.aliyun.com/api/FCSandbox/2026-05-09/DeleteTemplate) 删除，或更换模板名称。
+A template with the same name already exists in the team. Confirm it with [ListTemplates](https://api.aliyun.com/api/FCSandbox/2026-05-09/ListTemplates), delete it with [DeleteTemplate](https://api.aliyun.com/api/FCSandbox/2026-05-09/DeleteTemplate) when it is no longer needed, or use a different template name.
 
-#### 返回 `TemplateNotFound` 错误码
+### The `TemplateNotFound` error code is returned
 
-模板不存在、已删除，或不属于当前 Team。
+The template does not exist, has been deleted, or does not belong to the current team.
 
-#### 返回 `SignatureDoesNotMatch` 错误
+### The `SignatureDoesNotMatch` error is returned
 
-签名校验失败。常见原因为 AccessKey Secret 不正确、STS 临时凭证过期或本机时间偏差过大；使用官方 SDK 发起调用可避免手工构造签名带来的问题。
+Signature verification failed. Common causes are an incorrect AccessKey secret, expired STS temporary credentials, or a large local clock skew. Using the official SDK avoids the problems of constructing signatures manually.
 
-#### `status.state` 为 `error`
+### `status.state` is `error`
 
-构建失败，查看 `status.reason.message` 中的具体原因，常见为镜像拉取失败、镜像不满足要求或 VPC 网络配置错误。镜像源的约束与传参见上文「镜像源」，vSwitch 可用区问题参见下文。
+The build failed. Check the specific cause in `status.reason.message`. Common causes are image pull failures, images that do not meet the requirements, or VPC network configuration errors. For the constraints and parameters of image sources, see "Image sources" above; for vSwitch availability zone issues, see below.
 
-#### 模板构建慢
+### Template builds are slow
 
-优先检查自己的 ACR EE 镜像体积、网络链路、镜像层缓存和 ACR EE 私网访问配置。基础镜像越大，首次构建通常越慢。
+Check the size of your ACR EE image, the network link, image layer caches, and the ACR EE private network access configuration first. The larger the base image, the slower the first build usually is.
 
-如果只是排查模板构建链路是否正常，可以临时使用已有 E2B 兼容镜像做对照验证。这类镜像已经包含云沙箱运行依赖，通常更容易排除镜像适配问题。
+If you only need to troubleshoot whether the template build pipeline works, you can temporarily use an existing E2B-compatible image for comparison. Such images already contain the FC Agent Sandbox runtime dependencies and usually make it easier to rule out image adaptation issues.
 
-#### vSwitch 所在可用区不支持
+### The vSwitch is in an unsupported zone
 
-如果构建或运行过程中遇到 `vSwitch is in unsupported zone`，说明当前选择的 vSwitch 所在可用区不被函数计算支持。
+If you encounter `vSwitch is in unsupported zone` during the build or at runtime, the availability zone of the selected vSwitch is not supported by Function Compute.
 
-处理方式：
+To resolve the issue:
 
-1. 根据错误信息确认当前 vSwitch 所在可用区。
-2. 在函数计算支持的可用区中选择一个 Zone。
-3. 在同一个 VPC 中新建该 Zone 下的 vSwitch。
-4. 使用这个新的 vSwitch 配置函数计算或相关网络配置。
-5. 重新构建模板并创建沙箱验证。
+1. Confirm the availability zone of the current vSwitch from the error message.
+2. Select a zone from the availability zones supported by Function Compute.
+3. Create a new vSwitch under that zone in the same VPC.
+4. Use this new vSwitch to configure Function Compute or the related network configuration.
+5. Rebuild the template and create a sandbox to verify.
 
-同一个 VPC 内不同可用区的交换机默认内网互通。因此，即使业务资源在其他可用区，也可以在同一个 VPC 中新增一个函数计算支持可用区下的 vSwitch，用于完成函数计算侧网络接入。
+vSwitches in different zones of the same VPC can communicate with each other over the internal network by default. Therefore, even if your business resources are in other zones, you can add a vSwitch in a zone supported by Function Compute within the same VPC for network access on the Function Compute side.
 
-#### 沙箱创建成功但 `run_code` 失败
+### The sandbox is created but `run_code` fails
 
-`run_code` 会调用镜像的 `python3` 命令执行代码，如果镜像不包含 `python3` 或相关依赖，可能会导致执行失败。建议先确认镜像是否包含代码解释器所需依赖。可以在沙箱中运行：
+`run_code` invokes the image's `python3` command to execute code. If the image does not contain `python3` or the related dependencies, the execution may fail. Check whether the image contains the dependencies required by the code interpreter first. You can run the following commands in the sandbox:
 
 ```bash
 python3 --version
@@ -1747,11 +1749,11 @@ which python3
 env | sort | head -50
 ```
 
-#### 沙箱启动慢
+### Sandboxes start slowly
 
-如果沙箱启动较慢，可以先使用以下脚本将镜像压缩为单层镜像，再使用原镜像和压缩后的镜像进行 A/B 对照。测试时应保持模板规格、地域、并发量和启动命令一致，并分别记录模板构建、沙箱创建和首次执行耗时。
+If sandboxes start slowly, you can use the following script to flatten the image into a single-layer image, and then run an A/B comparison between the original image and the flattened image. Keep the template specifications, region, concurrency, and start command the same during the test, and record the time spent on template building, sandbox creation, and first execution respectively.
 
-脚本依赖 Docker 和 Python 3。运行前请确认源镜像已拉取到本地，并为目标镜像使用新的 tag。使用压缩后的镜像前请先完成验证。
+The script depends on Docker and Python 3. Before running it, confirm that the source image has been pulled locally, and use a new tag for the target image. Validate the flattened image before using it.
 
 ```bash
 #!/usr/bin/env bash
@@ -1759,22 +1761,22 @@ set -euo pipefail
 
 PLATFORM="linux/amd64"
 
-SRC="${1:?用法：$0 <源镜像> [目标 tag]}"
+SRC="${1:?Usage: $0 <source image> [target tag]}"
 
 if [ "$#" -ge 2 ]; then
     DST="$2"
 elif [[ "$SRC" == *@* ]] || [[ "${SRC##*/}" != *:* ]]; then
-    echo "错误：源镜像使用 digest 或未指定 tag 时，请显式传入目标 tag。" >&2
+    echo "Error: when the source image uses a digest or has no tag, pass the target tag explicitly." >&2
     exit 2
 else
     DST="${SRC}-flat"
 fi
 
-echo "==> 源镜像：   $SRC"
-echo "==> 目标镜像： $DST"
-echo "==> 平台：     $PLATFORM"
+echo "==> Source image: $SRC"
+echo "==> Target image: $DST"
+echo "==> Platform:     $PLATFORM"
 
-echo "==> 提取镜像元数据..."
+echo "==> Extracting image metadata..."
 RAW_CMD=$(docker inspect --format='{{json .Config.Cmd}}' "$SRC")
 RAW_ENTRYPOINT=$(docker inspect --format='{{json .Config.Entrypoint}}' "$SRC")
 RAW_ENV=$(docker inspect --format='{{json .Config.Env}}' "$SRC")
@@ -1852,9 +1854,9 @@ if [ -n "$RAW_STOPSIGNAL" ]; then
 fi
 
 ORIG_LAYERS=$(docker inspect --format='{{len .RootFS.Layers}}' "$SRC")
-echo "==> 原始镜像层数：$ORIG_LAYERS"
+echo "==> Original image layers: $ORIG_LAYERS"
 
-echo "==> 开始压缩镜像层..."
+echo "==> Flattening image layers..."
 CONTAINER_ID=$(docker create --platform "$PLATFORM" "$SRC" /bin/true)
 trap 'docker rm -f "${CONTAINER_ID:-}" >/dev/null 2>&1 || true' EXIT
 
@@ -1870,15 +1872,15 @@ ORIG_ARCH=$(docker inspect --format='{{.Architecture}}' "$SRC")
 NEW_ARCH=$(docker inspect --format='{{.Architecture}}' "$DST")
 
 echo ""
-echo "==> 完成"
-echo "    原始镜像：$ORIG_LAYERS 层，$ORIG_SIZE，架构=$ORIG_ARCH"
-echo "    压缩镜像：$NEW_LAYERS 层，$NEW_SIZE，架构=$NEW_ARCH"
-echo "    Tag：$DST"
+echo "==> Done"
+echo "    Original image: $ORIG_LAYERS layers, $ORIG_SIZE, arch=$ORIG_ARCH"
+echo "    Flattened image: $NEW_LAYERS layers, $NEW_SIZE, arch=$NEW_ARCH"
+echo "    Tag: $DST"
 ```
 
-##### 使用示例
+#### Usage example
 
-将上述脚本保存为 `flatten-image.sh` 并赋予执行权限。以下示例将源镜像压缩为单层镜像，并生成新的目标 tag：
+Save the script above as `flatten-image.sh` and grant execute permission. The following example flattens the source image into a single-layer image and generates a new target tag:
 
 ```bash
 chmod +x flatten-image.sh
@@ -1887,10 +1889,10 @@ chmod +x flatten-image.sh
   registry.example.com/runtime/python:3.12-v1-flat
 ```
 
-脚本执行完成后，确认输出的镜像层数和大小符合预期，再将目标镜像推送到镜像仓库，并在构建模板时使用目标镜像地址：
+After the script finishes, confirm that the reported image layer count and size meet your expectations, push the target image to the registry, and use the target image address when building the template:
 
 ```bash
 docker push registry.example.com/runtime/python:3.12-v1-flat
 ```
 
-如果压缩后的镜像在相同条件下启动明显更快，建议在后续构建镜像时合并构建步骤，减少镜像层数。
+If the flattened image starts significantly faster under the same conditions, merge build steps in subsequent image builds to reduce the number of image layers.

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
@@ -505,13 +505,11 @@ The build runs asynchronously. Polling takes tens of seconds to several minutes 
 
 ## Use the second-generation runtime
 
-FC Agent Sandbox runtimes come in two generations. The first generation is the default. The second generation is isolated by lightweight virtual machines (MicroVMs) and provides capabilities unavailable in the first generation, such as snapshots (snapshots are available only on the second-generation runtime; see [Snapshots](../01.Sandbox/12.Snapshots.md)).
+FC Agent Sandbox runtimes come in two generations. The second generation is isolated by lightweight virtual machines (MicroVMs) and provides capabilities unavailable in the first generation, such as snapshots (snapshots are available only on the second-generation runtime; see [Snapshots](../01.Sandbox/12.Snapshots.md)).
 
 The second-generation runtime is currently available only to whitelisted accounts and regions. Without access, the template build fails with `MicroSandbox runtime is not enabled for this account`. To use it, contact technical support to request access.
 
-Pass `generation` in `runtime_config.sandbox_config` to select the generation: omitted or explicit `1` selects the first generation, and `2` selects the second generation. Any other value returns `400 InvalidParameter` (`runtimeConfig.sandboxConfig.generation must be 1 or 2`). `GetTemplate` and `ListTemplates` echo the template's `generation`.
-
-The default is currently `1` (first generation). To prevent a future default change from affecting existing template behavior, always specify `generation` explicitly when creating a template, as all examples in this topic do.
+Pass `generation` in `runtime_config.sandbox_config` to select the generation: `1` selects the first generation, and `2` selects the second generation. Any other value returns `400 InvalidParameter` (`runtimeConfig.sandboxConfig.generation must be 1 or 2`). `GetTemplate` and `ListTemplates` echo the template's `generation`. Always specify `generation` explicitly when creating a template, as all examples in this topic do.
 
 Differences between the two generations:
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
@@ -177,7 +177,7 @@ The following examples use the Beijing region and an official FC Agent Sandbox i
                 name=f"pop-demo-{int(time.time())}",
                 team_id=team_id,
                 runtime_config=models.CreateTemplateRuntimeConfig(
-                    sandbox_config=models.CreateTemplateSandboxConfig(image=from_image),
+                    sandbox_config=models.CreateTemplateSandboxConfig(image=from_image, generation=1),
                 ),
             )
         )
@@ -238,7 +238,7 @@ The following examples use the Beijing region and an official FC Agent Sandbox i
           name: `pop-demo-${Math.floor(Date.now() / 1000)}`,
           teamID,
           runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
-            sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({ image: fromImage }),
+            sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({ image: fromImage, generation: 1 }),
           }),
         }),
       }));
@@ -328,7 +328,8 @@ The following examples use the Beijing region and an official FC Agent Sandbox i
                 TeamID: tea.String(teamID),
                 RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                     SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                        Image: tea.String(fromImage),
+                        Image:      tea.String(fromImage),
+                        Generation: tea.Int32(1),
                     },
                 },
             },
@@ -436,7 +437,8 @@ The following examples use the Beijing region and an official FC Agent Sandbox i
                     .setTeamID(teamID)
                     .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                             .setSandboxConfig(new CreateTemplateSandboxConfig()
-                                    .setImage(fromImage)));
+                                    .setImage(fromImage)
+                                    .setGeneration(1)));
             String templateID = popClient
                     .createTemplate(new CreateTemplateRequest().setBody(body))
                     .getBody().getTemplateID();
@@ -508,6 +510,8 @@ FC Agent Sandbox runtimes come in two generations. The first generation is the d
 The second-generation runtime is currently available only to whitelisted accounts and regions. Without access, the template build fails with `MicroSandbox runtime is not enabled for this account`. To use it, contact technical support to request access.
 
 Pass `generation` in `runtime_config.sandbox_config` to select the generation: omitted or explicit `1` selects the first generation, and `2` selects the second generation. Any other value returns `400 InvalidParameter` (`runtimeConfig.sandboxConfig.generation must be 1 or 2`). `GetTemplate` and `ListTemplates` echo the template's `generation`.
+
+The default is currently `1` (first generation). To prevent a future default change from affecting existing template behavior, always specify `generation` explicitly when creating a template, as all examples in this topic do.
 
 Differences between the two generations:
 
@@ -677,6 +681,7 @@ Parameter example:
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49",
+                        generation=1,
                     ),
                 ),
             )
@@ -694,6 +699,7 @@ Parameter example:
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49',
+            generation: 1,
           }),
         }),
       }),
@@ -709,7 +715,8 @@ Parameter example:
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Image:      tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Generation: tea.Int32(1),
                 },
             },
         },
@@ -727,7 +734,8 @@ Parameter example:
             .setTeamID(teamID)
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")));
+                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")
+                            .setGeneration(1)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
@@ -776,6 +784,7 @@ Parameter example 1: pass only `image`; the instance, credentials, and pull netw
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1",
+                        generation=1,
                     ),
                 ),
             )
@@ -793,6 +802,7 @@ Parameter example 1: pass only `image`; the instance, credentials, and pull netw
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1',
+            generation: 1,
           }),
         }),
       }),
@@ -808,7 +818,8 @@ Parameter example 1: pass only `image`; the instance, credentials, and pull netw
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
+                    Image:      tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
+                    Generation: tea.Int32(1),
                 },
             },
         },
@@ -826,7 +837,8 @@ Parameter example 1: pass only `image`; the instance, credentials, and pull netw
             .setTeamID(teamID)
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")));
+                            .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")
+                            .setGeneration(1)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
@@ -845,6 +857,7 @@ Parameter example 2: pass `acr_instance_id`, `auth_config`, and `network_config`
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1",
+                        generation=1,
                         acr_instance_id="cri-xxxxxx",
                         registry_config=models.CreateTemplateRegistryConfig(
                             auth_config=models.CreateTemplateRegistryAuthConfig(
@@ -874,6 +887,7 @@ Parameter example 2: pass `acr_instance_id`, `auth_config`, and `network_config`
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1',
+            generation: 1,
             acrInstanceId: 'cri-xxxxxx',
             registryConfig: new $FCSandbox20260509.CreateTemplateRegistryConfig({
               authConfig: new $FCSandbox20260509.CreateTemplateRegistryAuthConfig({
@@ -901,8 +915,9 @@ Parameter example 2: pass `acr_instance_id`, `auth_config`, and `network_config`
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image:         tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
-                    AcrInstanceId: tea.String("cri-xxxxxx"),
+                    Image:          tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
+                    Generation:     tea.Int32(1),
+                    AcrInstanceId:  tea.String("cri-xxxxxx"),
                     RegistryConfig: &fcsandbox20260509.CreateTemplateRegistryConfig{
                         AuthConfig: &fcsandbox20260509.CreateTemplateRegistryAuthConfig{
                             UserName: tea.String("<username>"),
@@ -932,6 +947,7 @@ Parameter example 2: pass `acr_instance_id`, `auth_config`, and `network_config`
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")
+                            .setGeneration(1)
                             .setAcrInstanceId("cri-xxxxxx")
                             .setRegistryConfig(new CreateTemplateRegistryConfig()
                                     .setAuthConfig(new CreateTemplateRegistryAuthConfig()
@@ -969,6 +985,7 @@ Parameter example:
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="registry.example.com/ns/repo:v1",
+                        generation=1,
                         registry_config=models.CreateTemplateRegistryConfig(
                             auth_config=models.CreateTemplateRegistryAuthConfig(
                                 user_name="<username>",
@@ -992,6 +1009,7 @@ Parameter example:
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'registry.example.com/ns/repo:v1',
+            generation: 1,
             registryConfig: new $FCSandbox20260509.CreateTemplateRegistryConfig({
               authConfig: new $FCSandbox20260509.CreateTemplateRegistryAuthConfig({
                 userName: '<username>',
@@ -1013,7 +1031,8 @@ Parameter example:
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("registry.example.com/ns/repo:v1"),
+                    Image:          tea.String("registry.example.com/ns/repo:v1"),
+                    Generation:     tea.Int32(1),
                     RegistryConfig: &fcsandbox20260509.CreateTemplateRegistryConfig{
                         AuthConfig: &fcsandbox20260509.CreateTemplateRegistryAuthConfig{
                             UserName: tea.String("<username>"),
@@ -1038,6 +1057,7 @@ Parameter example:
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("registry.example.com/ns/repo:v1")
+                            .setGeneration(1)
                             .setRegistryConfig(new CreateTemplateRegistryConfig()
                                     .setAuthConfig(new CreateTemplateRegistryAuthConfig()
                                             .setUserName("<username>")
@@ -1071,6 +1091,7 @@ Parameter example:
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="registry.internal.example.com/ns/repo:v1",
+                        generation=1,
                         registry_config=models.CreateTemplateRegistryConfig(
                             auth_config=models.CreateTemplateRegistryAuthConfig(
                                 user_name="<username>",
@@ -1102,6 +1123,7 @@ Parameter example:
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'registry.internal.example.com/ns/repo:v1',
+            generation: 1,
             registryConfig: new $FCSandbox20260509.CreateTemplateRegistryConfig({
               authConfig: new $FCSandbox20260509.CreateTemplateRegistryAuthConfig({
                 userName: '<username>',
@@ -1131,7 +1153,8 @@ Parameter example:
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("registry.internal.example.com/ns/repo:v1"),
+                    Image:          tea.String("registry.internal.example.com/ns/repo:v1"),
+                    Generation:     tea.Int32(1),
                     RegistryConfig: &fcsandbox20260509.CreateTemplateRegistryConfig{
                         AuthConfig: &fcsandbox20260509.CreateTemplateRegistryAuthConfig{
                             UserName: tea.String("<username>"),
@@ -1164,6 +1187,7 @@ Parameter example:
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("registry.internal.example.com/ns/repo:v1")
+                            .setGeneration(1)
                             .setRegistryConfig(new CreateTemplateRegistryConfig()
                                     .setAuthConfig(new CreateTemplateRegistryAuthConfig()
                                             .setUserName("<username>")
@@ -1202,6 +1226,7 @@ After the public egress is disabled (`internet_access=False`), public network ac
                     ),
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49",
+                        generation=1,
                     ),
                 ),
             )
@@ -1225,6 +1250,7 @@ After the public egress is disabled (`internet_access=False`), public network ac
           }),
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49',
+            generation: 1,
           }),
         }),
       }),
@@ -1246,7 +1272,8 @@ After the public egress is disabled (`internet_access=False`), public network ac
                     SecurityGroupId: tea.String("sg-xxxxxx"),
                 },
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Image:      tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Generation: tea.Int32(1),
                 },
             },
         },
@@ -1269,7 +1296,8 @@ After the public egress is disabled (`internet_access=False`), public network ac
                             .setVSwitchIds(java.util.Arrays.asList("vsw-xxxxxx"))
                             .setSecurityGroupId("sg-xxxxxx"))
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")));
+                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")
+                            .setGeneration(1)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
@@ -1294,6 +1322,7 @@ Sandbox runtime logs can be delivered to Simple Log Service (SLS) under your acc
                     ),
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49",
+                        generation=1,
                     ),
                 ),
             )
@@ -1315,6 +1344,7 @@ Sandbox runtime logs can be delivered to Simple Log Service (SLS) under your acc
           }),
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49',
+            generation: 1,
           }),
         }),
       }),
@@ -1334,7 +1364,8 @@ Sandbox runtime logs can be delivered to Simple Log Service (SLS) under your acc
                     Logstore: tea.String("<sls-logstore>"),
                 },
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Image:      tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Generation: tea.Int32(1),
                 },
             },
         },
@@ -1355,7 +1386,8 @@ Sandbox runtime logs can be delivered to Simple Log Service (SLS) under your acc
                             .setProject("<sls-project>")
                             .setLogstore("<sls-logstore>"))
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")));
+                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")
+                            .setGeneration(1)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
@@ -1380,6 +1412,7 @@ Parameter example (the target and the source image share the same repository; `e
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="registry.example.com/ns/repo:v1",
+                        generation=1,
                         registry_config=models.CreateTemplateRegistryConfig(
                             auth_config=models.CreateTemplateRegistryAuthConfig(
                                 user_name="<username>",
@@ -1409,6 +1442,7 @@ Parameter example (the target and the source image share the same repository; `e
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'registry.example.com/ns/repo:v1',
+            generation: 1,
             registryConfig: new $FCSandbox20260509.CreateTemplateRegistryConfig({
               authConfig: new $FCSandbox20260509.CreateTemplateRegistryAuthConfig({
                 userName: '<username>',
@@ -1436,7 +1470,8 @@ Parameter example (the target and the source image share the same repository; `e
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("registry.example.com/ns/repo:v1"),
+                    Image:          tea.String("registry.example.com/ns/repo:v1"),
+                    Generation:     tea.Int32(1),
                     RegistryConfig: &fcsandbox20260509.CreateTemplateRegistryConfig{
                         AuthConfig: &fcsandbox20260509.CreateTemplateRegistryAuthConfig{
                             UserName: tea.String("<username>"),
@@ -1467,6 +1502,7 @@ Parameter example (the target and the source image share the same repository; `e
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("registry.example.com/ns/repo:v1")
+                            .setGeneration(1)
                             .setRegistryConfig(new CreateTemplateRegistryConfig()
                                     .setAuthConfig(new CreateTemplateRegistryAuthConfig()
                                             .setUserName("<username>")

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
@@ -517,15 +517,11 @@ Differences between the two generations:
 
 | Dimension | First generation | Second generation |
 | --- | --- | --- |
-| `os_type` | Not supported; providing it returns `400 InvalidParameter` | Optional; specifies the sandbox operating system type; defaults to Linux |
-| `build_config` | Build mode is auto-derived from the source image | Ignored as a whole; sandbox runtime dependencies are injected by the platform without copy or envdInject |
-| `registry_config` (`auth_config`, `cert_config`, `network_config`) | Supported | Not supported; providing `cert_config` or `network_config` returns `400 InvalidParameter` |
+| `os_type` | Not supported; providing it returns `400 InvalidParameter` | Optional enum: `linux-amd64` (default), `android-36-osworld`, `windows-osworld`; case-insensitive |
 | `vpc_config` | Serves only as the sandbox runtime network | Serves as both the image pull network and the sandbox runtime network; required when pulling `-vpc` internal images |
 | Default specifications | 2 vCPU / 2 GiB memory / 10 GiB disk | 8 vCPU / 8 GiB memory / 60 GiB disk |
 | Image distribution | Ubuntu 20.04, Debian 12 or later recommended but not enforced | Ubuntu/Debian-based images only, with system components such as `systemd`, `openssh-server`, `sudo`, `chrony`, `fuse3`, and `iptables` preserved (or `apt-get` guaranteed to work); minimal rootfs images such as Alpine and BusyBox are not supported |
 | `/workspace` working directory | Injected by the platform during the build | Not injected; bake it into the image if needed |
-
-When using an ACR EE image with the second generation, set `image` to the instance's `-vpc` internal endpoint address and pass the VPC trio (`vpc_id`, `v_switch_ids`, `security_group_id`) in `runtime_config.vpc_config`: the second generation has no builder stage, so the platform creates the sandbox function directly with this VPC configuration and pulls the image through your VPC; `vpc_config` is also the VPC where sandboxes created from this template run. Image pulls use the managed authorization of the ACR EE instance under the same account, so no registry credentials are required. The ACR EE prerequisites (same account and region, with a VPC attached) are the same as for the first generation; see "Image sources → ACR Enterprise Edition (ACR EE)" below. The second generation does not support `registry_config` (`auth_config`, `cert_config`, and `network_config` are all unavailable). Use the first generation when explicit registry credentials or self-signed certificates are required.
 
 Parameter examples (create a second-generation template from an ACR EE `-vpc` internal image; the polling and deletion steps are the same as above):
 

--- a/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
+++ b/docs/en-US/01.FC Agent Sandbox/04.Features/02.Templates/08.Build and Manage Templates via OpenAPI.md
@@ -509,7 +509,7 @@ FC Agent Sandbox runtimes come in two generations. The second generation is isol
 
 The second-generation runtime is currently available only to whitelisted accounts and regions. Without access, the template build fails with `MicroSandbox runtime is not enabled for this account`. To use it, contact technical support to request access.
 
-Pass `generation` in `runtime_config.sandbox_config` to select the generation: `1` selects the first generation, and `2` selects the second generation. Any other value returns `400 InvalidParameter` (`runtimeConfig.sandboxConfig.generation must be 1 or 2`). `GetTemplate` and `ListTemplates` echo the template's `generation`. Always specify `generation` explicitly when creating a template, as all examples in this topic do.
+Pass `generation` in `runtime_config.sandbox_config` to select the generation: `1` selects the first generation, and `2` selects the second generation.
 
 Differences between the two generations:
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
@@ -519,15 +519,11 @@ export FCSANDBOX_TEAM_ID="<team-id>"
 
 | 维度 | 第一代 | 第二代 |
 | --- | --- | --- |
-| `os_type` | 不支持，提供即 `400 InvalidParameter` | 可选，指定沙箱操作系统类型，缺省为 Linux |
-| `build_config` | 按源镜像自动推导构建方式 | 整体忽略，沙箱运行依赖由平台注入，不涉及 copy 与 envdInject |
-| `registry_config`（`auth_config`、`cert_config`、`network_config`） | 支持 | 不支持，`cert_config`、`network_config` 提供即 `400 InvalidParameter` |
+| `os_type` | 不支持，提供即 `400 InvalidParameter` | 可选枚举：`linux-amd64`（缺省）、`android-36-osworld`、`windows-osworld`，不区分大小写 |
 | `vpc_config` | 仅作为沙箱运行网络 | 同时作为镜像拉取网络与沙箱运行网络，拉取 `-vpc` 内网镜像时必填 |
 | 缺省规格 | 2 vCPU / 2 GiB 内存 / 10 GiB 磁盘 | 8 vCPU / 8 GiB 内存 / 60 GiB 磁盘 |
 | 镜像发行版 | 推荐 Ubuntu 20.04、Debian 12 及以上，不强制 | 仅支持 Ubuntu/Debian 系，且需保留 `systemd`、`openssh-server`、`sudo`、`chrony`、`fuse3`、`iptables` 等系统组件（或保证 `apt-get` 可用）；Alpine、BusyBox 等精简 rootfs 不可用 |
 | `/workspace` 工作目录 | 构建时由平台注入 | 不注入，需要时请在镜像中自带 |
-
-第二代使用 ACR EE 镜像时，`image` 填实例的 `-vpc` 内网域名地址，并必须在 `runtime_config.vpc_config` 中传入 VPC 三件套（`vpc_id`、`v_switch_ids`、`security_group_id`）：第二代不经过构建器，平台直接以该 VPC 配置创建沙箱函数并经由您的 VPC 拉取镜像，`vpc_config` 同时是模板运行期沙箱所在的 VPC。镜像拉取使用同账号 ACR EE 实例的托管授权，无需配置仓库凭证；ACR EE 实例的前置准备（同账号同地域、绑定专有网络）与第一代相同，参见下文「镜像源 → ACR 企业版（ACR EE）」。第二代暂不支持 `registry_config`（`auth_config`、`cert_config`、`network_config` 均不可用），需要显式仓库凭证或自签证书的场景请使用第一代。
 
 传参示例（以 ACR EE `-vpc` 内网镜像创建第二代模板为例，轮询与删除步骤与上文相同）：
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
@@ -179,7 +179,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                 name=f"pop-demo-{int(time.time())}",
                 team_id=team_id,
                 runtime_config=models.CreateTemplateRuntimeConfig(
-                    sandbox_config=models.CreateTemplateSandboxConfig(image=from_image),
+                    sandbox_config=models.CreateTemplateSandboxConfig(image=from_image, generation=1),
                 ),
             )
         )
@@ -240,7 +240,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
           name: `pop-demo-${Math.floor(Date.now() / 1000)}`,
           teamID,
           runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
-            sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({ image: fromImage }),
+            sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({ image: fromImage, generation: 1 }),
           }),
         }),
       }));
@@ -330,7 +330,8 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                 TeamID: tea.String(teamID),
                 RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                     SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                        Image: tea.String(fromImage),
+                        Image:      tea.String(fromImage),
+                        Generation: tea.Int32(1),
                     },
                 },
             },
@@ -438,7 +439,8 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                     .setTeamID(teamID)
                     .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                             .setSandboxConfig(new CreateTemplateSandboxConfig()
-                                    .setImage(fromImage)));
+                                    .setImage(fromImage)
+                                    .setGeneration(1)));
             String templateID = popClient
                     .createTemplate(new CreateTemplateRequest().setBody(body))
                     .getBody().getTemplateID();
@@ -510,6 +512,8 @@ export FCSANDBOX_TEAM_ID="<team-id>"
 第二代运行时当前仅对已开通白名单的账号和地域可用，未开通时模板构建会以 `MicroSandbox runtime is not enabled for this account` 失败。如需使用，请联系技术支持开通。
 
 在 `runtime_config.sandbox_config` 中传 `generation` 选择代际：缺省或显式 `1` 为第一代，传 `2` 为第二代，其他取值返回 `400 InvalidParameter`（`runtimeConfig.sandboxConfig.generation must be 1 or 2`）。`GetTemplate`、`ListTemplates` 回显模板的 `generation`。
+
+当前缺省为 `1`（第一代）。为避免未来缺省值变化影响既有模板行为，建议创建模板时始终显式指定 `generation`，本文示例均已显式写出。
 
 第二代与第一代的差异：
 
@@ -675,6 +679,7 @@ fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49",
+                        generation=1,
                     ),
                 ),
             )
@@ -692,6 +697,7 @@ fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49',
+            generation: 1,
           }),
         }),
       }),
@@ -707,7 +713,8 @@ fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Image:      tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Generation: tea.Int32(1),
                 },
             },
         },
@@ -725,7 +732,8 @@ fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49
             .setTeamID(teamID)
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")));
+                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")
+                            .setGeneration(1)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
@@ -774,6 +782,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1",
+                        generation=1,
                     ),
                 ),
             )
@@ -791,6 +800,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1',
+            generation: 1,
           }),
         }),
       }),
@@ -806,7 +816,8 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
+                    Image:      tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
+                    Generation: tea.Int32(1),
                 },
             },
         },
@@ -824,7 +835,8 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             .setTeamID(teamID)
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")));
+                            .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")
+                            .setGeneration(1)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
@@ -843,6 +855,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1",
+                        generation=1,
                         acr_instance_id="cri-xxxxxx",
                         registry_config=models.CreateTemplateRegistryConfig(
                             auth_config=models.CreateTemplateRegistryAuthConfig(
@@ -872,6 +885,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1',
+            generation: 1,
             acrInstanceId: 'cri-xxxxxx',
             registryConfig: new $FCSandbox20260509.CreateTemplateRegistryConfig({
               authConfig: new $FCSandbox20260509.CreateTemplateRegistryAuthConfig({
@@ -899,8 +913,9 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image:         tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
-                    AcrInstanceId: tea.String("cri-xxxxxx"),
+                    Image:          tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
+                    Generation:     tea.Int32(1),
+                    AcrInstanceId:  tea.String("cri-xxxxxx"),
                     RegistryConfig: &fcsandbox20260509.CreateTemplateRegistryConfig{
                         AuthConfig: &fcsandbox20260509.CreateTemplateRegistryAuthConfig{
                             UserName: tea.String("<username>"),
@@ -930,6 +945,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")
+                            .setGeneration(1)
                             .setAcrInstanceId("cri-xxxxxx")
                             .setRegistryConfig(new CreateTemplateRegistryConfig()
                                     .setAuthConfig(new CreateTemplateRegistryAuthConfig()
@@ -967,6 +983,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="registry.example.com/ns/repo:v1",
+                        generation=1,
                         registry_config=models.CreateTemplateRegistryConfig(
                             auth_config=models.CreateTemplateRegistryAuthConfig(
                                 user_name="<username>",
@@ -990,6 +1007,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'registry.example.com/ns/repo:v1',
+            generation: 1,
             registryConfig: new $FCSandbox20260509.CreateTemplateRegistryConfig({
               authConfig: new $FCSandbox20260509.CreateTemplateRegistryAuthConfig({
                 userName: '<username>',
@@ -1011,7 +1029,8 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("registry.example.com/ns/repo:v1"),
+                    Image:          tea.String("registry.example.com/ns/repo:v1"),
+                    Generation:     tea.Int32(1),
                     RegistryConfig: &fcsandbox20260509.CreateTemplateRegistryConfig{
                         AuthConfig: &fcsandbox20260509.CreateTemplateRegistryAuthConfig{
                             UserName: tea.String("<username>"),
@@ -1036,6 +1055,7 @@ test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("registry.example.com/ns/repo:v1")
+                            .setGeneration(1)
                             .setRegistryConfig(new CreateTemplateRegistryConfig()
                                     .setAuthConfig(new CreateTemplateRegistryAuthConfig()
                                             .setUserName("<username>")
@@ -1069,6 +1089,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="registry.internal.example.com/ns/repo:v1",
+                        generation=1,
                         registry_config=models.CreateTemplateRegistryConfig(
                             auth_config=models.CreateTemplateRegistryAuthConfig(
                                 user_name="<username>",
@@ -1100,6 +1121,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'registry.internal.example.com/ns/repo:v1',
+            generation: 1,
             registryConfig: new $FCSandbox20260509.CreateTemplateRegistryConfig({
               authConfig: new $FCSandbox20260509.CreateTemplateRegistryAuthConfig({
                 userName: '<username>',
@@ -1129,7 +1151,8 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("registry.internal.example.com/ns/repo:v1"),
+                    Image:          tea.String("registry.internal.example.com/ns/repo:v1"),
+                    Generation:     tea.Int32(1),
                     RegistryConfig: &fcsandbox20260509.CreateTemplateRegistryConfig{
                         AuthConfig: &fcsandbox20260509.CreateTemplateRegistryAuthConfig{
                             UserName: tea.String("<username>"),
@@ -1162,6 +1185,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("registry.internal.example.com/ns/repo:v1")
+                            .setGeneration(1)
                             .setRegistryConfig(new CreateTemplateRegistryConfig()
                                     .setAuthConfig(new CreateTemplateRegistryAuthConfig()
                                             .setUserName("<username>")
@@ -1200,6 +1224,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
                     ),
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49",
+                        generation=1,
                     ),
                 ),
             )
@@ -1223,6 +1248,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
           }),
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49',
+            generation: 1,
           }),
         }),
       }),
@@ -1244,7 +1270,8 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
                     SecurityGroupId: tea.String("sg-xxxxxx"),
                 },
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Image:      tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Generation: tea.Int32(1),
                 },
             },
         },
@@ -1267,7 +1294,8 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
                             .setVSwitchIds(java.util.Arrays.asList("vsw-xxxxxx"))
                             .setSecurityGroupId("sg-xxxxxx"))
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")));
+                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")
+                            .setGeneration(1)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
@@ -1292,6 +1320,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
                     ),
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49",
+                        generation=1,
                     ),
                 ),
             )
@@ -1313,6 +1342,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
           }),
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49',
+            generation: 1,
           }),
         }),
       }),
@@ -1332,7 +1362,8 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
                     Logstore: tea.String("<sls-logstore>"),
                 },
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Image:      tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Generation: tea.Int32(1),
                 },
             },
         },
@@ -1353,7 +1384,8 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
                             .setProject("<sls-project>")
                             .setLogstore("<sls-logstore>"))
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")));
+                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")
+                            .setGeneration(1)));
     String templateID = popClient
             .createTemplate(new CreateTemplateRequest().setBody(body))
             .getBody().getTemplateID();
@@ -1378,6 +1410,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
                         image="registry.example.com/ns/repo:v1",
+                        generation=1,
                         registry_config=models.CreateTemplateRegistryConfig(
                             auth_config=models.CreateTemplateRegistryAuthConfig(
                                 user_name="<username>",
@@ -1407,6 +1440,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
             image: 'registry.example.com/ns/repo:v1',
+            generation: 1,
             registryConfig: new $FCSandbox20260509.CreateTemplateRegistryConfig({
               authConfig: new $FCSandbox20260509.CreateTemplateRegistryAuthConfig({
                 userName: '<username>',
@@ -1434,7 +1468,8 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("registry.example.com/ns/repo:v1"),
+                    Image:          tea.String("registry.example.com/ns/repo:v1"),
+                    Generation:     tea.Int32(1),
                     RegistryConfig: &fcsandbox20260509.CreateTemplateRegistryConfig{
                         AuthConfig: &fcsandbox20260509.CreateTemplateRegistryAuthConfig{
                             UserName: tea.String("<username>"),
@@ -1465,6 +1500,7 @@ Registry 域名仅 VPC 内可达的自建私有仓库，例如在 VPC 内的 ECS
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
                             .setImage("registry.example.com/ns/repo:v1")
+                            .setGeneration(1)
                             .setRegistryConfig(new CreateTemplateRegistryConfig()
                                     .setAuthConfig(new CreateTemplateRegistryAuthConfig()
                                             .setUserName("<username>")

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
@@ -507,13 +507,11 @@ export FCSANDBOX_TEAM_ID="<team-id>"
 
 ### 使用第二代运行时
 
-云沙箱运行时分为两代。第一代为默认；第二代基于轻量虚拟机（MicroVM）隔离，提供快照等第一代不具备的能力（快照仅第二代运行时可用，参见[快照](../01.沙箱/12.快照.md)）。
+云沙箱运行时分为两代。第二代基于轻量虚拟机（MicroVM）隔离，提供快照等第一代不具备的能力（快照仅第二代运行时可用，参见[快照](../01.沙箱/12.快照.md)）。
 
 第二代运行时当前仅对已开通白名单的账号和地域可用，未开通时模板构建会以 `MicroSandbox runtime is not enabled for this account` 失败。如需使用，请联系技术支持开通。
 
-在 `runtime_config.sandbox_config` 中传 `generation` 选择代际：缺省或显式 `1` 为第一代，传 `2` 为第二代，其他取值返回 `400 InvalidParameter`（`runtimeConfig.sandboxConfig.generation must be 1 or 2`）。`GetTemplate`、`ListTemplates` 回显模板的 `generation`。
-
-当前缺省为 `1`（第一代）。为避免未来缺省值变化影响既有模板行为，建议创建模板时始终显式指定 `generation`，本文示例均已显式写出。
+在 `runtime_config.sandbox_config` 中传 `generation` 选择代际：`1` 为第一代，`2` 为第二代，其他取值返回 `400 InvalidParameter`（`runtimeConfig.sandboxConfig.generation must be 1 or 2`）。`GetTemplate`、`ListTemplates` 回显模板的 `generation`。创建模板时请始终显式指定 `generation`，本文示例均已显式写出。
 
 第二代与第一代的差异：
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
@@ -522,9 +522,9 @@ export FCSANDBOX_TEAM_ID="<team-id>"
 | 镜像发行版 | 推荐 Ubuntu 20.04、Debian 12 及以上，不强制 | 仅支持 Ubuntu/Debian 系，且需保留 `systemd`、`openssh-server`、`sudo`、`chrony`、`fuse3`、`iptables` 等系统组件（或保证 `apt-get` 可用）；Alpine、BusyBox 等精简 rootfs 不可用 |
 | `/workspace` 工作目录 | 构建时由平台注入 | 不注入，需要时请在镜像中自带 |
 
-第二代当前建议配合云沙箱官方镜像使用；私有镜像仓库的凭证与 VPC 拉取能力正在逐步开放。
+第二代使用 ACR EE 镜像只需传 `image`（`test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1`），实例与拉取网络由平台按镜像地址自动推导；ACR EE 实例的前置准备与第一代相同，参见下文「镜像源 → ACR 企业版（ACR EE）」。`registry_config` 中的 `cert_config`、`network_config` 第二代不支持，自签证书与自定义拉取网络场景请使用第一代。
 
-传参示例（以公共镜像创建第二代模板为例，轮询与删除步骤与上文相同）：
+传参示例（以 ACR EE 镜像创建第二代模板为例，轮询与删除步骤与上文相同）：
 
 === "Python"
 
@@ -536,7 +536,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                 team_id=team_id,
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
-                        image="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49",
+                        image="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1",
                         # 使用第二代运行时。
                         generation=2,
                     ),
@@ -555,7 +555,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
         teamID,
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
-            image: 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49',
+            image: 'test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1',
             // 使用第二代运行时。
             generation: 2,
           }),
@@ -573,7 +573,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    Image: tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
                     // 使用第二代运行时。
                     Generation: tea.Int32(2),
                 },
@@ -593,7 +593,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
             .setTeamID(teamID)
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")
+                            .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")
                             // 使用第二代运行时。
                             .setGeneration(2)));
     String templateID = popClient

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
@@ -503,6 +503,104 @@ export FCSANDBOX_TEAM_ID="<team-id>"
 
 构建为异步执行，轮询耗时取决于镜像大小，通常在数十秒到数分钟之间。
 
+### 使用第二代运行时
+
+云沙箱运行时分为两代。第一代为默认；第二代基于轻量虚拟机（MicroVM）隔离，提供快照等第一代不具备的能力（快照仅第二代运行时可用，参见[快照](../01.沙箱/12.快照.md)）。
+
+第二代运行时当前仅对已开通白名单的账号和地域可用，未开通时模板构建会以 `MicroSandbox runtime is not enabled for this account` 失败。如需使用，请联系技术支持开通。
+
+在 `runtime_config.sandbox_config` 中传 `generation` 选择代际：缺省或显式 `1` 为第一代，传 `2` 为第二代，其他取值返回 `400 InvalidParameter`（`runtimeConfig.sandboxConfig.generation must be 1 or 2`）。`GetTemplate`、`ListTemplates` 回显模板的 `generation`。
+
+第二代与第一代的差异：
+
+| 维度 | 第一代 | 第二代 |
+| --- | --- | --- |
+| `os_type` | 不支持，提供即 `400 InvalidParameter` | 可选，指定沙箱操作系统类型，缺省为 Linux |
+| `build_config` | 按源镜像自动推导构建方式 | 整体忽略，沙箱运行依赖由平台注入，不涉及 copy 与 envdInject |
+| `registry_config.cert_config`、`registry_config.network_config` | 支持 | 不支持，提供即 `400 InvalidParameter` |
+| 缺省规格 | 2 vCPU / 2 GiB 内存 / 10 GiB 磁盘 | 8 vCPU / 8 GiB 内存 / 60 GiB 磁盘 |
+| 镜像发行版 | 推荐 Ubuntu 20.04、Debian 12 及以上，不强制 | 仅支持 Ubuntu/Debian 系，且需保留 `systemd`、`openssh-server`、`sudo`、`chrony`、`fuse3`、`iptables` 等系统组件（或保证 `apt-get` 可用）；Alpine、BusyBox 等精简 rootfs 不可用 |
+| `/workspace` 工作目录 | 构建时由平台注入 | 不注入，需要时请在镜像中自带 |
+
+第二代当前建议配合云沙箱官方镜像使用；私有镜像仓库的凭证与 VPC 拉取能力正在逐步开放。
+
+传参示例（以公共镜像创建第二代模板为例，轮询与删除步骤与上文相同）：
+
+=== "Python"
+
+    ```python
+    response = pop_client.create_template(
+        models.CreateTemplateRequest(
+            body=models.CreateTemplateInput(
+                name=f"pop-demo-gen2-{int(time.time())}",
+                team_id=team_id,
+                runtime_config=models.CreateTemplateRuntimeConfig(
+                    sandbox_config=models.CreateTemplateSandboxConfig(
+                        image="fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49",
+                        # 使用第二代运行时。
+                        generation=2,
+                    ),
+                ),
+            )
+        )
+    )
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    const created = await popClient.createTemplate(new $FCSandbox20260509.CreateTemplateRequest({
+      body: new $FCSandbox20260509.CreateTemplateInput({
+        name: `pop-demo-gen2-${Math.floor(Date.now() / 1000)}`,
+        teamID,
+        runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
+          sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
+            image: 'fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49',
+            // 使用第二代运行时。
+            generation: 2,
+          }),
+        }),
+      }),
+    }));
+    ```
+
+=== "Go"
+
+    ```go
+    created, err := popClient.CreateTemplate(&fcsandbox20260509.CreateTemplateRequest{
+        Body: &fcsandbox20260509.CreateTemplateInput{
+            Name:   tea.String(fmt.Sprintf("pop-demo-gen2-%d", time.Now().Unix())),
+            TeamID: tea.String(teamID),
+            RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
+                SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
+                    Image: tea.String("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49"),
+                    // 使用第二代运行时。
+                    Generation: tea.Int32(2),
+                },
+            },
+        },
+    })
+    if err != nil {
+        panic(err)
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    CreateTemplateInput body = new CreateTemplateInput()
+            .setName("pop-demo-gen2-" + System.currentTimeMillis() / 1000)
+            .setTeamID(teamID)
+            .setRuntimeConfig(new CreateTemplateRuntimeConfig()
+                    .setSandboxConfig(new CreateTemplateSandboxConfig()
+                            .setImage("fc-e2b-registry.cn-beijing.cr.aliyuncs.com/runtime/code-interpreter-v1:v0.0.49")
+                            // 使用第二代运行时。
+                            .setGeneration(2)));
+    String templateID = popClient
+            .createTemplate(new CreateTemplateRequest().setBody(body))
+            .getBody().getTemplateID();
+    ```
+
 ### 镜像要求
 
 推荐基础镜像：Ubuntu 20.04、Debian 12 (bookworm) 及以上（仅作推荐，不强制发行版）。自定义镜像需满足下表要求，按“硬性 / 条件 / 推荐”分级：

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
@@ -511,7 +511,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
 
 第二代运行时当前仅对已开通白名单的账号和地域可用，未开通时模板构建会以 `MicroSandbox runtime is not enabled for this account` 失败。如需使用，请联系技术支持开通。
 
-在 `runtime_config.sandbox_config` 中传 `generation` 选择代际：`1` 为第一代，`2` 为第二代，其他取值返回 `400 InvalidParameter`（`runtimeConfig.sandboxConfig.generation must be 1 or 2`）。`GetTemplate`、`ListTemplates` 回显模板的 `generation`。创建模板时请始终显式指定 `generation`，本文示例均已显式写出。
+在 `runtime_config.sandbox_config` 中传 `generation` 选择代际：`1` 为第一代，`2` 为第二代。
 
 第二代与第一代的差异：
 

--- a/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
+++ b/docs/zh-CN/01.云沙箱/04.功能说明/02.模板/03.通过 OpenAPI 构建和管理模板.md
@@ -517,12 +517,12 @@ export FCSANDBOX_TEAM_ID="<team-id>"
 | --- | --- | --- |
 | `os_type` | 不支持，提供即 `400 InvalidParameter` | 可选，指定沙箱操作系统类型，缺省为 Linux |
 | `build_config` | 按源镜像自动推导构建方式 | 整体忽略，沙箱运行依赖由平台注入，不涉及 copy 与 envdInject |
-| `registry_config.cert_config`、`registry_config.network_config` | 支持 | 不支持，提供即 `400 InvalidParameter` |
+| `registry_config`（`auth_config`、`cert_config`、`network_config`） | 支持 | 不支持，`cert_config`、`network_config` 提供即 `400 InvalidParameter` |
 | 缺省规格 | 2 vCPU / 2 GiB 内存 / 10 GiB 磁盘 | 8 vCPU / 8 GiB 内存 / 60 GiB 磁盘 |
 | 镜像发行版 | 推荐 Ubuntu 20.04、Debian 12 及以上，不强制 | 仅支持 Ubuntu/Debian 系，且需保留 `systemd`、`openssh-server`、`sudo`、`chrony`、`fuse3`、`iptables` 等系统组件（或保证 `apt-get` 可用）；Alpine、BusyBox 等精简 rootfs 不可用 |
 | `/workspace` 工作目录 | 构建时由平台注入 | 不注入，需要时请在镜像中自带 |
 
-第二代使用 ACR EE 镜像只需传 `image`（`test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1`），实例与拉取网络由平台按镜像地址自动推导；ACR EE 实例的前置准备与第一代相同，参见下文「镜像源 → ACR 企业版（ACR EE）」。`registry_config` 中的 `cert_config`、`network_config` 第二代不支持，自签证书与自定义拉取网络场景请使用第一代。
+第二代使用 ACR EE 镜像只需在 `sandbox_config` 中传 `image` 与 `generation`：`image` 使用实例的公网访问域名地址，不支持 `-vpc` 内网域名，镜像经实例公网端点拉取，请确认实例已开启公网访问。第二代暂不支持 `registry_config`（`auth_config`、`cert_config`、`network_config` 均不可用），需要私有仓库凭证、自签证书或自定义拉取网络的场景请使用第一代。ACR EE 实例的创建参见下文「镜像源 → ACR 企业版（ACR EE）」，其中 VPC 拉取网络相关配置仅适用于第一代。
 
 传参示例（以 ACR EE 镜像创建第二代模板为例，轮询与删除步骤与上文相同）：
 
@@ -536,7 +536,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
                 team_id=team_id,
                 runtime_config=models.CreateTemplateRuntimeConfig(
                     sandbox_config=models.CreateTemplateSandboxConfig(
-                        image="test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1",
+                        image="test-registry.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1",
                         # 使用第二代运行时。
                         generation=2,
                     ),
@@ -555,7 +555,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
         teamID,
         runtimeConfig: new $FCSandbox20260509.CreateTemplateRuntimeConfig({
           sandboxConfig: new $FCSandbox20260509.CreateTemplateSandboxConfig({
-            image: 'test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1',
+            image: 'test-registry.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1',
             // 使用第二代运行时。
             generation: 2,
           }),
@@ -573,7 +573,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
             TeamID: tea.String(teamID),
             RuntimeConfig: &fcsandbox20260509.CreateTemplateRuntimeConfig{
                 SandboxConfig: &fcsandbox20260509.CreateTemplateSandboxConfig{
-                    Image: tea.String("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
+                    Image: tea.String("test-registry.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1"),
                     // 使用第二代运行时。
                     Generation: tea.Int32(2),
                 },
@@ -593,7 +593,7 @@ export FCSANDBOX_TEAM_ID="<team-id>"
             .setTeamID(teamID)
             .setRuntimeConfig(new CreateTemplateRuntimeConfig()
                     .setSandboxConfig(new CreateTemplateSandboxConfig()
-                            .setImage("test-registry-vpc.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")
+                            .setImage("test-registry.cn-beijing.cr.aliyuncs.com/runtime/python:3.12-v1")
                             // 使用第二代运行时。
                             .setGeneration(2)));
     String templateID = popClient


### PR DESCRIPTION
## Summary

在《通过 OpenAPI 构建和管理模板》中新增「使用第二代运行时」章节：

- `runtimeConfig.sandboxConfig.generation=2` 选择第二代运行时（缺省/显式 1 为第一代，其他取值 400），GetTemplate/ListTemplates 回显
- 白名单前提：未开通账号构建报 `MicroSandbox runtime is not enabled for this account`
- 两代差异表：osType（第二代专属）、buildConfig（第二代忽略）、certConfig/networkConfig（第二代不支持）、缺省规格（2C/2G/10G vs 8C/8G/60G）、镜像发行版要求、/workspace 工作目录注入契约
- 四语言（Python/TypeScript/Go/Java）传参示例，字段与 SDK 1.4.x 实测一致

依据 sandbox-gateway master 实现（pop_create_template.go 代际校验与缺省规格）与 2026-09-01 生产多 Region 验证结论。

## Test plan

- [x] `make check`（含 MkDocs 严格构建）本地通过
- [ ] 评审确认第二代镜像要求与缺省规格口径

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **文档范围**：涉及阿里云 FC Agent Sandbox 的模板功能。
- **中文文档**：更新“通过 OpenAPI 构建和管理模板”章节，新增“使用第二代运行时”章节及四种语言的 `generation` 参数示例。
- **英文文档**：新增“Build and Manage Templates via OpenAPI”完整页面，涵盖模板创建、查询、构建、管理、镜像来源和第二代运行时。
- **页面变更**：新增 1 个英文页面，未删除页面。
- **图片资源**：未新增、删除或修改图片资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->